### PR TITLE
Feature: Add AsGeosearch method for RedisResult

### DIFF
--- a/message.go
+++ b/message.go
@@ -984,7 +984,7 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 			loc.Name = info[i].string
 			i++
 			//distance
-			if i < len(info) && info[i].IsString() {
+			if i < len(info) && info[i].IsFloat64() {
 				loc.Dist, err = util.ToFloat64(info[i].string)
 				if err != nil {
 					return nil, err

--- a/message.go
+++ b/message.go
@@ -974,57 +974,36 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 	geoLocations := make([]GeoLocation, 0, len(arr))
 	for _, v := range arr {
 		var loc GeoLocation
-		if v.typ == '$' {
-			loc.Name, err = v.ToString()
-			if err != nil {
-				return nil, err
-			}
+		if v.IsString() {
+			loc.Name = v.string
 		} else {
-			info, err := v.ToArray()
-			if err != nil {
-				return nil, err
-			}
+			info := v.values
 			var i int
 
 			//name
-			loc.Name, err = info[i].ToString()
-			if err != nil {
-				return nil, err
-			}
+			loc.Name = info[i].string
 			i++
 			//distance
-			if i < len(info) && info[i].string != "" {
-				loc.Dist, err = info[i].AsFloat64()
+			if i < len(info) && info[i].IsString() {
+				loc.Dist, err = util.ToFloat64(info[i].string)
 				if err != nil {
 					return nil, err
 				}
 				i++
 			}
 			//hash
-			if i < len(info) && info[i].integer != 0 {
-				loc.GeoHash, err = info[i].AsInt64()
-				if err != nil {
-					return nil, err
-				}
+			if i < len(info) && info[i].IsInt64() {
+				loc.GeoHash = info[i].integer
 				i++
 			}
 			//coordinates
 			if i < len(info) && info[i].values != nil {
-				cord, err := info[i].ToArray()
-				if err != nil {
-					return nil, err
-				}
-				if len(cord) != 2 {
+				cord := info[i].values
+				if len(cord) < 2 {
 					return nil, fmt.Errorf("got %d, expected 2", len(info))
 				}
-				loc.Longitude, err = cord[0].AsFloat64()
-				if err != nil {
-					return nil, err
-				}
-				loc.Latitude, err = cord[1].AsFloat64()
-				if err != nil {
-					return nil, err
-				}
+				loc.Longitude, _ = cord[0].AsFloat64()
+				loc.Latitude, _ = cord[1].AsFloat64()
 			}
 		}
 		geoLocations = append(geoLocations, loc)

--- a/message.go
+++ b/message.go
@@ -973,51 +973,58 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 	}
 	geoLocations := make([]GeoLocation, 0, len(arr))
 	for _, v := range arr {
-		info, err := v.ToArray()
-		if err != nil {
-			return nil, err
-		}
-		var i int
 		var loc GeoLocation
+		if v.typ == '$' {
+			loc.Name, err = v.ToString()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			info, err := v.ToArray()
+			if err != nil {
+				return nil, err
+			}
+			var i int
 
-		//name
-		loc.Name, err = info[i].ToString()
-		if err != nil {
-			return nil, err
-		}
-		i++
-		//distance
-		if i < len(info) && info[i].string != "" {
-			loc.Dist, err = info[i].AsFloat64()
+			//name
+			loc.Name, err = info[i].ToString()
 			if err != nil {
 				return nil, err
 			}
 			i++
-		}
-		//hash
-		if i < len(info) && info[i].integer != 0 {
-			loc.GeoHash, err = info[i].AsInt64()
-			if err != nil {
-				return nil, err
+			//distance
+			if i < len(info) && info[i].string != "" {
+				loc.Dist, err = info[i].AsFloat64()
+				if err != nil {
+					return nil, err
+				}
+				i++
 			}
-			i++
-		}
-		//coords
-		if i < len(info) && info[i].values != nil {
-			cord, err := info[i].ToArray()
-			if err != nil {
-				return nil, err
+			//hash
+			if i < len(info) && info[i].integer != 0 {
+				loc.GeoHash, err = info[i].AsInt64()
+				if err != nil {
+					return nil, err
+				}
+				i++
 			}
-			if len(cord) != 2 {
-				return nil, fmt.Errorf("got %d, expected 2", len(info))
-			}
-			loc.Longitude, err = cord[0].AsFloat64()
-			if err != nil {
-				return nil, err
-			}
-			loc.Latitude, err = cord[1].AsFloat64()
-			if err != nil {
-				return nil, err
+			//coordinates
+			if i < len(info) && info[i].values != nil {
+				cord, err := info[i].ToArray()
+				if err != nil {
+					return nil, err
+				}
+				if len(cord) != 2 {
+					return nil, fmt.Errorf("got %d, expected 2", len(info))
+				}
+				loc.Longitude, err = cord[0].AsFloat64()
+				if err != nil {
+					return nil, err
+				}
+				loc.Latitude, err = cord[1].AsFloat64()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		geoLocations = append(geoLocations, loc)

--- a/message.go
+++ b/message.go
@@ -984,7 +984,7 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 			loc.Name = info[i].string
 			i++
 			//distance
-			if i < len(info) && info[i].IsFloat64() {
+			if i < len(info) && info[i].string != "" {
 				loc.Dist, err = util.ToFloat64(info[i].string)
 				if err != nil {
 					return nil, err

--- a/message_test.go
+++ b/message_test.go
@@ -630,6 +630,103 @@ func TestRedisResult(t *testing.T) {
 		}
 	})
 
+	t.Run("asGeosearch", func(t *testing.T) {
+		if _, err := (RedisResult{err: errors.New("other")}).AsGeosearch(); err == nil {
+			t.Fatal("asGeosearch not failed as expected")
+		}
+		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsGeosearch(); err == nil {
+			t.Fatal("asGeosearch not failed as expected")
+		}
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: ',', string: "2.5"},
+				{typ: ':', integer: 1},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "45.7"},
+					{typ: ',', string: "73.1"},
+				}},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: ',', string: "4.5"},
+				{typ: ':', integer: 4},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "45.7"},
+					{typ: ',', string: "73.1"},
+				}},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", Dist: 2.5, GeoHash: 1, Longitude: 45.7, Latitude: 73.1},
+			{Name: "k2", Dist: 4.5, GeoHash: 4, Longitude: 45.7, Latitude: 73.1},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: ',', string: "2.5"},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: ',', string: "4.5"},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", Dist: 2.5},
+			{Name: "k2", Dist: 4.5},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: ':', integer: 1},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "45.7"},
+					{typ: ',', string: "73.1"},
+				}},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: ':', integer: 4},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "45.7"},
+					{typ: ',', string: "73.1"},
+				}},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", GeoHash: 1, Longitude: 45.7, Latitude: 73.1},
+			{Name: "k2", GeoHash: 4, Longitude: 45.7, Latitude: 73.1},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "45.7"},
+					{typ: ',', string: "73.1"},
+				}},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "45.7"},
+					{typ: ',', string: "73.1"},
+				}},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", Longitude: 45.7, Latitude: 73.1},
+			{Name: "k2", Longitude: 45.7, Latitude: 73.1},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+
+	})
+
 	t.Run("IsCacheHit", func(t *testing.T) {
 		if (RedisResult{err: errors.New("other")}).IsCacheHit() {
 			t.Fatal("IsCacheHit not as expected")

--- a/message_test.go
+++ b/message_test.go
@@ -642,8 +642,8 @@ func TestRedisResult(t *testing.T) {
 		//WithDist, WithHash, WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: ',', string: "2.5"},
+				{typ: '$', string: "k1"},
+				{typ: '$', string: "2.5"},
 				{typ: ':', integer: 1},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "28.0473"},
@@ -651,8 +651,8 @@ func TestRedisResult(t *testing.T) {
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
-				{typ: ',', string: "4.5"},
+				{typ: '$', string: "k2"},
+				{typ: '$', string: "4.5"},
 				{typ: ':', integer: 4},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "72.4973"},
@@ -668,7 +668,7 @@ func TestRedisResult(t *testing.T) {
 		//WithHash, WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
+				{typ: '$', string: "k1"},
 				{typ: ':', integer: 1},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "84.3877"},
@@ -676,7 +676,7 @@ func TestRedisResult(t *testing.T) {
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
+				{typ: '$', string: "k2"},
 				{typ: ':', integer: 4},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "115.8613"},
@@ -692,16 +692,16 @@ func TestRedisResult(t *testing.T) {
 		//WithDist, WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: ',', string: "2.50076"},
+				{typ: '$', string: "k1"},
+				{typ: '$', string: "2.50076"},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "84.3877"},
 					{typ: ',', string: "33.7488"},
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
-				{typ: ',', string: "1024.96"},
+				{typ: '$', string: "k2"},
+				{typ: '$', string: "1024.96"},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "115.8613"},
 					{typ: ',', string: "31.9523"},
@@ -716,14 +716,14 @@ func TestRedisResult(t *testing.T) {
 		//WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
+				{typ: '$', string: "k1"},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "122.4194"},
 					{typ: ',', string: "37.7749"},
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
+				{typ: '$', string: "k2"},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "35.6762"},
 					{typ: ',', string: "139.6503"},
@@ -738,11 +738,11 @@ func TestRedisResult(t *testing.T) {
 		//WithDist
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
+				{typ: '$', string: "k1"},
 				{typ: ',', string: "2.50076"},
 			}},
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
+				{typ: '$', string: "k2"},
 				{typ: ',', string: strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)},
 			}},
 		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
