### PR TITLE
fix: cluster of 1 node with unknown ip

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -205,7 +205,15 @@ func parseSlots(slots RedisMessage, firstAddr string) map[string]group {
 			g.slots = make([][2]int64, 0)
 			g.nodes = make([]string, 0, len(v.values)-2)
 			for i := 2; i < len(v.values); i++ {
-				dst := net.JoinHostPort(v.values[i].values[0].string, strconv.FormatInt(v.values[i].values[1].integer, 10))
+				var dst string
+				switch v.values[i].values[0].string {
+				case "":
+					dst = firstAddr
+				case "?":
+					continue
+				default:
+					dst = net.JoinHostPort(v.values[i].values[0].string, strconv.FormatInt(v.values[i].values[1].integer, 10))
+				}
 				g.nodes = append(g.nodes, dst)
 			}
 		}

--- a/cluster.go
+++ b/cluster.go
@@ -199,14 +199,14 @@ type group struct {
 }
 
 // parseSlots - map redis slots for each redis nodes/addresses
-// firstAddr is needed in case the cluster only has one node and this node does not know its own IP
-func parseSlots(slots RedisMessage, firstAddr string) map[string]group {
+// defaultAddr is needed in case the node does not know its own IP
+func parseSlots(slots RedisMessage, defaultAddr string) map[string]group {
 	groups := make(map[string]group, len(slots.values))
 	for _, v := range slots.values {
 		var master string
 		switch v.values[2].values[0].string {
 		case "":
-			master = firstAddr
+			master = defaultAddr
 		case "?":
 			continue
 		default:
@@ -220,7 +220,7 @@ func parseSlots(slots RedisMessage, firstAddr string) map[string]group {
 				var dst string
 				switch v.values[i].values[0].string {
 				case "":
-					dst = firstAddr
+					dst = defaultAddr
 				case "?":
 					continue
 				default:

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -128,6 +128,7 @@ func TestClusterClientInit(t *testing.T) {
 				DoFn: func(cmd Completed) RedisResult {
 					return singleSlotWithoutIP
 				},
+				AddrFn: func() string { return "127.0.4.1:4" },
 			}
 		})
 		if err != nil {


### PR DESCRIPTION
## What

Related to #284 described issue, this fix proposed by @rueian should fix the parsing of an empty slot IP on clusters of 1 node, whom node does not know his own IP.

## TODOs
- [x] Fix unit test - ok weird test are passing now 🤔 
- [x] Create new unit test
- [x] Test it in real life against such a described cluster