### PR TITLE
fix: correct RESP3 map type generated by mock.RedisMap helper

### DIFF
--- a/mock/result.go
+++ b/mock/result.go
@@ -61,7 +61,7 @@ func RedisMap(kv map[string]rueidis.RedisMessage) rueidis.RedisMessage {
 		values = append(values, RedisString(k))
 		values = append(values, v)
 	}
-	m := message{typ: '*', values: values}
+	m := message{typ: '%', values: values}
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 

--- a/mock/result_test.go
+++ b/mock/result_test.go
@@ -80,6 +80,12 @@ func TestRedisMap(t *testing.T) {
 	}) {
 		t.Fatalf("unexpected value %v", err)
 	}
+	if arr, err := m.ToMap(); err != nil || !reflect.DeepEqual(arr, map[string]rueidis.RedisMessage{
+		"a": RedisString("0"),
+		"b": RedisString("1"),
+	}) {
+		t.Fatalf("unexpected value %v", err)
+	}
 }
 
 func TestRedisResult(t *testing.T) {


### PR DESCRIPTION
fixes #231 