### PR TITLE
Use type name in RedisMessage error instead of RESP3 character

### DIFF
--- a/message.go
+++ b/message.go
@@ -15,7 +15,7 @@ import (
 const messageStructSize = int(unsafe.Sizeof(RedisMessage{}))
 
 // Nil represents a Redis Nil message
-var Nil = &RedisError{typ: '_'}
+var Nil = &RedisError{typ: typeNull}
 
 // IsRedisNil is a handy method to check if error is a redis nil response.
 // All redis nil response returns as an error.
@@ -41,7 +41,7 @@ func (r *RedisError) Error() string {
 
 // IsNil checks if it is a redis nil message.
 func (r *RedisError) IsNil() bool {
-	return r.typ == '_'
+	return r.typ == typeNull
 }
 
 // IsMoved checks if it is a redis MOVED message and returns moved address.
@@ -434,45 +434,45 @@ type RedisMessage struct {
 
 // IsNil check if message is a redis nil response
 func (m *RedisMessage) IsNil() bool {
-	return m.typ == '_'
+	return m.typ == typeNull
 }
 
 // IsInt64 check if message is a redis RESP3 int response
 func (m *RedisMessage) IsInt64() bool {
-	return m.typ == ':'
+	return m.typ == typeInteger
 }
 
 // IsFloat64 check if message is a redis RESP3 double response
 func (m *RedisMessage) IsFloat64() bool {
-	return m.typ == ','
+	return m.typ == typeFloat
 }
 
 // IsString check if message is a redis string response
 func (m *RedisMessage) IsString() bool {
-	return m.typ == '$' || m.typ == '+'
+	return m.typ == typeBlobString || m.typ == typeSimpleString
 }
 
 // IsBool check if message is a redis RESP3 bool response
 func (m *RedisMessage) IsBool() bool {
-	return m.typ == '#'
+	return m.typ == typeBool
 }
 
 // IsArray check if message is a redis array response
 func (m *RedisMessage) IsArray() bool {
-	return m.typ == '*' || m.typ == '~'
+	return m.typ == typeArray || m.typ == typeSet
 }
 
 // IsMap check if message is a redis RESP3 map response
 func (m *RedisMessage) IsMap() bool {
-	return m.typ == '%'
+	return m.typ == typeMap
 }
 
 // Error check if message is a redis error response, including nil response
 func (m *RedisMessage) Error() error {
-	if m.typ == '_' {
+	if m.typ == typeNull {
 		return Nil
 	}
-	if m.typ == '-' || m.typ == '!' {
+	if m.typ == typeSimpleErr || m.typ == typeBlobErr {
 		// kvrocks: https://github.com/redis/rueidis/issues/152#issuecomment-1333923750
 		mm := *m
 		mm.string = strings.TrimPrefix(m.string, "ERR ")
@@ -488,7 +488,7 @@ func (m *RedisMessage) ToString() (val string, err error) {
 	}
 	if m.IsInt64() || m.values != nil {
 		typ := m.typ
-		panic(fmt.Sprintf("redis message type %c is not a string", typ))
+		panic(fmt.Sprintf("redis message type %s is not a string", typeNames[typ]))
 	}
 	return m.string, m.Error()
 }
@@ -551,18 +551,18 @@ func (m *RedisMessage) AsBool() (val bool, err error) {
 		return
 	}
 	switch m.typ {
-	case '$', '+':
+	case typeBlobString, typeSimpleString:
 		val = m.string == "OK"
 		return
-	case ':':
+	case typeInteger:
 		val = m.integer != 0
 		return
-	case '#':
+	case typeBool:
 		val = m.integer == 1
 		return
 	default:
 		typ := m.typ
-		panic(fmt.Sprintf("redis message type %c is not a int, string or bool", typ))
+		panic(fmt.Sprintf("redis message type %s is not a int, string or bool", typeNames[typ]))
 	}
 }
 
@@ -587,7 +587,7 @@ func (m *RedisMessage) ToInt64() (val int64, err error) {
 		return 0, err
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a RESP3 int64", typ))
+	panic(fmt.Sprintf("redis message type %s is not a RESP3 int64", typeNames[typ]))
 }
 
 // ToBool check if message is a redis RESP3 bool response, and return it
@@ -599,7 +599,7 @@ func (m *RedisMessage) ToBool() (val bool, err error) {
 		return false, err
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a RESP3 bool", typ))
+	panic(fmt.Sprintf("redis message type %s is not a RESP3 bool", typeNames[typ]))
 }
 
 // ToFloat64 check if message is a redis RESP3 double response, and return it
@@ -611,7 +611,7 @@ func (m *RedisMessage) ToFloat64() (val float64, err error) {
 		return 0, err
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a RESP3 float64", typ))
+	panic(fmt.Sprintf("redis message type %s is not a RESP3 float64", typeNames[typ]))
 }
 
 // ToArray check if message is a redis array/set response, and return it
@@ -623,7 +623,7 @@ func (m *RedisMessage) ToArray() ([]RedisMessage, error) {
 		return nil, err
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a array", typ))
+	panic(fmt.Sprintf("redis message type %s is not a array", typeNames[typ]))
 }
 
 // AsStrSlice check if message is a redis array/set response, and convert to []string.
@@ -752,7 +752,7 @@ func (m *RedisMessage) AsXRead() (ret map[string][]XRangeEntry, err error) {
 		return ret, nil
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a map/array/set or its length is not even", typ))
+	panic(fmt.Sprintf("redis message type %s is not a map/array/set or its length is not even", typeNames[typ]))
 }
 
 // ZScore is the element type of ZRANGE WITHSCORES, ZDIFF WITHSCORES and ZPOPMAX command response
@@ -824,7 +824,7 @@ func (m *RedisMessage) AsScanEntry() (e ScanEntry, err error) {
 		return e, err
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a scan response or its length is not at least 2", typ))
+	panic(fmt.Sprintf("redis message type %s is not a scan response or its length is not at least 2", typeNames[typ]))
 }
 
 // AsMap check if message is a redis array/set response, and convert to map[string]RedisMessage
@@ -836,7 +836,7 @@ func (m *RedisMessage) AsMap() (map[string]RedisMessage, error) {
 		return toMap(m.values), nil
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a map/array/set or its length is not even", typ))
+	panic(fmt.Sprintf("redis message type %s is not a map/array/set or its length is not even", typeNames[typ]))
 }
 
 // AsStrMap check if message is a redis map/array/set response, and convert to map[string]string.
@@ -855,7 +855,7 @@ func (m *RedisMessage) AsStrMap() (map[string]string, error) {
 		return r, nil
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a map/array/set or its length is not even", typ))
+	panic(fmt.Sprintf("redis message type %s is not a map/array/set or its length is not even", typeNames[typ]))
 }
 
 // AsIntMap check if message is a redis map/array/set response, and convert to map[string]int64.
@@ -870,12 +870,12 @@ func (m *RedisMessage) AsIntMap() (map[string]int64, error) {
 		for i := 0; i < len(m.values); i += 2 {
 			k := m.values[i]
 			v := m.values[i+1]
-			if k.typ == '$' || k.typ == '+' {
+			if k.typ == typeBlobString || k.typ == typeSimpleString {
 				if len(v.string) != 0 {
 					if r[k.string], err = strconv.ParseInt(v.string, 0, 64); err != nil {
 						return nil, err
 					}
-				} else if v.typ == ':' || v.typ == '_' {
+				} else if v.typ == typeInteger || v.typ == typeNull {
 					r[k.string] = v.integer
 				}
 			}
@@ -883,7 +883,7 @@ func (m *RedisMessage) AsIntMap() (map[string]int64, error) {
 		return r, nil
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a map/array/set or its length is not even", typ))
+	panic(fmt.Sprintf("redis message type %s is not a map/array/set or its length is not even", typeNames[typ]))
 }
 
 type KeyValues struct {
@@ -901,7 +901,7 @@ func (m *RedisMessage) AsLMPop() (kvs KeyValues, err error) {
 		return
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a LMPOP response", typ))
+	panic(fmt.Sprintf("redis message type %s is not a LMPOP response", typeNames[typ]))
 }
 
 type KeyZScores struct {
@@ -919,7 +919,7 @@ func (m *RedisMessage) AsZMPop() (kvs KeyZScores, err error) {
 		return
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a ZMPOP response", typ))
+	panic(fmt.Sprintf("redis message type %s is not a ZMPOP response", typeNames[typ]))
 }
 
 type FtSearchDoc struct {
@@ -948,7 +948,7 @@ func (m *RedisMessage) AsFtSearch() (total int64, docs []FtSearchDoc, err error)
 		return
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a FT.SEARCH response", typ))
+	panic(fmt.Sprintf("redis message type %s is not a FT.SEARCH response", typeNames[typ]))
 }
 
 // ToMap check if message is a redis RESP3 map response, and return it
@@ -960,7 +960,7 @@ func (m *RedisMessage) ToMap() (map[string]RedisMessage, error) {
 		return nil, err
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a RESP3 map", typ))
+	panic(fmt.Sprintf("redis message type %s is not a RESP3 map", typeNames[typ]))
 }
 
 // ToAny turns message into go any value
@@ -969,15 +969,15 @@ func (m *RedisMessage) ToAny() (any, error) {
 		return nil, err
 	}
 	switch m.typ {
-	case ',':
+	case typeFloat:
 		return util.ToFloat64(m.string)
-	case '$', '+', '=', '(':
+	case typeBlobString, typeSimpleString, typeVerbatimString, typeBigNumber:
 		return m.string, nil
-	case '#':
+	case typeBool:
 		return m.integer == 1, nil
-	case ':':
+	case typeInteger:
 		return m.integer, nil
-	case '%':
+	case typeMap:
 		vs := make(map[string]any, len(m.values)/2)
 		for i := 0; i < len(m.values); i += 2 {
 			if v, err := m.values[i+1].ToAny(); err != nil && !IsRedisNil(err) {
@@ -987,7 +987,7 @@ func (m *RedisMessage) ToAny() (any, error) {
 			}
 		}
 		return vs, nil
-	case '~', '*':
+	case typeSet, typeArray:
 		vs := make([]any, len(m.values))
 		for i := 0; i < len(m.values); i++ {
 			if v, err := m.values[i].ToAny(); err != nil && !IsRedisNil(err) {
@@ -999,7 +999,7 @@ func (m *RedisMessage) ToAny() (any, error) {
 		return vs, nil
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a supported in ToAny", typ))
+	panic(fmt.Sprintf("redis message type %s is not a supported in ToAny", typeNames[typ]))
 }
 
 // IsCacheHit check if message is from client side cache
@@ -1062,12 +1062,12 @@ func (m *RedisMessage) setExpireAt(pttl int64) {
 func toMap(values []RedisMessage) map[string]RedisMessage {
 	r := make(map[string]RedisMessage, len(values)/2)
 	for i := 0; i < len(values); i += 2 {
-		if values[i].typ == '$' || values[i].typ == '+' {
+		if values[i].typ == typeBlobString || values[i].typ == typeSimpleString {
 			r[values[i].string] = values[i+1]
 			continue
 		}
 		typ := values[i].typ
-		panic(fmt.Sprintf("redis message type %c as map key is not supported", typ))
+		panic(fmt.Sprintf("redis message type %s as map key is not supported", typeNames[typ]))
 	}
 	return r
 }

--- a/message_test.go
+++ b/message_test.go
@@ -3,6 +3,7 @@ package rueidis
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -57,6 +58,9 @@ func TestIsRedisErr(t *testing.T) {
 
 //gocyclo:ignore
 func TestRedisResult(t *testing.T) {
+	//Add erroneous type
+	typeNames['t'] = "t"
+
 	t.Run("ToInt64", func(t *testing.T) {
 		if _, err := (RedisResult{err: errors.New("other")}).ToInt64(); err == nil {
 			t.Fatal("ToInt64 not failed as expected")
@@ -683,6 +687,9 @@ func TestRedisResult(t *testing.T) {
 
 //gocyclo:ignore
 func TestRedisMessage(t *testing.T) {
+	//Add erroneous type
+	typeNames['t'] = "t"
+
 	t.Run("IsNil", func(t *testing.T) {
 		if !(&RedisMessage{typ: '_'}).IsNil() {
 			t.Fatal("IsNil fail")
@@ -752,7 +759,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 				t.Fatal("ToString not panic as expected")
 			}
 		}()
@@ -765,7 +772,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 				t.Fatal("AsReader not panic as expected")
 			}
 		}()
@@ -778,7 +785,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 				t.Fatal("AsBytes not panic as expected")
 			}
 		}()
@@ -791,7 +798,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 				t.Fatal("DecodeJSON not panic as expected")
 			}
 		}()
@@ -803,7 +810,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsInt64 not failed as expected")
 		}
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type * is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames['*'])) {
 				t.Fatal("AsInt64 not panic as expected")
 			}
 		}()
@@ -815,7 +822,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsUint64 not failed as expected")
 		}
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type * is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames['*'])) {
 				t.Fatal("AsUint64 not panic as expected")
 			}
 		}()
@@ -827,7 +834,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsFloat64 not failed as expected")
 		}
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 				t.Fatal("AsFloat64 not panic as expected")
 			}
 		}()
@@ -965,7 +972,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : is not a string") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 				t.Fatal("AsXRangeEntry not panic as expected")
 			}
 		}()
@@ -1080,7 +1087,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsLMPop not fails as expected")
 		}
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type * is not a LMPOP response") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a LMPOP response", typeNames['*'])) {
 				t.Fatal("AsLMPop not panic as expected")
 			}
 		}()
@@ -1100,7 +1107,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsZMPop not fails as expected")
 		}
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type * is not a ZMPOP response") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a ZMPOP response", typeNames['*'])) {
 				t.Fatal("AsZMPop not panic as expected")
 			}
 		}()
