### PR TITLE
fix(message): use errors is with redis nil

### DIFF
--- a/message.go
+++ b/message.go
@@ -2,6 +2,7 @@ package rueidis
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -20,13 +21,17 @@ var Nil = &RedisError{typ: '_'}
 // IsRedisNil is a handy method to check if error is a redis nil response.
 // All redis nil response returns as an error.
 func IsRedisNil(err error) bool {
-	return err == Nil
+	return errors.Is(err, Nil)
 }
 
 // IsRedisErr is a handy method to check if error is a redis ERR response.
 func IsRedisErr(err error) (ret *RedisError, ok bool) {
-	ret, ok = err.(*RedisError)
-	return ret, ok && ret != Nil
+	var e *RedisError
+	if errors.As(err, &e) {
+		ret = e
+		ok = !errors.Is(err, Nil)
+	}
+	return ret, ok
 }
 
 // RedisError is an error response or a nil message from redis instance

--- a/message_test.go
+++ b/message_test.go
@@ -10,6 +10,14 @@ import (
 	"time"
 )
 
+type wrapped struct {
+	msg string
+	err error
+}
+
+func (e wrapped) Error() string { return e.msg }
+func (e wrapped) Unwrap() error { return e.err }
+
 func TestIsRedisNil(t *testing.T) {
 	err := Nil
 	if !IsRedisNil(err) {
@@ -19,6 +27,13 @@ func TestIsRedisNil(t *testing.T) {
 		t.Fatal("IsRedisNil fail")
 	}
 	if err.Error() != "redis nil message" {
+		t.Fatal("IsRedisNil fail")
+	}
+	wrappedErr := wrapped{
+		msg: errors.New("wrapped error").Error(),
+		err: Nil,
+	}
+	if !IsRedisNil(wrappedErr) {
 		t.Fatal("IsRedisNil fail")
 	}
 }


### PR DESCRIPTION
This pull request aims to enhance error handling by utilizing errors.Is and errors.As.

Just found out, the IsRedisNil function fails to capture wrapped errors.