@@ -754,16 +754,26 @@ func TestRedisResult(t *testing.T) {
 		//WithHash
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
+				{typ: '$', string: "k1"},
 				{typ: ':', integer: math.MaxInt64},
 			}},
 			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
+				{typ: '$', string: "k2"},
 				{typ: ':', integer: 22296},
 			}},
 		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", GeoHash: math.MaxInt64},
 			{Name: "k2", GeoHash: 22296},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+		//With no additional options
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '$', string: "k1"},
+			{typ: '$', string: "k2"},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1"},
+			{Name: "k2"},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -637,14 +639,15 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsGeosearch(); err == nil {
 			t.Fatal("asGeosearch not failed as expected")
 		}
+		//WithDist, WithHash, WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
 				{typ: '+', string: "k1"},
 				{typ: ',', string: "2.5"},
 				{typ: ':', integer: 1},
 				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "45.7"},
-					{typ: ',', string: "73.1"},
+					{typ: ',', string: "28.0473"},
+					{typ: ',', string: "26.2041"},
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
@@ -652,75 +655,115 @@ func TestRedisResult(t *testing.T) {
 				{typ: ',', string: "4.5"},
 				{typ: ':', integer: 4},
 				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "45.7"},
-					{typ: ',', string: "73.1"},
+					{typ: ',', string: "72.4973"},
+					{typ: ',', string: "13.2263"},
 				}},
 			}},
 		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
