### PR TITLE
feat: replace RedisResult.RedisError() with rueidis.IsRedisErr() to avoid confusion

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -38,7 +38,7 @@ func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp Red
 	} else {
 		resp = c.Do(ctx, c.B().Evalsha().Sha1(s.sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
 	}
-	if err := resp.RedisError(); err != nil && err.IsNoScript() {
+	if err, ok := IsRedisErr(resp.Error()); ok && err.IsNoScript() {
 		if s.readonly {
 			resp = c.Do(ctx, c.B().EvalRo().Script(s.script).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
 		} else {

--- a/lua_test.go
+++ b/lua_test.go
@@ -68,7 +68,7 @@ func TestNewLuaScript(t *testing.T) {
 
 	script := NewLuaScript(body)
 
-	if !script.Exec(context.Background(), c, k, a).RedisError().IsNil() {
+	if err, ok := IsRedisErr(script.Exec(context.Background(), c, k, a).Error()); ok && !err.IsNil() {
 		t.Fatalf("ret mistmatch")
 	}
 }
@@ -101,7 +101,7 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 
 	script := NewLuaScriptReadOnly(body)
 
-	if !script.Exec(context.Background(), c, k, a).RedisError().IsNil() {
+	if err, ok := IsRedisErr(script.Exec(context.Background(), c, k, a).Error()); ok && !err.IsNil() {
 		t.Fatalf("ret mistmatch")
 	}
 }

--- a/message.go
+++ b/message.go
@@ -17,10 +17,16 @@ const messageStructSize = int(unsafe.Sizeof(RedisMessage{}))
 // Nil represents a Redis Nil message
 var Nil = &RedisError{typ: '_'}
 
-// IsRedisNil is a handy method to check if error is redis nil response.
+// IsRedisNil is a handy method to check if error is a redis nil response.
 // All redis nil response returns as an error.
 func IsRedisNil(err error) bool {
 	return err == Nil
+}
+
+// IsRedisErr is a handy method to check if error is a redis ERR response.
+func IsRedisErr(err error) (ret *RedisError, ok bool) {
+	ret, ok = err.(*RedisError)
+	return ret, ok && ret != Nil
 }
 
 // RedisError is an error response or a nil message from redis instance
@@ -82,14 +88,6 @@ func newErrResult(err error) RedisResult {
 type RedisResult struct {
 	err error
 	val RedisMessage
-}
-
-// RedisError can be used to check if the redis response is an error message.
-func (r RedisResult) RedisError() *RedisError {
-	if err := r.val.Error(); err != nil {
-		return err.(*RedisError)
-	}
-	return nil
 }
 
 // NonRedisError can be used to check if there is an underlying error (ex. network timeout).

--- a/message_test.go
+++ b/message_test.go
@@ -23,6 +23,22 @@ func TestIsRedisNil(t *testing.T) {
 	}
 }
 
+func TestIsRedisErr(t *testing.T) {
+	err := Nil
+	if ret, ok := IsRedisErr(err); ok || ret != Nil {
+		t.Fatal("TestIsRedisErr fail")
+	}
+	if ret, ok := IsRedisErr(nil); ok || ret != nil {
+		t.Fatal("TestIsRedisErr fail")
+	}
+	if ret, ok := IsRedisErr(errors.New("other")); ok || ret != nil {
+		t.Fatal("TestIsRedisErr fail")
+	}
+	if ret, ok := IsRedisErr(&RedisError{typ: '-'}); !ok || ret.typ != '-' {
+		t.Fatal("TestIsRedisErr fail")
+	}
+}
+
 //gocyclo:ignore
 func TestRedisResult(t *testing.T) {
 	t.Run("ToInt64", func(t *testing.T) {


### PR DESCRIPTION
RedisResult.RedisError() only returns Redis ERR message and ignores other errors, such as network errors. It is easily to be confused with RedisResult.Error(), which will return all errors and is the actual one that users should use.

By replacing RedisResult.RedisError with rueidis.IsRedisErr(), it now requires users to call RedisResult.Error() first, and checking the ok flag it returned.

fixes #229 