### PR TITLE
feat: force single client connection

### DIFF
--- a/rueidis.go
+++ b/rueidis.go
@@ -81,7 +81,12 @@ type ClientOption struct {
 	// Rueidis will connect to them one by one and issue CLUSTER SLOT command to initialize the cluster client until success.
 	// If len(InitAddress) == 1 and the address is not running in cluster mode, rueidis will fall back to the single client mode.
 	// If ClientOption.Sentinel.MasterSet is set, then InitAddress will be used to connect sentinels
+	// You can bypass this behaviour by using ClientOption.ForceSingleClient.
 	InitAddress []string
+
+	//  ForceSingleClient force the usage of a single client connection, without letting the lib guessing
+	//  if redis instance is a cluster or a single redis instance.
+	ForceSingleClient bool
 
 	// ClientTrackingOptions will be appended to CLIENT TRACKING ON command when the connection is established.
 	// The default is []string{"OPTIN"}
@@ -296,6 +301,12 @@ func NewClient(option ClientOption) (client Client, err error) {
 	}
 	pmbk := option.PipelineMultiplex
 	option.PipelineMultiplex = 0 // PipelineMultiplex is meaningless for cluster client
+
+	if option.ForceSingleClient {
+		option.PipelineMultiplex = singleClientMultiplex(pmbk)
+		conn := makeConn(option.InitAddress[0], &option)
+		return newSingleClientWithConn(conn, cmds.NewBuilder(cmds.NoSlot), !option.DisableRetry), nil
+	}
 	if client, err = newClusterClient(&option, makeConn); err != nil {
 		if len(option.InitAddress) == 1 && (err.Error() == redisErrMsgCommandNotAllow || strings.Contains(strings.ToUpper(err.Error()), "CLUSTER")) {
 			option.PipelineMultiplex = singleClientMultiplex(pmbk)

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -156,6 +156,27 @@ func TestFallBackSingleClient(t *testing.T) {
 	<-done
 }
 
+func TestForceSingleClient(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	client, err := NewClient(ClientOption{
+		InitAddress: []string{"127.0.0.1:" + port},
+		ForceSingleClient: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := client.(*singleClient); !ok {
+		t.Fatal("client should be a singleClient")
+	}
+	client.Close()
+}
+
 func TestTLSClient(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
👋 Hello

First thank you for this superb lib!

## Issue
On a redis instance with one node, but spawned as a cluster (yes a cluster of one node), if we are using the rueidis default behaviour, we can connect to this redis instance (HELLO 3 is ok), but once we send a command, the redis cluster is flooded with `CLUSTER SLOTS` commands.

## Solution
I was not able (and do not have time right now to dig further) to find the issue, I've seen we are looking at InitAddress and we should not flood `CLUSTER SLOTS` commands in for loop from `cluster.go/_refresh`, but I have not dag further.

## Quick fix (this PR)
The quick fix for us is to force rueidis to connect as a single redis instance.
I can understand you don't want to merge this PR since this is a dirty fix, no problem!
But I wanted to share this behaviour!

If someone has the same issue, and while waiting for a proper fix, you can use this in your go.mod:
`replace github.com/redis/rueidis v1.0.9 => github.com/fabienjuif/rueidis v1.0.9-fjuif`

Have a nice day,