### PR TITLE
Use ParallelMGet for single client in MGetCache helper function

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -15,9 +15,6 @@ func MGetCache(client Client, ctx context.Context, ttl time.Duration, keys []str
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
-	if _, ok := client.(*singleClient); ok {
-		return clientMGetCache(client, ctx, ttl, client.B().Mget().Key(keys...).Cache(), keys)
-	}
 	return parallelMGetCache(client, ctx, ttl, cmds.MGets(keys), keys)
 }
 
@@ -70,9 +67,6 @@ func JsonMGetCache(client Client, ctx context.Context, ttl time.Duration, keys [
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
-	if _, ok := client.(*singleClient); ok {
-		return clientMGetCache(client, ctx, ttl, client.B().JsonMget().Key(keys...).Path(path).Cache(), keys)
-	}
 	return parallelMGetCache(client, ctx, ttl, cmds.JsonMGets(keys, path), keys)
 }
 
@@ -96,14 +90,6 @@ func JsonMSet(client Client, ctx context.Context, kvs map[string]string, path st
 		return clientJSONMSet(client, ctx, kvs, path, make(map[string]error, len(kvs)))
 	}
 	return parallelMSet(client, ctx, cmds.JsonMSets(kvs, path), make(map[string]error, len(kvs)))
-}
-
-func clientMGetCache(client Client, ctx context.Context, ttl time.Duration, cmd Cacheable, keys []string) (ret map[string]RedisMessage, err error) {
-	arr, err := client.DoCache(ctx, cmd, ttl).ToArray()
-	if err != nil {
-		return nil, err
-	}
-	return arrayToKV(make(map[string]RedisMessage, len(keys)), arr, keys), nil
 }
 
 func clientMGet(client Client, ctx context.Context, cmd Completed, keys []string) (ret map[string]RedisMessage, err error) {

--- a/helper_test.go
+++ b/helper_test.go
@@ -21,10 +21,14 @@ func TestMGetCache(t *testing.T) {
 		}
 		t.Run("Delegate DoCache", func(t *testing.T) {
 			m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
-				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) || ttl != 100 {
-					t.Fatalf("unexpected command %v, %v", cmd, ttl)
+				if reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1"}) && ttl == 100 {
+					return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}}}, nil)
 				}
-				return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}, {typ: '+', string: "2"}}}, nil)
+				if reflect.DeepEqual(cmd.Commands(), []string{"MGET", "2"}) && ttl == 100 {
+					return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "2"}}}, nil)
+				}
+				t.Fatalf("unexpected command %v, %v", cmd, ttl)
+				return RedisResult{}
 			}
 			if v, err := MGetCache(client, context.Background(), 100, []string{"1", "2"}); err != nil || v["1"].string != "1" || v["2"].string != "2" {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -514,10 +518,14 @@ func TestJsonMGetCache(t *testing.T) {
 		}
 		t.Run("Delegate DoCache", func(t *testing.T) {
 			m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
-				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) || ttl != 100 {
-					t.Fatalf("unexpected command %v, %v", cmd, ttl)
+				if reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "$"}) && ttl == 100 {
+					return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}}}, nil)
 				}
-				return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}, {typ: '+', string: "2"}}}, nil)
+				if reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "2", "$"}) && ttl == 100 {
+					return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "2"}}}, nil)
+				}
+				t.Fatalf("unexpected command %v, %v", cmd, ttl)
+				return RedisResult{}
 			}
 			if v, err := JsonMGetCache(client, context.Background(), 100, []string{"1", "2"}, "$"); err != nil || v["1"].string != "1" || v["2"].string != "2" {
 				t.Fatalf("unexpected response %v %v", v, err)


### PR DESCRIPTION
Regarding #239, I think using `parallelMget` for cached MGet helper functions will solve the issue. please let me know if anything else should be done.