-			{Name: "k1", Dist: 2.5, GeoHash: 1, Longitude: 45.7, Latitude: 73.1},
-			{Name: "k2", Dist: 4.5, GeoHash: 4, Longitude: 45.7, Latitude: 73.1},
+			{Name: "k1", Dist: 2.5, GeoHash: 1, Longitude: 28.0473, Latitude: 26.2041},
+			{Name: "k2", Dist: 4.5, GeoHash: 4, Longitude: 72.4973, Latitude: 13.2263},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
-
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: ',', string: "2.5"},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
-				{typ: ',', string: "4.5"},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
-			{Name: "k1", Dist: 2.5},
-			{Name: "k2", Dist: 4.5},
-		}, ret) {
-			t.Fatal("AsGeosearch not get value as expected")
-		}
-
+		//WithHash, WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
 				{typ: '+', string: "k1"},
 				{typ: ':', integer: 1},
 				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "45.7"},
-					{typ: ',', string: "73.1"},
+					{typ: ',', string: "84.3877"},
+					{typ: ',', string: "33.7488"},
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
 				{typ: '+', string: "k2"},
 				{typ: ':', integer: 4},
 				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "45.7"},
-					{typ: ',', string: "73.1"},
+					{typ: ',', string: "115.8613"},
+					{typ: ',', string: "31.9523"},
 				}},
 			}},
 		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
-			{Name: "k1", GeoHash: 1, Longitude: 45.7, Latitude: 73.1},
-			{Name: "k2", GeoHash: 4, Longitude: 45.7, Latitude: 73.1},
+			{Name: "k1", GeoHash: 1, Longitude: 84.3877, Latitude: 33.7488},
+			{Name: "k2", GeoHash: 4, Longitude: 115.8613, Latitude: 31.9523},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
-
+		//WithDist, WithCoord
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: ',', string: "2.50076"},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "84.3877"},
+					{typ: ',', string: "33.7488"},
+				}},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: ',', string: "1024.96"},
+				{typ: '*', values: []RedisMessage{
+					{typ: ',', string: "115.8613"},
+					{typ: ',', string: "31.9523"},
+				}},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", Dist: 2.50076, Longitude: 84.3877, Latitude: 33.7488},
+			{Name: "k2", Dist: 1024.96, Longitude: 115.8613, Latitude: 31.9523},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+		//WithCoord
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
 				{typ: '+', string: "k1"},
 				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "45.7"},
-					{typ: ',', string: "73.1"},
+					{typ: ',', string: "122.4194"},
+					{typ: ',', string: "37.7749"},
 				}},
 			}},
 			{typ: '*', values: []RedisMessage{
 				{typ: '+', string: "k2"},
 				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "45.7"},
-					{typ: ',', string: "73.1"},
+					{typ: ',', string: "35.6762"},
+					{typ: ',', string: "139.6503"},
 				}},
 			}},
 		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
