### PR TITLE
perf: improve user specified flush delay automatically by statistics

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -281,26 +281,50 @@ func (p *pipe) _background() {
 	atomic.StoreInt32(&p.state, 4)
 }
 
+type flush struct {
+	works time.Duration
+	waits time.Duration
+	bytes int
+}
+
+const flushesKeep = 16
+const flushesMask = flushesKeep - 1
+
 func (p *pipe) _backgroundWrite() (err error) {
 	var (
 		ones  = make([]cmds.Completed, 1)
 		multi []cmds.Completed
 		ch    chan RedisResult
 
-		flushDelay = p.maxFlushDelay
-		flushStart = time.Time{}
+		flushes [flushesKeep]flush
+		flushId = 0
+		bytes   = 1 // avoid zero
+		works   = time.Duration(0)
+		waits   = time.Duration(0)
+
+		userDelay = p.maxFlushDelay
 	)
 
+	var ts1 = time.Now()
 	for atomic.LoadInt32(&p.state) < 3 {
 		if ones[0], multi, ch = p.queue.NextWriteCmd(); ch == nil {
-			if flushDelay != 0 {
-				flushStart = time.Now()
-			}
-			if p.w.Buffered() == 0 {
+			buf := p.w.Buffered()
+			if buf == 0 {
 				err = p.Error()
-			} else {
+			} else if userDelay == 0 {
 				err = p.w.Flush()
+			} else {
+				ts2 := time.Now()
+				err = p.w.Flush()
+				dur, gap := time.Since(ts2), ts2.Sub(ts1)
+				bytes = bytes + buf - flushes[flushId].bytes
+				works = works + dur - flushes[flushId].works
+				waits = waits + gap - flushes[flushId].waits
+				flushes[flushId] = flush{bytes: buf, works: dur, waits: gap}
+				flushId = (flushId + 1) & flushesMask
+				ts1 = ts2
 			}
+
 			if err == nil {
 				if atomic.LoadInt32(&p.state) == 1 {
 					ones[0], multi, ch = p.queue.WaitForWrite()
@@ -308,8 +332,14 @@ func (p *pipe) _backgroundWrite() (err error) {
 					runtime.Gosched()
 					continue
 				}
-				if flushDelay != 0 && atomic.LoadInt32(&p.waits) > 1 { // do not delay for sequential usage
-					time.Sleep(flushDelay - time.Since(flushStart)) // ref: https://github.com/rueian/rueidis/issues/156
+				if userDelay != 0 && atomic.LoadInt32(&p.waits) > 1 { // do not delay for sequential usage
+					byteWork := works / time.Duration(bytes)
+					byteWait := waits / time.Duration(bytes)
+					delay := byteWait * (works / flushesKeep) / (byteWait + byteWork + 1) // avoid zero
+					if delay > userDelay {
+						delay = userDelay
+					}
+					time.Sleep(delay) // ref: https://github.com/rueian/rueidis/issues/156
 				}
 			}
 		}


### PR DESCRIPTION
Choose flush delay automatically by statistics from previous flush histories.

It generally achieves better throughput than just using `MaxFlushDelay` provided by users directly while still keeping reasonable CPU usage.

---

Benchmark comparison to the old v0.0.89 by using the code https://github.com/FZambia/pipelines:

### `PIPE_PARALLELISM=1 PIPE_MAX_FLUSH_DELAY=100`
```sh
▶ PIPE_PARALLELISM=1 PIPE_MAX_FLUSH_DELAY=100 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > old-100us-p1.txt
▶ PIPE_PARALLELISM=1 PIPE_MAX_FLUSH_DELAY=100 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > new-100us-p1.txt
▶ benchstat old-100us-p1.txt new-100us-p1.txt
name        old time/op    new time/op    delta
Rueidis-10    12.0µs ± 0%     3.8µs ± 2%  -68.47%  (p=0.000 n=20+20)

name        old alloc/op   new alloc/op   delta
Rueidis-10     80.0B ± 0%     80.0B ± 0%     ~     (all equal)

name        old allocs/op  new allocs/op  delta
Rueidis-10      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```

### `PIPE_PARALLELISM=128 PIPE_MAX_FLUSH_DELAY=100`
```sh
▶ PIPE_PARALLELISM=128 PIPE_MAX_FLUSH_DELAY=100 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > old-100us-p128.txt
▶ PIPE_PARALLELISM=128 PIPE_MAX_FLUSH_DELAY=100 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > new-100us-p128.txt
▶ benchstat old-100us-p128.txt new-100us-p128.txt
name        old time/op    new time/op    delta
Rueidis-10     601ns ± 2%     589ns ± 2%  -1.89%  (p=0.000 n=20+19)

name        old alloc/op   new alloc/op   delta
Rueidis-10     80.0B ± 0%     80.0B ± 0%    ~     (all equal)

name        old allocs/op  new allocs/op  delta
Rueidis-10      1.00 ± 0%      1.00 ± 0%    ~     (all equal)
```

### `PIPE_PARALLELISM=1 PIPE_MAX_FLUSH_DELAY=20`
```sh
▶ PIPE_PARALLELISM=1 PIPE_MAX_FLUSH_DELAY=20 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > old-20us-p1.txt
▶ PIPE_PARALLELISM=1 PIPE_MAX_FLUSH_DELAY=20 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > new-20us-p1.txt
▶ benchstat old-20us-p1.txt new-20us-p1.txt
name        old time/op    new time/op    delta
Rueidis-10    4.43µs ± 1%    3.80µs ± 2%  -14.38%  (p=0.000 n=20+20)

name        old alloc/op   new alloc/op   delta
Rueidis-10     80.0B ± 0%     80.0B ± 0%     ~     (all equal)

name        old allocs/op  new allocs/op  delta
Rueidis-10      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```

### `PIPE_PARALLELISM=128 PIPE_MAX_FLUSH_DELAY=20`
```sh
▶ PIPE_PARALLELISM=128 PIPE_MAX_FLUSH_DELAY=20 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > old-20us-p128.txt
▶ PIPE_PARALLELISM=128 PIPE_MAX_FLUSH_DELAY=20 go test -run xxx -bench BenchmarkRueidis -benchtime=2s -count 20 > new-20us-p128.txt
▶ benchstat old-20us-p128.txt new-20us-p128.txt
name        old time/op    new time/op    delta
Rueidis-10     586ns ± 3%     587ns ± 3%   ~     (p=0.622 n=20+19)

name        old alloc/op   new alloc/op   delta
Rueidis-10     80.0B ± 0%     80.0B ± 0%   ~     (all equal)

name        old allocs/op  new allocs/op  delta
Rueidis-10      1.00 ± 0%      1.00 ± 0%   ~     (all equal)
```