### PR TITLE
perf: speed up MGet/Cache/MSet heplers by grouping commands by connections instead of slots

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -3,22 +3,24 @@ package rueidis
 import (
 	"context"
 	"errors"
-	"sync"
 	"time"
 
-	"github.com/redis/rueidis/internal/cmds"
-	"github.com/redis/rueidis/internal/util"
+	intl "github.com/redis/rueidis/internal/cmds"
 )
 
-// MGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within same slot into MGETs
+// MGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within same slot into multiple GETs
 func MGetCache(client Client, ctx context.Context, ttl time.Duration, keys []string) (ret map[string]RedisMessage, err error) {
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
-	return parallelMGetCache(client, ctx, ttl, cmds.MGets(keys), keys)
+	cmds := make([]CacheableTTL, len(keys))
+	for i := range cmds {
+		cmds[i] = CT(client.B().Get().Key(keys[i]).Cache(), ttl)
+	}
+	return doMultiCache(client, ctx, cmds, keys)
 }
 
-// MGet is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MGETs
+// MGet is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MGET or multiple GETs
 func MGet(client Client, ctx context.Context, keys []string) (ret map[string]RedisMessage, err error) {
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
@@ -26,10 +28,14 @@ func MGet(client Client, ctx context.Context, keys []string) (ret map[string]Red
 	if _, ok := client.(*singleClient); ok {
 		return clientMGet(client, ctx, client.B().Mget().Key(keys...).Build(), keys)
 	}
-	return parallelMGet(client, ctx, cmds.MGets(keys), keys)
+	cmds := make([]Completed, len(keys))
+	for i := range cmds {
+		cmds[i] = client.B().Get().Key(keys[i]).Build()
+	}
+	return doMultiGet(client, ctx, cmds, keys)
 }
 
-// MSet is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MSETs
+// MSet is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MSETs or multiple SETs
 func MSet(client Client, ctx context.Context, kvs map[string]string) map[string]error {
 	if len(kvs) == 0 {
 		return make(map[string]error)
@@ -37,7 +43,13 @@ func MSet(client Client, ctx context.Context, kvs map[string]string) map[string]
 	if _, ok := client.(*singleClient); ok {
 		return clientMSet(client, ctx, "MSET", kvs, make(map[string]error, len(kvs)))
 	}
-	return parallelMSet(client, ctx, cmds.MSets(kvs), make(map[string]error, len(kvs)))
+	cmds := make([]Completed, 0, len(kvs))
+	keys := make([]string, 0, len(kvs))
+	for k, v := range kvs {
+		cmds = append(cmds, client.B().Set().Key(k).Value(v).Build())
+		keys = append(keys, k)
+	}
+	return doMultiSet(client, ctx, cmds, keys)
 }
 
 // MDel is a helper that consults the redis directly with multiple keys by grouping keys within same slot into DELs
@@ -48,10 +60,14 @@ func MDel(client Client, ctx context.Context, keys []string) map[string]error {
 	if _, ok := client.(*singleClient); ok {
 		return clientMDel(client, ctx, keys)
 	}
-	return parallelMDel(client, ctx, cmds.MDels(keys), make(map[string]error, len(keys)))
+	cmds := make([]Completed, len(keys))
+	for i, k := range keys {
+		cmds[i] = client.B().Del().Key(k).Build()
+	}
+	return doMultiSet(client, ctx, cmds, keys)
 }
 
-// MSetNX is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MSETNXs
+// MSetNX is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MSETNXs or multiple SETNXs
 func MSetNX(client Client, ctx context.Context, kvs map[string]string) map[string]error {
 	if len(kvs) == 0 {
 		return make(map[string]error)
@@ -59,18 +75,28 @@ func MSetNX(client Client, ctx context.Context, kvs map[string]string) map[strin
 	if _, ok := client.(*singleClient); ok {
 		return clientMSet(client, ctx, "MSETNX", kvs, make(map[string]error, len(kvs)))
 	}
-	return parallelMSet(client, ctx, cmds.MSetNXs(kvs), make(map[string]error, len(kvs)))
+	cmds := make([]Completed, 0, len(kvs))
+	keys := make([]string, 0, len(kvs))
+	for k, v := range kvs {
+		cmds = append(cmds, client.B().Set().Key(k).Value(v).Nx().Build())
+		keys = append(keys, k)
+	}
+	return doMultiSet(client, ctx, cmds, keys)
 }
 
-// JsonMGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within same slot into JSON.MGETs
+// JsonMGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within same slot into multiple JSON.GETs
 func JsonMGetCache(client Client, ctx context.Context, ttl time.Duration, keys []string, path string) (ret map[string]RedisMessage, err error) {
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
-	return parallelMGetCache(client, ctx, ttl, cmds.JsonMGets(keys, path), keys)
+	cmds := make([]CacheableTTL, len(keys))
+	for i := range cmds {
+		cmds[i] = CT(client.B().JsonGet().Key(keys[i]).Path(path).Cache(), ttl)
+	}
+	return doMultiCache(client, ctx, cmds, keys)
 }
 
-// JsonMGet is a helper that consults redis directly with multiple keys by grouping keys within same slot into JSON.MGETs
+// JsonMGet is a helper that consults redis directly with multiple keys by grouping keys within same slot into JSON.MGETs or multiple JSON.GETs
 func JsonMGet(client Client, ctx context.Context, keys []string, path string) (ret map[string]RedisMessage, err error) {
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
@@ -78,10 +104,14 @@ func JsonMGet(client Client, ctx context.Context, keys []string, path string) (r
 	if _, ok := client.(*singleClient); ok {
 		return clientMGet(client, ctx, client.B().JsonMget().Key(keys...).Path(path).Build(), keys)
 	}
-	return parallelMGet(client, ctx, cmds.JsonMGets(keys, path), keys)
+	cmds := make([]Completed, len(keys))
+	for i := range cmds {
+		cmds[i] = client.B().JsonGet().Key(keys[i]).Path(path).Build()
+	}
+	return doMultiGet(client, ctx, cmds, keys)
 }
 
-// JsonMSet is a helper that consults redis directly with multiple keys by grouping keys within same slot into JSON.MSETs
+// JsonMSet is a helper that consults redis directly with multiple keys by grouping keys within same slot into JSON.MSETs or multiple JOSN.SETs
 func JsonMSet(client Client, ctx context.Context, kvs map[string]string, path string) map[string]error {
 	if len(kvs) == 0 {
 		return make(map[string]error)
@@ -89,7 +119,13 @@ func JsonMSet(client Client, ctx context.Context, kvs map[string]string, path st
 	if _, ok := client.(*singleClient); ok {
 		return clientJSONMSet(client, ctx, kvs, path, make(map[string]error, len(kvs)))
 	}
-	return parallelMSet(client, ctx, cmds.JsonMSets(kvs, path), make(map[string]error, len(kvs)))
+	cmds := make([]Completed, 0, len(kvs))
+	keys := make([]string, 0, len(kvs))
+	for k, v := range kvs {
+		cmds = append(cmds, client.B().JsonSet().Key(k).Path(path).Value(v).Build())
+		keys = append(keys, k)
+	}
+	return doMultiSet(client, ctx, cmds, keys)
 }
 
 func clientMGet(client Client, ctx context.Context, cmd Completed, keys []string) (ret map[string]RedisMessage, err error) {
@@ -116,7 +152,7 @@ func clientMSet(client Client, ctx context.Context, mset string, kvs map[string]
 }
 
 func clientJSONMSet(client Client, ctx context.Context, kvs map[string]string, path string, ret map[string]error) map[string]error {
-	cmd := cmds.JsonMsetTripletValue(client.B().JsonMset())
+	cmd := intl.JsonMsetTripletValue(client.B().JsonMset())
 	for k, v := range kvs {
 		cmd = cmd.Key(k).Path(path).Value(v)
 	}
@@ -136,82 +172,34 @@ func clientMDel(client Client, ctx context.Context, keys []string) map[string]er
 	return ret
 }
 
-func parallelMGetCache(cc Client, ctx context.Context, ttl time.Duration, mgets map[uint16]Completed, keys []string) (ret map[string]RedisMessage, err error) {
-	return doMGets(make(map[string]RedisMessage, len(keys)), mgets, func(cmd Completed) RedisResult {
-		return cc.DoCache(ctx, Cacheable(cmd), ttl)
-	})
-}
-
-func parallelMGet(cc Client, ctx context.Context, mgets map[uint16]Completed, keys []string) (ret map[string]RedisMessage, err error) {
-	return doMGets(make(map[string]RedisMessage, len(keys)), mgets, func(cmd Completed) RedisResult {
-		return cc.Do(ctx, cmd)
-	})
-}
-
-func parallelMSet(cc Client, ctx context.Context, msets map[uint16]Completed, ret map[string]error) map[string]error {
-	var mu sync.Mutex
-	for _, cmd := range msets {
-		cmd.Pin()
+func doMultiCache(cc Client, ctx context.Context, cmds []CacheableTTL, keys []string) (ret map[string]RedisMessage, err error) {
+	ret = make(map[string]RedisMessage, len(keys))
+	for i, resp := range cc.DoMultiCache(ctx, cmds...) {
+		if err := resp.NonRedisError(); err != nil {
+			return nil, err
+		}
+		ret[keys[i]] = resp.val
 	}
-	util.ParallelVals(msets, func(cmd Completed) {
-		ok, err := cc.Do(ctx, cmd).AsBool()
-		err2 := err
-		if err2 == nil && !ok {
-			err2 = ErrMSetNXNotSet
+	return ret, nil
+}
+
+func doMultiGet(cc Client, ctx context.Context, cmds []Completed, keys []string) (ret map[string]RedisMessage, err error) {
+	ret = make(map[string]RedisMessage, len(keys))
+	for i, resp := range cc.DoMulti(ctx, cmds...) {
+		if err := resp.NonRedisError(); err != nil {
+			return nil, err
 		}
-		mu.Lock()
-		for i := 1; i < len(cmd.Commands()); i += 2 {
-			ret[cmd.Commands()[i]] = err2
-		}
-		mu.Unlock()
-		if err == nil {
-			cmds.Put(cmds.CompletedCS(cmd))
-		}
-	})
+		ret[keys[i]] = resp.val
+	}
+	return ret, nil
+}
+
+func doMultiSet(cc Client, ctx context.Context, cmds []Completed, keys []string) (ret map[string]error) {
+	ret = make(map[string]error, len(keys))
+	for i, resp := range cc.DoMulti(ctx, cmds...) {
+		ret[keys[i]] = resp.Error()
+	}
 	return ret
-}
-
-func parallelMDel(cc Client, ctx context.Context, mdels map[uint16]Completed, ret map[string]error) map[string]error {
-	var mu sync.Mutex
-	for _, cmd := range mdels {
-		cmd.Pin()
-	}
-	util.ParallelVals(mdels, func(cmd Completed) {
-		err := cc.Do(ctx, cmd).Error()
-		mu.Lock()
-		for i := 1; i < len(cmd.Commands()); i += 2 {
-			ret[cmd.Commands()[i]] = err
-		}
-		mu.Unlock()
-		if err == nil {
-			cmds.Put(cmds.CompletedCS(cmd))
-		}
-	})
-	return ret
-}
-
-func doMGets(m map[string]RedisMessage, mgets map[uint16]Completed, fn func(cmd Completed) RedisResult) (ret map[string]RedisMessage, err error) {
-	var mu sync.Mutex
-	for _, cmd := range mgets {
-		cmd.Pin()
-	}
-	util.ParallelVals(mgets, func(cmd Completed) {
-		arr, err2 := fn(cmd).ToArray()
-		mu.Lock()
-		if err2 != nil {
-			err = err2
-		} else {
-			arrayToKV(m, arr, cmd.Commands()[1:])
-		}
-		mu.Unlock()
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, cmd := range mgets {
-		cmds.Put(cmds.CompletedCS(cmd))
-	}
-	return m, nil
 }
 
 func arrayToKV(m map[string]RedisMessage, arr []RedisMessage, keys []string) map[string]RedisMessage {


### PR DESCRIPTION
related to https://github.com/redis/rueidis/issues/278

Single Client Before
```
Benchmark
Benchmark/MGet
Benchmark/MGet-10         	    2770	    520576 ns/op	  310661 B/op	    1005 allocs/op
Benchmark/MGetCache
Benchmark/MGetCache-10    	    6554	    179813 ns/op	  370530 B/op	    1045 allocs/op
PASS
```

Single Client After
```
Benchmark
Benchmark/MGet
Benchmark/MGet-10         	    2749	    490253 ns/op	  310944 B/op	    1006 allocs/op
Benchmark/MGetCache
Benchmark/MGetCache-10    	   11476	    105266 ns/op	  471776 B/op	      55 allocs/op
PASS
```

---

Sentinel Client Before
```
Benchmark
Benchmark/MGet
Benchmark/MGet-10         	     135	   8403304 ns/op	  471670 B/op	    2281 allocs/op
Benchmark/MGetCache
Benchmark/MGetCache-10    	    6852	    150697 ns/op	  369290 B/op	    1042 allocs/op
PASS
```

Sentinel Client After
```
Benchmark
Benchmark/MGet
Benchmark/MGet-10         	    2084	    615179 ns/op	  345916 B/op	    1010 allocs/op
Benchmark/MGetCache
Benchmark/MGetCache-10    	   12031	    100673 ns/op	  469690 B/op	      52 allocs/op
PASS
```

---

Cluster Client Before
```
Benchmark
Benchmark/MGet
Benchmark/MGet-10         	     148	   7580940 ns/op	  454352 B/op	    2113 allocs/op
Benchmark/MGetCache
Benchmark/MGetCache-10    	    6472	    185624 ns/op	  369112 B/op	    1037 allocs/op
PASS
```

Cluster Client After
```
Benchmark
Benchmark/MGet
Benchmark/MGet-10         	    2088	    533159 ns/op	  565037 B/op	    1107 allocs/op
Benchmark/MGetCache
Benchmark/MGetCache-10    	    9366	    130200 ns/op	  563585 B/op	     118 allocs/op
PASS
```

---

Benchmark Source
```go
package sep

import (
	"context"
	"math/rand"
	"testing"
	"time"

	"github.com/redis/rueidis"
)

var charset = []byte("abcdefghijklmnopqrstuvwxyz")

func randstr(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = charset[rand.Intn(len(charset))]
	}
	return string(b)
}

func Benchmark(b *testing.B) {
	makeclient := func() rueidis.Client {
		client, err := rueidis.NewClient(rueidis.ClientOption{
			InitAddress: []string{"127.0.0.1:7001"},
		})
		if err != nil {
			panic(err)
		}
		return client
	}

	// prepare keys
	keys := make([]string, 1000)
	cmds := make(rueidis.Commands, 1000)

	{
		// fill the data
		client := makeclient()
		defer client.Close()

		for i := range keys {
			keys[i] = randstr(10)
			cmds[i] = client.B().Set().Key(keys[i]).Value(randstr(50)).Build()
		}

		for _, resp := range client.DoMulti(context.Background(), cmds...) {
			if err := resp.Error(); err != nil {
				panic(err)
			}
		}
	}

	b.Run("MGet", func(b *testing.B) {
		client := makeclient()
		defer client.Close()
		b.ReportAllocs()
		b.ResetTimer()
		b.RunParallel(func(pb *testing.PB) {
			for pb.Next() {
				ret, err := rueidis.MGet(client, context.Background(), keys)
				if err != nil || len(ret) != len(keys) {
					panic(err)
				}
			}
		})
		b.StopTimer()
	})
	b.Run("MGetCache", func(b *testing.B) {
		client := makeclient()
		defer client.Close()
		b.ReportAllocs()
		b.ResetTimer()
		b.RunParallel(func(pb *testing.PB) {
			for pb.Next() {
				ret, err := rueidis.MGetCache(client, context.Background(), time.Minute, keys)
				if err != nil || len(ret) != len(keys) {
					panic(err)
				}
			}
		})
		b.StopTimer()
	})
}

```