@@ -1114,7 +1121,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsFtSearch not failed as expected")
 		}
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type * is not a FT.SEARCH response") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a FT.SEARCH response", typeNames['*'])) {
 				t.Fatal("AsFtSearch not panic as expected")
 			}
 		}()
@@ -1139,7 +1146,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type * is not a scan response or its length is not at least 2") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s is not a scan response or its length is not at least 2", typeNames['*'])) {
 				t.Fatal("AsScanEntry not panic as expected")
 			}
 		}()
@@ -1148,7 +1155,7 @@ func TestRedisMessage(t *testing.T) {
 
 	t.Run("ToMap with non string key", func(t *testing.T) {
 		defer func() {
-			if !strings.Contains(recover().(string), "redis message type : as map key is not supported") {
+			if !strings.Contains(recover().(string), fmt.Sprintf("redis message type %s as map key is not supported", typeNames[':'])) {
 				t.Fatal("ToMap not panic as expected")
 			}
 		}()

--- a/resp.go
+++ b/resp.go
@@ -11,27 +11,65 @@ import (
 var errChunked = errors.New("unbounded redis message")
 var errOldNull = errors.New("RESP2 null")
 
+const (
+	typeBlobString     = byte('$')
+	typeSimpleString   = byte('+')
+	typeSimpleErr      = byte('-')
+	typeInteger        = byte(':')
+	typeNull           = byte('_')
+	typeNull2          = byte('.')
+	typeFloat          = byte(',')
+	typeBool           = byte('#')
+	typeBlobErr        = byte('!')
+	typeVerbatimString = byte('=')
+	typeBigNumber      = byte('(')
+	typeArray          = byte('*')
+	typeMap            = byte('%')
+	typeSet            = byte('~')
+	typeAttribute      = byte('|')
+	typePush           = byte('>')
+)
+
+var typeNames = [256]string{}
+
 type reader func(i *bufio.Reader) (RedisMessage, error)
 
 var readers = [256]reader{}
 
 func init() {
-	readers['$'] = readBlobString
-	readers['+'] = readSimpleString
-	readers['-'] = readSimpleString
-	readers[':'] = readInteger
-	readers['_'] = readNull
-	readers[','] = readSimpleString
-	readers['#'] = readBoolean
-	readers['!'] = readBlobString
-	readers['='] = readBlobString
-	readers['('] = readSimpleString
-	readers['*'] = readArray
-	readers['%'] = readMap
-	readers['~'] = readArray
-	readers['|'] = readMap
-	readers['>'] = readArray
-	readers['.'] = readNull
+	readers[typeBlobString] = readBlobString
+	readers[typeSimpleString] = readSimpleString
+	readers[typeSimpleErr] = readSimpleString
+	readers[typeInteger] = readInteger
+	readers[typeNull] = readNull
+	readers[typeFloat] = readSimpleString
+	readers[typeBool] = readBoolean
+	readers[typeBlobErr] = readBlobString
+	readers[typeVerbatimString] = readBlobString
+	readers[typeBigNumber] = readSimpleString
+	readers[typeArray] = readArray
+	readers[typeMap] = readMap
+	readers[typeSet] = readArray
+	readers[typeAttribute] = readMap
+	readers[typePush] = readArray
+	readers[typeNull2] = readNull
+
+	typeNames[typeBlobString] = "blob string"
+	typeNames[typeSimpleString] = "simple string"
+	typeNames[typeSimpleErr] = "simple error"
+	typeNames[typeInteger] = "int64"
+	typeNames[typeNull] = "null"
+	typeNames[typeFloat] = "float64"
+	typeNames[typeBool] = "boolean"
+	typeNames[typeBlobErr] = "blob error"
+	typeNames[typeVerbatimString] = "verbatim string"
+	typeNames[typeBigNumber] = "big number"
+	typeNames[typeArray] = "array"
+	typeNames[typeMap] = "map"
+	typeNames[typeSet] = "set"
+	typeNames[typeAttribute] = "attribute"
+	typeNames[typePush] = "push"
+	typeNames[typeNull2] = "null"
 }
 
 func readSimpleString(i *bufio.Reader) (m RedisMessage, err error) {
@@ -223,12 +261,12 @@ func readNextMessage(i *bufio.Reader) (m RedisMessage, err error) {
 		}
 		if m, err = fn(i); err != nil {
 			if err == errOldNull {
-				return RedisMessage{typ: '_'}, nil
+				return RedisMessage{typ: typeNull}, nil
 			}
 			return RedisMessage{}, err
 		}
 		m.typ = typ
-		if m.typ == '|' { // handle the attributes
+		if m.typ == typeAttribute { // handle the attributes
 			a := m     // clone the original m first, and then take address of the clone
 			attrs = &a // to avoid go compiler allocating the m on heap which causing worse performance.
 			m = RedisMessage{}


### PR DESCRIPTION
This change is made to address issue [127](https://github.com/redis/rueidis/issues/271). Currently when a no-op type conversion happens as a result of calling To* or As* the error message produced looks like this
```
panic: redis message type : as map key is not supported
```
The RESP3 character that represents a 64 bit integer ':' is shown to be reason for the panic
With the current change applied, the error message would now look like this 
```
panic: redis message type int64 as map key is not supported
```
Current unit tests are covering the changes to the error messages in message.go, let me know if more tests are desired to add to coverage of the different types.

Notes for maintainers:
For this PR I decided to keep the change small while still addressing the root problem. I see that there is quite a bit of usage of RESP3 characters throughout the library, I could sub those in for these constants if that's asked of me (In this PR or a few others).
Also I left unit tests message_test.go and resp_test.go as is in terms of RESP3 characters instead of swapping in the new constants due to creating a massive diff that would be hard to review, but I could I also get that done if that's wanted.