### PR TITLE
perf: pool and recycle intermediate allocations

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -325,6 +325,17 @@ type retry struct {
 	cAskings []Completed
 }
 
+func (r *retry) Capacity() int {
+	return cap(r.commands)
+}
+
+func (r *retry) ResetLen(n int) {
+	r.cIndexes = r.cIndexes[:n]
+	r.commands = r.commands[:n]
+	r.aIndexes = r.aIndexes[:0]
+	r.cAskings = r.cAskings[:0]
+}
+
 func (c *clusterClient) DoMulti(ctx context.Context, multi ...Completed) []RedisResult {
 	if len(multi) == 0 {
 		return nil
@@ -559,6 +570,17 @@ type retrycache struct {
 	commands []CacheableTTL
 	aIndexes []int
 	cAskings []CacheableTTL
+}
+
+func (r *retrycache) Capacity() int {
+	return cap(r.commands)
+}
+
+func (r *retrycache) ResetLen(n int) {
+	r.cIndexes = r.cIndexes[:n]
+	r.commands = r.commands[:n]
+	r.aIndexes = r.aIndexes[:0]
+	r.cAskings = r.cAskings[:0]
 }
 
 func (c *clusterClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL) []RedisResult {

--- a/helper.go
+++ b/helper.go
@@ -174,7 +174,9 @@ func clientMDel(client Client, ctx context.Context, keys []string) map[string]er
 
 func doMultiCache(cc Client, ctx context.Context, cmds []CacheableTTL, keys []string) (ret map[string]RedisMessage, err error) {
 	ret = make(map[string]RedisMessage, len(keys))
-	for i, resp := range cc.DoMultiCache(ctx, cmds...) {
+	resps := cc.DoMultiCache(ctx, cmds...)
+	defer rrssp.Put(&rrs{rs: resps})
+	for i, resp := range resps {
 		if err := resp.NonRedisError(); err != nil {
 			return nil, err
 		}

--- a/internal/util/parallel.go
+++ b/internal/util/parallel.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"runtime"
 	"sync"
+	"sync/atomic"
 )
 
 func ParallelKeys[K comparable, V any](p map[K]V, fn func(k K)) {
@@ -21,12 +21,32 @@ func ParallelVals[K comparable, V any](p map[K]V, fn func(k V)) {
 	closeThenParallel(ch, fn)
 }
 
+func ParallelArrI[V any](p []V, fn func(index int)) {
+	index := int32(-1)
+	wg := sync.WaitGroup{}
+	wg.Add(len(p))
+	for i := 1; i < len(p); i++ {
+		go func() {
+			for i := int(atomic.AddInt32(&index, 1)); i < len(p); i = int(atomic.AddInt32(&index, 1)) {
+				fn(i)
+			}
+			wg.Done()
+		}()
+	}
+	for i := int(atomic.AddInt32(&index, 1)); i < len(p); i = int(atomic.AddInt32(&index, 1)) {
+		fn(i)
+	}
+	wg.Done()
+	wg.Wait()
+}
+
 func closeThenParallel[V any](ch chan V, fn func(k V)) {
 	close(ch)
 	concurrency := len(ch)
-	if cpus := runtime.GOMAXPROCS(0); concurrency > cpus {
-		concurrency = cpus
-	}
+	// TODO runtime.GOMAXPROCS(0) is heavy, we should avoid doing it every time
+	//if cpus := runtime.GOMAXPROCS(0); concurrency > cpus {
+	//	concurrency = cpus
+	//}
 	wg := sync.WaitGroup{}
 	wg.Add(concurrency)
 	for i := 1; i < concurrency; i++ {

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type Unit interface {
+	Capacity() int
+	ResetLen(n int)
+}
+
+func NewPool[T Unit](fn func(capacity int) T) *Pool[T] {
+	p := &Pool[T]{fn: fn}
+	p.sp.New = func() any {
+		return fn(int(atomic.LoadUint32(&p.ca)))
+	}
+	return p
+}
+
+type Pool[T Unit] struct {
+	sp sync.Pool
+	fn func(capacity int) T
+	ca uint32
+}
+
+func (p *Pool[T]) Get(length, capacity int) T {
+	s := p.sp.Get().(T)
+	if s.Capacity() < capacity {
+		atomic.StoreUint32(&p.ca, uint32(capacity))
+		p.sp.Put(s)
+		s = p.fn(capacity)
+	}
+	s.ResetLen(length)
+	return s
+}
+
+func (p *Pool[T]) Put(s T) {
+	p.sp.Put(s)
+}


### PR DESCRIPTION
This PR tries to pool and recycle intermediate allocations, such as maps, and slices, to reduce overhead.

The initial result shows that this can improve 1.4x throughput on the `MGetCache` helper.

Before:
```
Benchmark
Benchmark/MGetCache
Benchmark/MGetCache-10         	   35938	     33182 ns/op	  136428 B/op	      40 allocs/op
PASS
```

After:
```
Benchmark
Benchmark/MGetCache
Benchmark/MGetCache-10         	   50653	     22980 ns/op	   59474 B/op	      18 allocs/op
PASS
```

Benchmark Source:
```go
package sep

import (
	"context"
	"github.com/redis/rueidis"
	"math/rand"
	"testing"
	"time"
)

var charset = []byte("abcdefghijklmnopqrstuvwxyz")

func randstr(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = charset[rand.Intn(len(charset))]
	}
	return string(b)
}

func Benchmark(b *testing.B) {
	makeclient := func() rueidis.Client {
		client, err := rueidis.NewClient(rueidis.ClientOption{
			InitAddress: []string{"127.0.0.1:6379"},
		})
		if err != nil {
			panic(err)
		}
		return client
	}

	// prepare keys
	keys := make([]string, 300)
	cmds := make(rueidis.Commands, 300)

	{
		// fill the data
		client := makeclient()
		defer client.Close()

		for i := range keys {
			keys[i] = randstr(10)
			cmds[i] = client.B().Set().Key(keys[i]).Value(randstr(50)).Build()
		}

		resps := client.DoMulti(context.Background(), cmds...)
		if len(resps) != len(keys) {
			panic("wrong")
		}
	}

	b.Run("MGetCache", func(b *testing.B) {
		client := makeclient()
		defer client.Close()
		b.ReportAllocs()
		b.ResetTimer()
		b.RunParallel(func(pb *testing.PB) {
			for pb.Next() {
				ret, err := rueidis.MGetCache(client, context.Background(), time.Minute, keys)
				if err != nil || len(ret) != len(keys) {
					panic(err)
				}
			}
		})
		b.StopTimer()
	})
}

```