### PR TITLE
perf: use runtime.GOMAXPROCS() to determine max concurrency

### DIFF
--- a/internal/util/parallel.go
+++ b/internal/util/parallel.go
@@ -24,7 +24,7 @@ func ParallelVals[K comparable, V any](p map[K]V, fn func(k V)) {
 func closeThenParallel[V any](ch chan V, fn func(k V)) {
 	close(ch)
 	concurrency := len(ch)
-	if cpus := runtime.NumCPU(); concurrency > cpus {
+	if cpus := runtime.GOMAXPROCS(0); concurrency > cpus {
 		concurrency = cpus
 	}
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Program may be running on an N core machine but only allowed to use M cores via GOMAXPROCS=M. Spawning more than M CPU-bound goroutines just creates useless work for Go scheduler. It can also result in CPU throttling when limits are enforced by cgroups. See https://github.com/golang/go/issues/33803.