-			{Name: "k1", Longitude: 45.7, Latitude: 73.1},
-			{Name: "k2", Longitude: 45.7, Latitude: 73.1},
+			{Name: "k1", Longitude: 122.4194, Latitude: 37.7749},
+			{Name: "k2", Longitude: 35.6762, Latitude: 139.6503},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+		//WithDist
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: ',', string: "2.50076"},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: ',', string: strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", Dist: 2.50076},
+			{Name: "k2", Dist: math.MaxFloat64},
+		}, ret) {
+			t.Fatal("AsGeosearch not get value as expected")
+		}
+		//WithHash
+		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k1"},
+				{typ: ':', integer: math.MaxInt64},
+			}},
+			{typ: '*', values: []RedisMessage{
+				{typ: '+', string: "k2"},
+				{typ: ':', integer: 22296},
+			}},
+		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			{Name: "k1", GeoHash: math.MaxInt64},
+			{Name: "k2", GeoHash: 22296},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -643,7 +643,7 @@ func TestRedisResult(t *testing.T) {
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
 				{typ: '$', string: "k1"},
-				{typ: '$', string: "2.5"},
+				{typ: ',', string: "2.5"},
 				{typ: ':', integer: 1},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "28.0473"},
@@ -652,7 +652,7 @@ func TestRedisResult(t *testing.T) {
 			}},
 			{typ: '*', values: []RedisMessage{
 				{typ: '$', string: "k2"},
-				{typ: '$', string: "4.5"},
+				{typ: ',', string: "4.5"},
 				{typ: ':', integer: 4},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "72.4973"},
@@ -693,7 +693,7 @@ func TestRedisResult(t *testing.T) {
 		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
 			{typ: '*', values: []RedisMessage{
 				{typ: '$', string: "k1"},
-				{typ: '$', string: "2.50076"},
+				{typ: ',', string: "2.50076"},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "84.3877"},
 					{typ: ',', string: "33.7488"},
@@ -701,7 +701,7 @@ func TestRedisResult(t *testing.T) {
 			}},
 			{typ: '*', values: []RedisMessage{
 				{typ: '$', string: "k2"},
-				{typ: '$', string: "1024.96"},
+				{typ: ',', string: "1024.96"},
 				{typ: '*', values: []RedisMessage{
 					{typ: ',', string: "115.8613"},
 					{typ: ',', string: "31.9523"},


### PR DESCRIPTION
This change is to add an AsGeosearch method to RedisResult and RedisMessage to convert Geosearch query results into the GeoLocation type that is available in go-redis. Geosearch responses can be tricky to parse as you can get two types back. A standard request like below
```golang
resp = client.Do(context.Background(), client.B().
		Geosearch().
		Key("cities").
		Fromlonlat(76.1474, 43.0481).
		Bybox(200).
		Height(200).
		Mi().
		Build())
```
Will result in receiving an Array of BlobString where the contents are the geolocation names assigned when performing a GeoAdd insertion query
```
//Using github.com/davecgh/go-spew/spew to inspect the type
([]interface {}) (len=2 cap=2) {
 (string) (len=8) "Syracuse",
 (string) (len=6) "Albany"
}
```
However, if additional features are requested, then the data shape changes
```golang
resp := client.Do(context.Background(), client.B().
		Geosearch().
		Key("cities").
		Fromlonlat(76.1474, 43.0481).
		Bybox(900).
		Height(900).
		Mi().Withcoord().Withdist().Withhash().
		Build())
```

```
([]interface {}) (len=2 cap=2) {
 ([]interface {}) (len=4 cap=4) {
  (string) (len=8) "Syracuse",
  (string) (len=6) "0.0001",
  (int64) 3837869069283989,
  ([]interface {}) (len=2 cap=2) {
   (float64) 76.14740163087845,
   (float64) 43.04810095907946
  }
 },
 ([]interface {}) (len=4 cap=4) {
  (string) (len=6) "Albany",
  (string) (len=8) "147.4430",
  (int64) 3649518021478809,
  ([]interface {}) (len=2 cap=2) {
   (float64) 75.14739900827408,
   (float64) 41.04809950607234
  }
 }
}
```
The data shape is different and the size of the Geosearch response array is different depending on the options specified too. I have added unit tests for all possible permutations of the Redis response for Geosearches. 
Doing some local testing with my own geoqueries I was able to successfully parse these queries to GeoLocation structs. I can add in some integration tests where actual queries are made to Redis if that is desired. 

