### PR TITLE
perf: reuse intermediate alloc

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ func (c *singleClient) DoMulti(ctx context.Context, multi ...Completed) (resps [
 		return nil
 	}
 retry:
-	resps = c.conn.DoMulti(ctx, multi...)
+	resps = c.conn.DoMulti(ctx, multi...).s
 	if c.retry && allReadOnly(multi) {
 		for _, resp := range resps {
 			if c.isRetryable(resp.NonRedisError(), ctx) {
@@ -74,7 +74,7 @@ func (c *singleClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL) 
 		return nil
 	}
 retry:
-	resps = c.conn.DoMultiCache(ctx, multi...)
+	resps = c.conn.DoMultiCache(ctx, multi...).s
 	if c.retry {
 		for _, resp := range resps {
 			if c.isRetryable(resp.NonRedisError(), ctx) {
@@ -173,7 +173,7 @@ func (c *dedicatedSingleClient) DoMulti(ctx context.Context, multi ...Completed)
 		retryable = allReadOnly(multi)
 	}
 retry:
-	resp = c.wire.DoMulti(ctx, multi...)
+	resp = c.wire.DoMulti(ctx, multi...).s
 	if retryable && anyRetryable(resp, c.wire, ctx) {
 		goto retry
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -119,7 +119,7 @@ func TestClusterClientInit(t *testing.T) {
 					return slotsResp
 				},
 			}
-		}); err != nil || atomic.LoadInt64(&first) != 2 {
+		}); err != nil || atomic.LoadInt64(&first) < 2 {
 			t.Fatalf("unexpected err %v", err)
 		}
 	})

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -209,19 +209,19 @@ func TestClusterClient(t *testing.T) {
 			}
 			return RedisResult{}
 		},
-		DoMultiFn: func(multi ...Completed) []RedisResult {
+		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
 			}
-			return resps
+			return &redisresults{s: resps}
 		},
-		DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
 			}
-			return resps
+			return &redisresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
@@ -437,12 +437,12 @@ func TestClusterClient(t *testing.T) {
 		}()
 		m.AcquireFn = func() wire {
 			return &mockWire{
-				DoMultiFn: func(multi ...Completed) []RedisResult {
-					return []RedisResult{
+				DoMultiFn: func(multi ...Completed) *redisresults {
+					return &redisresults{s: []RedisResult{
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
 						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
-					}
+					}}
 				},
 			}
 		}
@@ -504,9 +504,9 @@ func TestClusterClient(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult {
 				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
 			},
-			DoMultiFn: func(cmd ...Completed) []RedisResult {
+			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
-					return []RedisResult{
+					return &redisresults{s: []RedisResult{
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
@@ -514,12 +514,12 @@ func TestClusterClient(t *testing.T) {
 							{typ: '+', string: "Delegate0"},
 							{typ: '+', string: "Delegate1"},
 						}}, nil),
-					}
+					}}
 				}
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
 					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
-				}
+				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -612,9 +612,9 @@ func TestClusterClient(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult {
 				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
 			},
-			DoMultiFn: func(cmd ...Completed) []RedisResult {
+			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
-					return []RedisResult{
+					return &redisresults{s: []RedisResult{
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
 						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
@@ -622,12 +622,12 @@ func TestClusterClient(t *testing.T) {
 							{typ: '+', string: "Delegate0"},
 							{typ: '+', string: "Delegate1"},
 						}}, nil),
-					}
+					}}
 				}
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
 					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
-				}
+				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -790,22 +790,22 @@ func TestClusterClientErr(t *testing.T) {
 				}
 				return newErrResult(v)
 			},
-			DoMultiFn: func(multi ...Completed) []RedisResult {
+			DoMultiFn: func(multi ...Completed) *redisresults {
 				res := make([]RedisResult, len(multi))
 				for i := range res {
 					res[i] = newErrResult(v)
 				}
-				return res
+				return &redisresults{s: res}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 				return newErrResult(v)
 			},
-			DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+			DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 				res := make([]RedisResult, len(multi))
 				for i := range res {
 					res[i] = newErrResult(v)
 				}
-				return res
+				return &redisresults{s: res}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return v
@@ -1015,18 +1015,18 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiFn: func(multi ...Completed) []RedisResult {
+			}, DoMultiFn: func(multi ...Completed) *redisresults {
 				ret := make([]RedisResult, len(multi))
 				if atomic.AddInt64(&count, 1) <= 3 {
 					for i := range ret {
 						ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				}
 				for i := range ret {
 					ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
 				}
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1042,18 +1042,18 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiFn: func(multi ...Completed) []RedisResult {
+			}, DoMultiFn: func(multi ...Completed) *redisresults {
 				ret := make([]RedisResult, len(multi))
 				if atomic.AddInt64(&count, 1) <= 3 {
 					for i := range ret {
 						ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				}
 				for i := range ret {
 					ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
 				}
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1106,18 +1106,18 @@ func TestClusterClientErr(t *testing.T) {
 			}
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiFn: func(multi ...Completed) []RedisResult {
+			}, DoMultiFn: func(multi ...Completed) *redisresults {
 				ret := make([]RedisResult, len(multi))
 				if atomic.AddInt64(&count, 1) <= 3 {
 					for i := range ret {
 						ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				}
 				for i := range ret {
 					ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
 				}
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1139,18 +1139,18 @@ func TestClusterClientErr(t *testing.T) {
 			}
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiFn: func(multi ...Completed) []RedisResult {
+			}, DoMultiFn: func(multi ...Completed) *redisresults {
 				ret := make([]RedisResult, len(multi))
 				if atomic.AddInt64(&count, 1) <= 3 {
 					for i := range ret {
 						ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				}
 				for i := range ret {
 					ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
 				}
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1198,18 +1198,18 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+			}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 				ret := make([]RedisResult, len(multi))
 				if atomic.AddInt64(&count, 1) <= 3 {
 					for i := range ret {
 						ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				}
 				for i := range ret {
 					ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Cmd.Commands()[1]}, nil)
 				}
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1225,18 +1225,18 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+			}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 				ret := make([]RedisResult, len(multi))
 				if atomic.AddInt64(&count, 1) <= 3 {
 					for i := range ret {
 						ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				}
 				for i := range ret {
 					ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Cmd.Commands()[1]}, nil)
 				}
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1263,11 +1263,11 @@ func TestClusterClientErr(t *testing.T) {
 					}
 					return newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
 				},
-				DoMultiFn: func(multi ...Completed) []RedisResult {
+				DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return []RedisResult{{}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}
+						return &redisresults{s: []RedisResult{{}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 					}
-					return []RedisResult{{}, newResult(RedisMessage{typ: '+', string: "b"}, nil)}
+					return &redisresults{s: []RedisResult{{}, newResult(RedisMessage{typ: '+', string: "b"}, nil)}}
 				},
 			}
 		})
@@ -1286,19 +1286,19 @@ func TestClusterClientErr(t *testing.T) {
 				DoFn: func(cmd Completed) RedisResult {
 					return slotsResp
 				},
-				DoMultiFn: func(multi ...Completed) []RedisResult {
+				DoMultiFn: func(multi ...Completed) *redisresults {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
 							ret[i] = newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
 						}
-						return ret
+						return &redisresults{s: ret}
 					}
 					for i := 0; i < len(multi); i += 2 {
 						ret[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
 						ret[i+1] = newResult(RedisMessage{typ: '+', string: multi[i+1].Commands()[1]}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				},
 			}
 		})
@@ -1317,19 +1317,19 @@ func TestClusterClientErr(t *testing.T) {
 				DoFn: func(cmd Completed) RedisResult {
 					return slotsResp
 				},
-				DoMultiFn: func(multi ...Completed) []RedisResult {
+				DoMultiFn: func(multi ...Completed) *redisresults {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
 							ret[i] = newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
 						}
-						return ret
+						return &redisresults{s: ret}
 					}
 					for i := 0; i < len(multi); i += 2 {
 						ret[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
 						ret[i+1] = newResult(RedisMessage{typ: '+', string: multi[i+1].Commands()[1]}, nil)
 					}
-					return ret
+					return &redisresults{s: ret}
 				},
 			}
 		})
@@ -1357,11 +1357,11 @@ func TestClusterClientErr(t *testing.T) {
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 					return newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
 				},
-				DoMultiFn: func(multi ...Completed) []RedisResult {
+				DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 					}
-					return []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}
+					return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
 				},
 			}
 		})
@@ -1380,14 +1380,14 @@ func TestClusterClientErr(t *testing.T) {
 				DoFn: func(cmd Completed) RedisResult {
 					return slotsResp
 				},
-				DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
-					return []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}
+				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 				},
-				DoMultiFn: func(multi ...Completed) []RedisResult {
+				DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 					}
-					return []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}
+					return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
 				},
 			}
 		})
@@ -1406,20 +1406,20 @@ func TestClusterClientErr(t *testing.T) {
 				DoFn: func(cmd Completed) RedisResult {
 					return slotsResp
 				},
-				DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
-					return []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil), newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}
+				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil), newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 				},
-				DoMultiFn: func(multi ...Completed) []RedisResult {
+				DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return []RedisResult{
+						return &redisresults{s: []RedisResult{
 							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
 							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-						}
+						}}
 					}
-					return []RedisResult{
+					return &redisresults{s: []RedisResult{
 						{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "a"}}}, nil),
 						{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil),
-					}
+					}}
 				},
 			}
 		})
@@ -1463,13 +1463,13 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiFn: func(multi ...Completed) []RedisResult {
+			}, DoMultiFn: func(multi ...Completed) *redisresults {
 				if atomic.AddInt64(&count, 1) <= 3 {
-					return []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
 				}
 				ret := make([]RedisResult, len(multi))
 				ret[0] = newResult(RedisMessage{typ: '+', string: "b"}, nil)
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1485,14 +1485,14 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiFn: func(multi ...Completed) []RedisResult {
+			}, DoMultiFn: func(multi ...Completed) *redisresults {
 				if atomic.AddInt64(&count, 1) <= 3 {
-					return []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil), newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil), newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
 				}
 				ret := make([]RedisResult, len(multi))
 				ret[0] = newResult(RedisMessage{typ: '+', string: "a"}, nil)
 				ret[1] = newResult(RedisMessage{typ: '+', string: "b"}, nil)
-				return ret
+				return &redisresults{s: ret}
 			}}
 		})
 		if err != nil {
@@ -1537,11 +1537,11 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+			}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 				if atomic.AddInt64(&count, 1) <= 3 {
-					return []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
 				}
-				return []RedisResult{newResult(RedisMessage{typ: '+', string: "b"}, nil)}
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "b"}, nil)}}
 			}}
 		})
 		if err != nil {
@@ -1557,11 +1557,11 @@ func TestClusterClientErr(t *testing.T) {
 		client, err := newClusterClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{DoFn: func(cmd Completed) RedisResult {
 				return slotsResp
-			}, DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+			}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 				if atomic.AddInt64(&count, 1) <= 3 {
-					return []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil), newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil), newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
 				}
-				return []RedisResult{newResult(RedisMessage{typ: '+', string: "a"}, nil), newResult(RedisMessage{typ: '+', string: "b"}, nil)}
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "a"}, nil), newResult(RedisMessage{typ: '+', string: "b"}, nil)}}
 			}}
 		})
 		if err != nil {

--- a/helper.go
+++ b/helper.go
@@ -174,7 +174,9 @@ func clientMDel(client Client, ctx context.Context, keys []string) map[string]er
 
 func doMultiCache(cc Client, ctx context.Context, cmds []CacheableTTL, keys []string) (ret map[string]RedisMessage, err error) {
 	ret = make(map[string]RedisMessage, len(keys))
-	for i, resp := range cc.DoMultiCache(ctx, cmds...) {
+	resps := cc.DoMultiCache(ctx, cmds...)
+	defer resultsp.Put(&redisresults{s: resps})
+	for i, resp := range resps {
 		if err := resp.NonRedisError(); err != nil {
 			return nil, err
 		}
@@ -185,7 +187,9 @@ func doMultiCache(cc Client, ctx context.Context, cmds []CacheableTTL, keys []st
 
 func doMultiGet(cc Client, ctx context.Context, cmds []Completed, keys []string) (ret map[string]RedisMessage, err error) {
 	ret = make(map[string]RedisMessage, len(keys))
-	for i, resp := range cc.DoMulti(ctx, cmds...) {
+	resps := cc.DoMulti(ctx, cmds...)
+	defer resultsp.Put(&redisresults{s: resps})
+	for i, resp := range resps {
 		if err := resp.NonRedisError(); err != nil {
 			return nil, err
 		}
@@ -196,9 +200,11 @@ func doMultiGet(cc Client, ctx context.Context, cmds []Completed, keys []string)
 
 func doMultiSet(cc Client, ctx context.Context, cmds []Completed, keys []string) (ret map[string]error) {
 	ret = make(map[string]error, len(keys))
-	for i, resp := range cc.DoMulti(ctx, cmds...) {
+	resps := cc.DoMulti(ctx, cmds...)
+	for i, resp := range resps {
 		ret[keys[i]] = resp.Error()
 	}
+	resultsp.Put(&redisresults{s: resps})
 	return ret
 }
 

--- a/internal/util/pool.go
+++ b/internal/util/pool.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type Container interface {
+	Capacity() int
+	ResetLen(n int)
+}
+
+func NewPool[T Container](fn func(capacity int) T) *Pool[T] {
+	p := &Pool[T]{fn: fn}
+	p.sp.New = func() any {
+		return fn(int(atomic.LoadUint32(&p.ca)))
+	}
+	return p
+}
+
+type Pool[T Container] struct {
+	sp sync.Pool
+	fn func(capacity int) T
+	ca uint32
+}
+
+func (p *Pool[T]) Get(length, capacity int) T {
+	atomic.StoreUint32(&p.ca, uint32(capacity))
+	s := p.sp.Get().(T)
+	if s.Capacity() < capacity {
+		p.sp.Put(s)
+		s = p.fn(capacity)
+	}
+	s.ResetLen(length)
+	return s
+}
+
+func (p *Pool[T]) Put(s T) {
+	p.sp.Put(s)
+}

--- a/internal/util/pool_test.go
+++ b/internal/util/pool_test.go
@@ -1,0 +1,35 @@
+package util
+
+import "testing"
+
+type container struct {
+	s []int
+}
+
+func (c *container) Capacity() int {
+	return cap(c.s)
+}
+
+func (c *container) ResetLen(n int) {
+	c.s = c.s[:n]
+}
+
+func TestPool(t *testing.T) {
+	p := NewPool(func(capacity int) *container {
+		return &container{s: make([]int, 0, capacity)}
+	})
+	c := p.Get(5, 10)
+	if len(c.s) != 5 || cap(c.s) != 10 {
+		t.Fatal("wrong length or capacity")
+	}
+	c.s[0] = 1
+	p.Put(c)
+	c = p.Get(5, 10)
+	if c.s[0] != 1 {
+		t.Fatal("should use recycled")
+	}
+	c = p.Get(5, 20)
+	if c.s[0] != 0 {
+		t.Fatal("should not use recycled")
+	}
+}

--- a/internal/util/pool_test.go
+++ b/internal/util/pool_test.go
@@ -28,6 +28,7 @@ func TestPool(t *testing.T) {
 	if c.s[0] != 1 {
 		t.Fatal("should use recycled")
 	}
+	p.Put(c)
 	c = p.Get(5, 20)
 	if c.s[0] != 0 {
 		t.Fatal("should not use recycled")

--- a/mux_test.go
+++ b/mux_test.go
@@ -312,25 +312,25 @@ func TestMuxDelegation(t *testing.T) {
 	t.Run("wire do multi", func(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
-				DoMultiFn: func(multi ...Completed) []RedisResult {
-					return []RedisResult{newErrResult(context.DeadlineExceeded)}
+				DoMultiFn: func(multi ...Completed) *redisresults {
+					return &redisresults{s: []RedisResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
 				},
 			},
 			{
-				DoMultiFn: func(multi ...Completed) []RedisResult {
-					return []RedisResult{newResult(RedisMessage{typ: '+', string: "MULTI_COMMANDS_RESPONSE"}, nil)}
+				DoMultiFn: func(multi ...Completed) *redisresults {
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "MULTI_COMMANDS_RESPONSE"}, nil)}}
 				},
 			},
 		})
 		defer checkClean(t)
 		defer m.Close()
-		if err := m.DoMulti(context.Background(), cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"}))[0].Error(); !errors.Is(err, context.DeadlineExceeded) {
+		if err := m.DoMulti(context.Background(), cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})).s[0].Error(); !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("unexpected error %v", err)
 		}
-		if val, err := m.DoMulti(context.Background(), cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"}))[0].ToString(); err != nil {
+		if val, err := m.DoMulti(context.Background(), cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})).s[0].ToString(); err != nil {
 			t.Fatalf("unexpected error %v", err)
 		} else if val != "MULTI_COMMANDS_RESPONSE" {
 			t.Fatalf("unexpected response %v", val)
@@ -368,25 +368,25 @@ func TestMuxDelegation(t *testing.T) {
 	t.Run("wire do multi cache", func(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
-				DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
-					return []RedisResult{newErrResult(context.DeadlineExceeded)}
+				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
+					return &redisresults{s: []RedisResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
 				},
 			},
 			{
-				DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
-					return []RedisResult{newResult(RedisMessage{typ: '+', string: "MULTI_COMMANDS_RESPONSE"}, nil)}
+				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
+					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "MULTI_COMMANDS_RESPONSE"}, nil)}}
 				},
 			},
 		})
 		defer checkClean(t)
 		defer m.Close()
-		if err := m.DoMultiCache(context.Background(), CT(Cacheable(cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})), time.Second))[0].Error(); !errors.Is(err, context.DeadlineExceeded) {
+		if err := m.DoMultiCache(context.Background(), CT(Cacheable(cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})), time.Second)).s[0].Error(); !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("unexpected error %v", err)
 		}
-		if val, err := m.DoMultiCache(context.Background(), CT(Cacheable(cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})), time.Second))[0].ToString(); err != nil {
+		if val, err := m.DoMultiCache(context.Background(), CT(Cacheable(cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})), time.Second)).s[0].ToString(); err != nil {
 			t.Fatalf("unexpected error %v", err)
 		} else if val != "MULTI_COMMANDS_RESPONSE" {
 			t.Fatalf("unexpected response %v", val)
@@ -399,7 +399,7 @@ func TestMuxDelegation(t *testing.T) {
 		for i := range wires {
 			idx := uint16(i)
 			wires[i] = &mockWire{
-				DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 					result := make([]RedisResult, len(multi))
 					for j, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
@@ -408,7 +408,7 @@ func TestMuxDelegation(t *testing.T) {
 							result[j] = newResult(RedisMessage{typ: '+', string: cmd.Cmd.Commands()[1]}, nil)
 						}
 					}
-					return result
+					return &redisresults{s: result}
 				},
 			}
 		}
@@ -427,7 +427,7 @@ func TestMuxDelegation(t *testing.T) {
 			for c := 0; c < count; c++ {
 				commands[c] = CT(builder.Get().Key(strconv.Itoa(c)).Cache(), time.Second)
 			}
-			for i, resp := range m.DoMultiCache(context.Background(), commands...) {
+			for i, resp := range m.DoMultiCache(context.Background(), commands...).s {
 				if v, err := resp.ToString(); err != nil || v != strconv.Itoa(i) {
 					t.Fatalf("unexpected resp %v %v", v, err)
 				}
@@ -441,13 +441,13 @@ func TestMuxDelegation(t *testing.T) {
 		for i := range wires {
 			idx := uint16(i)
 			wires[i] = &mockWire{
-				DoMultiCacheFn: func(multi ...CacheableTTL) []RedisResult {
+				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 					for _, cmd := range multi {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
-							return []RedisResult{newErrResult(errors.New(fmt.Sprintf("wrong slot %v %v", s, idx)))}
+							return &redisresults{s: []RedisResult{newErrResult(errors.New(fmt.Sprintf("wrong slot %v %v", s, idx)))}}
 						}
 					}
-					return []RedisResult{newErrResult(context.DeadlineExceeded)}
+					return &redisresults{s: []RedisResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -467,7 +467,7 @@ func TestMuxDelegation(t *testing.T) {
 		for c := 0; c < len(commands); c++ {
 			commands[c] = CT(builder.Get().Key(strconv.Itoa(c)).Cache(), time.Second)
 		}
-		if err := m.DoMultiCache(context.Background(), commands...)[0].Error(); !errors.Is(err, context.DeadlineExceeded) {
+		if err := m.DoMultiCache(context.Background(), commands...).s[0].Error(); !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("unexpected error %v", err)
 		}
 	})
@@ -598,15 +598,15 @@ func TestMuxDelegation(t *testing.T) {
 				// leave first wire for pipeline calls
 			},
 			{
-				DoMultiFn: func(cmd ...Completed) []RedisResult {
+				DoMultiFn: func(cmd ...Completed) *redisresults {
 					blocked <- struct{}{}
-					return []RedisResult{<-responses}
+					return &redisresults{s: []RedisResult{<-responses}}
 				},
 			},
 			{
-				DoMultiFn: func(cmd ...Completed) []RedisResult {
+				DoMultiFn: func(cmd ...Completed) *redisresults {
 					blocked <- struct{}{}
-					return []RedisResult{<-responses}
+					return &redisresults{s: []RedisResult{<-responses}}
 				},
 			},
 		})
@@ -624,7 +624,7 @@ func TestMuxDelegation(t *testing.T) {
 					context.Background(),
 					cmds.NewReadOnlyCompleted([]string{"READONLY"}),
 					cmds.NewBlockingCompleted([]string{"BLOCK"}),
-				)[0].ToString(); err != nil {
+				).s[0].ToString(); err != nil {
 					t.Errorf("unexpected error %v", err)
 				} else if val != "BLOCK_COMMANDS_RESPONSE" {
 					t.Errorf("unexpected response %v", val)
@@ -649,8 +649,8 @@ func TestMuxDelegation(t *testing.T) {
 				// leave first wire for pipeline calls
 			},
 			{
-				DoMultiFn: func(cmd ...Completed) []RedisResult {
-					return []RedisResult{newErrResult(context.DeadlineExceeded)}
+				DoMultiFn: func(cmd ...Completed) *redisresults {
+					return &redisresults{s: []RedisResult{newErrResult(context.DeadlineExceeded)}}
 				},
 				ErrorFn: func() error {
 					return context.DeadlineExceeded
@@ -674,7 +674,7 @@ func TestMuxDelegation(t *testing.T) {
 			context.Background(),
 			cmds.NewReadOnlyCompleted([]string{"READONLY"}),
 			cmds.NewBlockingCompleted([]string{"BLOCK"}),
-		)[0].Error(); err != context.DeadlineExceeded {
+		).s[0].Error(); err != context.DeadlineExceeded {
 			t.Errorf("unexpected error %v", err)
 		}
 		if val, err := m.Do(context.Background(), cmds.NewBlockingCompleted([]string{"BLOCK"})).ToString(); err != nil || val != "OK" {
@@ -775,8 +775,8 @@ func BenchmarkClientSideCaching(b *testing.B) {
 type mockWire struct {
 	DoFn           func(cmd Completed) RedisResult
 	DoCacheFn      func(cmd Cacheable, ttl time.Duration) RedisResult
-	DoMultiFn      func(multi ...Completed) []RedisResult
-	DoMultiCacheFn func(multi ...CacheableTTL) []RedisResult
+	DoMultiFn      func(multi ...Completed) *redisresults
+	DoMultiCacheFn func(multi ...CacheableTTL) *redisresults
 	ReceiveFn      func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error
 	InfoFn         func() map[string]RedisMessage
 	ErrorFn        func() error
@@ -801,14 +801,14 @@ func (m *mockWire) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration
 	return RedisResult{}
 }
 
-func (m *mockWire) DoMultiCache(ctx context.Context, multi ...CacheableTTL) []RedisResult {
+func (m *mockWire) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisresults {
 	if m.DoMultiCacheFn != nil {
 		return m.DoMultiCacheFn(multi...)
 	}
 	return nil
 }
 
-func (m *mockWire) DoMulti(ctx context.Context, multi ...Completed) []RedisResult {
+func (m *mockWire) DoMulti(ctx context.Context, multi ...Completed) *redisresults {
 	if m.DoMultiFn != nil {
 		return m.DoMultiFn(multi...)
 	}

--- a/sentinel.go
+++ b/sentinel.go
@@ -72,25 +72,26 @@ retry:
 	return resp
 }
 
-func (c *sentinelClient) DoMulti(ctx context.Context, multi ...Completed) (resps []RedisResult) {
+func (c *sentinelClient) DoMulti(ctx context.Context, multi ...Completed) []RedisResult {
 	if len(multi) == 0 {
 		return nil
 	}
 retry:
-	resps = c.mConn.Load().(conn).DoMulti(ctx, multi...)
+	resps := c.mConn.Load().(conn).DoMulti(ctx, multi...)
 	if c.retry && allReadOnly(multi) {
-		for _, resp := range resps {
+		for _, resp := range resps.s {
 			if c.isRetryable(resp.NonRedisError(), ctx) {
+				resultsp.Put(resps)
 				goto retry
 			}
 		}
 	}
 	for i, cmd := range multi {
-		if resps[i].NonRedisError() == nil {
+		if resps.s[i].NonRedisError() == nil {
 			cmds.PutCompleted(cmd)
 		}
 	}
-	return resps
+	return resps.s
 }
 
 func (c *sentinelClient) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) (resp RedisResult) {
@@ -105,25 +106,26 @@ retry:
 	return resp
 }
 
-func (c *sentinelClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL) (resps []RedisResult) {
+func (c *sentinelClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL) []RedisResult {
 	if len(multi) == 0 {
 		return nil
 	}
 retry:
-	resps = c.mConn.Load().(conn).DoMultiCache(ctx, multi...)
+	resps := c.mConn.Load().(conn).DoMultiCache(ctx, multi...)
 	if c.retry {
-		for _, resp := range resps {
+		for _, resp := range resps.s {
 			if c.isRetryable(resp.NonRedisError(), ctx) {
+				resultsp.Put(resps)
 				goto retry
 			}
 		}
 	}
 	for i, cmd := range multi {
-		if err := resps[i].NonRedisError(); err == nil || err == ErrDoCacheAborted {
+		if err := resps.s[i].NonRedisError(); err == nil || err == ErrDoCacheAborted {
 			cmds.PutCacheable(cmd.Cmd)
 		}
 	}
-	return resps
+	return resps.s
 }
 
 func (c *sentinelClient) Receive(ctx context.Context, subscribe Completed, fn func(msg PubSubMessage)) (err error) {
@@ -364,7 +366,8 @@ func (c *sentinelClient) listWatch(cc conn) (target string, sentinels []string, 
 	}
 
 	resp := cc.DoMulti(ctx, commands...)
-	others, err := resp[0].ToArray()
+	defer resultsp.Put(resp)
+	others, err := resp.s[0].ToArray()
 	if err != nil {
 		return "", nil, err
 	}
@@ -376,7 +379,7 @@ func (c *sentinelClient) listWatch(cc conn) (target string, sentinels []string, 
 
 	// we return random slave address instead of master
 	if c.replica {
-		addr, err := pickReplica(resp)
+		addr, err := pickReplica(resp.s)
 		if err != nil {
 			return "", nil, err
 		}
@@ -385,7 +388,7 @@ func (c *sentinelClient) listWatch(cc conn) (target string, sentinels []string, 
 	}
 
 	// otherwise send master as address
-	m, err := resp[1].AsStrSlice()
+	m, err := resp.s[1].AsStrSlice()
 	if err != nil {
 		return "", nil, err
 	}

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -33,7 +33,7 @@ func TestSentinelClientInit(t *testing.T) {
 		v := errors.New("refresh err")
 		if _, err := newSentinelClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
 			return &mockConn{
-				DoMultiFn: func(cmd ...Completed) []RedisResult { return []RedisResult{newErrResult(v)} },
+				DoMultiFn: func(cmd ...Completed) *redisresults { return &redisresults{s: []RedisResult{newErrResult(v)}} },
 			}
 		}); err != v {
 			t.Fatalf("unexpected err %v", err)
@@ -44,17 +44,17 @@ func TestSentinelClientInit(t *testing.T) {
 		v := errors.New("refresh err")
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					newErrResult(v),
 					newErrResult(v),
-				}
+				}}
 			},
 		}
 		s1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -62,13 +62,13 @@ func TestSentinelClientInit(t *testing.T) {
 						}},
 					}}},
 					newErrResult(v),
-				}
+				}}
 			},
 		}
 		s2 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -78,13 +78,13 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "5"},
 					}}},
-				}
+				}}
 			},
 		}
 		s3 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -94,13 +94,13 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "6"},
 					}}},
-				}
+				}}
 			},
 		}
 		s4 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -110,7 +110,7 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "7"},
 					}}},
-				}
+				}}
 			},
 		}
 		client, err := newSentinelClient(&ClientOption{InitAddress: []string{":0", ":1", ":2"}}, func(dst string, opt *ClientOption) conn {
@@ -166,17 +166,17 @@ func TestSentinelClientInit(t *testing.T) {
 		v := errors.New("refresh err")
 		slaveWithMultiError := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					newErrResult(v),
 					newErrResult(v),
-				}
+				}}
 			},
 		}
 		slaveWithReplicaResponseErr := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -184,13 +184,13 @@ func TestSentinelClientInit(t *testing.T) {
 						}},
 					}}},
 					newErrResult(v),
-				}
+				}}
 			},
 		}
 		sentinelWithFaultiSlave := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -203,7 +203,7 @@ func TestSentinelClientInit(t *testing.T) {
 							{typ: '+', string: "port"}, {typ: '+', string: "6"},
 						}},
 					}}},
-				}
+				}}
 			},
 		}
 		// this connection will fail because OK slave is in 's-down' status
@@ -211,8 +211,8 @@ func TestSentinelClientInit(t *testing.T) {
 		// we update the list here.
 		sentinelWithHealthySlaveInSDown := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -238,13 +238,13 @@ func TestSentinelClientInit(t *testing.T) {
 							{typ: '+', string: "s-down-time"}, {typ: '+', string: "1"},
 						}},
 					}}},
-				}
+				}}
 			},
 		}
 		sentinelWithoutEligibleSlave := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -258,14 +258,14 @@ func TestSentinelClientInit(t *testing.T) {
 							{typ: '+', string: "s-down-time"}, {typ: '+', string: "1"},
 						}},
 					}}},
-				}
+				}}
 			},
 		}
 
 		sentinelWithInvalidMapResponse := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -275,13 +275,13 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						RedisMessage(*Nil),
 					}}},
-				}
+				}}
 			},
 		}
 		sentinelWithMasterRoleAsSlave := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -294,13 +294,13 @@ func TestSentinelClientInit(t *testing.T) {
 							{typ: '+', string: "port"}, {typ: '+', string: "7"},
 						}},
 					}}},
-				}
+				}}
 			},
 		}
 		sentinelWithOKResponse := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -313,7 +313,7 @@ func TestSentinelClientInit(t *testing.T) {
 							{typ: '+', string: "port"}, {typ: '+', string: "8"},
 						}},
 					}}},
-				}
+				}}
 			},
 		}
 
@@ -385,8 +385,8 @@ func TestSentinelClientInit(t *testing.T) {
 		v := errors.New("refresh err")
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -396,13 +396,13 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "2"},
 					}}},
-				}
+				}}
 			},
 		}
 		s1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -412,7 +412,7 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "3"},
 					}}},
-				}
+				}}
 			},
 		}
 		client, err := newSentinelClient(&ClientOption{InitAddress: []string{":0"}}, func(dst string, opt *ClientOption) conn {
@@ -460,8 +460,8 @@ func TestSentinelClientInit(t *testing.T) {
 				}
 				return RedisResult{}
 			},
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -471,7 +471,7 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "3"},
 					}}},
-				}
+				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				if err, ok := <-trigger; ok {
@@ -485,8 +485,8 @@ func TestSentinelClientInit(t *testing.T) {
 		}
 		s1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -496,13 +496,13 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "3"},
 					}}},
-				}
+				}}
 			},
 		}
 		s2 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
 							{typ: '+', string: "ip"}, {typ: '+', string: ""},
@@ -512,7 +512,7 @@ func TestSentinelClientInit(t *testing.T) {
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "4"},
 					}}},
-				}
+				}}
 			},
 		}
 		r3 := &mockConn{
@@ -582,17 +582,17 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 	first := true
 	s0 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-		DoMultiFn: func(multi ...Completed) []RedisResult {
+		DoMultiFn: func(multi ...Completed) *redisresults {
 			if first {
 				first = true
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "1"},
 					}}},
-				}
+				}}
 			}
-			return []RedisResult{newErrResult(ErrClosing), newErrResult(ErrClosing)}
+			return &redisresults{s: []RedisResult{newErrResult(ErrClosing), newErrResult(ErrClosing)}}
 		},
 	}
 	m := &mockConn{
@@ -623,13 +623,13 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 	first := true
 	s0 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-		DoMultiFn: func(multi ...Completed) []RedisResult {
-			return []RedisResult{
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			return &redisresults{s: []RedisResult{
 				{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 				{val: RedisMessage{typ: '*', values: []RedisMessage{
 					{typ: '+', string: ""}, {typ: '+', string: "1"},
 				}}},
-			}
+			}}
 		},
 	}
 	m := &mockConn{
@@ -664,13 +664,13 @@ func TestSentinelClientDelegate(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	s0 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-		DoMultiFn: func(multi ...Completed) []RedisResult {
-			return []RedisResult{
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			return &redisresults{s: []RedisResult{
 				{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 				{val: RedisMessage{typ: '*', values: []RedisMessage{
 					{typ: '+', string: ""}, {typ: '+', string: "1"},
 				}}},
-			}
+			}}
 		},
 	}
 	m := &mockConn{
@@ -714,11 +714,11 @@ func TestSentinelClientDelegate(t *testing.T) {
 
 	t.Run("Delegate DoMulti", func(t *testing.T) {
 		c := client.B().Get().Key("Do").Build()
-		m.DoMultiFn = func(cmd ...Completed) []RedisResult {
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return []RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)}
+			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -743,11 +743,11 @@ func TestSentinelClientDelegate(t *testing.T) {
 
 	t.Run("Delegate DoMultiCache", func(t *testing.T) {
 		c := client.B().Get().Key("DoCache").Cache()
-		m.DoMultiCacheFn = func(multi ...CacheableTTL) []RedisResult {
+		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return []RedisResult{newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)}
+			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -805,8 +805,8 @@ func TestSentinelClientDelegate(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult {
 				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
 			},
-			DoMultiFn: func(cmd ...Completed) []RedisResult {
-				return []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}
+			DoMultiFn: func(cmd ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -854,8 +854,8 @@ func TestSentinelClientDelegate(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult {
 				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
 			},
-			DoMultiFn: func(cmd ...Completed) []RedisResult {
-				return []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}
+			DoMultiFn: func(cmd ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -904,21 +904,21 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 		trigger := make(chan error)
 		s0 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-			DoMultiFn: func(multi ...Completed) []RedisResult {
+			DoMultiFn: func(multi ...Completed) *redisresults {
 				if atomic.LoadUint32(&retry) == 0 {
-					return []RedisResult{
+					return &redisresults{s: []RedisResult{
 						{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 						{val: RedisMessage{typ: '*', values: []RedisMessage{
 							{typ: '+', string: ""}, {typ: '+', string: "1"},
 						}}},
-					}
+					}}
 				}
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "2"},
 					}}},
-				}
+				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				if err, ok := <-trigger; ok {
@@ -938,9 +938,9 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 				atomic.AddUint32(&retry, 1)
 				return newErrResult(ErrClosing)
 			},
-			DoMultiFn: func(multi ...Completed) []RedisResult {
+			DoMultiFn: func(multi ...Completed) *redisresults {
 				atomic.AddUint32(&retry, 1)
-				return []RedisResult{newErrResult(ErrClosing)}
+				return &redisresults{s: []RedisResult{newErrResult(ErrClosing)}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 				atomic.AddUint32(&retry, 1)
@@ -958,8 +958,8 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 				}
 				return RedisResult{val: RedisMessage{typ: '+', string: "OK"}}
 			},
-			DoMultiFn: func(multi ...Completed) []RedisResult {
-				return []RedisResult{{val: RedisMessage{typ: '+', string: "OK"}}}
+			DoMultiFn: func(multi ...Completed) *redisresults {
+				return &redisresults{s: []RedisResult{{val: RedisMessage{typ: '+', string: "OK"}}}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 				return RedisResult{val: RedisMessage{typ: '+', string: "OK"}}
@@ -1064,22 +1064,22 @@ func TestSentinelClientPubSub(t *testing.T) {
 
 	s0 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-		DoMultiFn: func(multi ...Completed) []RedisResult {
+		DoMultiFn: func(multi ...Completed) *redisresults {
 			count := atomic.AddInt32(&s0count, 1)
 			if (count-1)%2 == 0 {
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '+', string: ""}, {typ: '+', string: "1"},
 					}}},
-				}
+				}}
 			}
-			return []RedisResult{
+			return &redisresults{s: []RedisResult{
 				{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 				{val: RedisMessage{typ: '*', values: []RedisMessage{
 					{typ: '+', string: ""}, {typ: '+', string: "2"},
 				}}},
-			}
+			}}
 		},
 		ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 			for msg := range messages {
@@ -1107,7 +1107,7 @@ func TestSentinelClientPubSub(t *testing.T) {
 		CloseFn: func() { atomic.AddInt32(&m2close, 1) },
 	}
 	s3 := &mockConn{
-		DoMultiFn: func(cmd ...Completed) []RedisResult { return []RedisResult{newErrResult(errClosing)} },
+		DoMultiFn: func(cmd ...Completed) *redisresults { return &redisresults{s: []RedisResult{newErrResult(errClosing)}} },
 	}
 	m4 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
@@ -1210,11 +1210,11 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 
 	s0 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
-		DoMultiFn: func(multi ...Completed) []RedisResult {
+		DoMultiFn: func(multi ...Completed) *redisresults {
 			count := atomic.AddInt32(&s0count, 1)
 			remainder := (count - 1) % 3
 			if remainder == 0 {
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
@@ -1222,9 +1222,9 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 							{typ: '+', string: "port"}, {typ: '+', string: "1"},
 						}},
 					}}},
-				}
+				}}
 			} else if remainder == 1 {
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
@@ -1232,9 +1232,9 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 							{typ: '+', string: "port"}, {typ: '+', string: "2"},
 						}},
 					}}},
-				}
+				}}
 			} else {
-				return []RedisResult{
+				return &redisresults{s: []RedisResult{
 					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
 					{val: RedisMessage{typ: '*', values: []RedisMessage{
 						{typ: '%', values: []RedisMessage{
@@ -1242,7 +1242,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 							{typ: '+', string: "port"}, {typ: '+', string: "4"},
 						}},
 					}}},
-				}
+				}}
 			}
 		},
 		ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -1271,7 +1271,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 		CloseFn: func() { atomic.AddInt32(&slave2close, 1) },
 	}
 	s3 := &mockConn{
-		DoMultiFn: func(cmd ...Completed) []RedisResult { return []RedisResult{newErrResult(errClosing)} },
+		DoMultiFn: func(cmd ...Completed) *redisresults { return &redisresults{s: []RedisResult{newErrResult(errClosing)}} },
 	}
 	slave4 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {


### PR DESCRIPTION
Improve throughput of the following operations by 12% to 33%.

Improve allocations of the following operations by 49% to 76%.

```
▶ benchstat old.txt new.txt
name                                      old time/op    new time/op    delta
/OneNode/128_keys_RueidisDoMulti-10         39.0µs ± 0%    39.0µs ± 0%     ~     (p=0.346 n=10+9)
/OneNode/128_keys_RueidisMGet-10            20.0µs ± 1%    19.9µs ± 1%   -0.52%  (p=0.029 n=10+10)
/OneNode/128_keys_RueidisMGetCache-10       15.6µs ± 2%    11.7µs ± 1%  -24.65%  (p=0.000 n=10+10)
/OneNode/128_keys_RueidisDoMultiCache-10    10.0µs ± 3%     7.8µs ± 1%  -21.88%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisDoMulti-10         40.8µs ± 4%    35.1µs ± 3%  -13.81%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisMGet-10            43.6µs ± 3%    38.3µs ± 5%  -12.14%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisMGetCache-10       16.5µs ± 3%    10.9µs ± 1%  -33.67%  (p=0.000 n=10+9)
/Cluster/128_keys_RueidisDoMultiCache-10    12.1µs ± 1%     8.6µs ± 2%  -28.74%  (p=0.000 n=10+10)

name                                      old alloc/op   new alloc/op   delta
/OneNode/128_keys_RueidisDoMulti-10         18.5kB ± 0%    18.5kB ± 0%     ~     (p=0.000 n=10+10)
/OneNode/128_keys_RueidisMGet-10            41.1kB ± 0%    41.1kB ± 0%     ~     (p=0.327 n=10+10)
/OneNode/128_keys_RueidisMGetCache-10       60.8kB ± 0%    30.8kB ± 1%  -49.36%  (p=0.000 n=9+9)
/OneNode/128_keys_RueidisDoMultiCache-10    32.7kB ± 0%    11.6kB ± 1%  -64.37%  (p=0.000 n=8+10)
/Cluster/128_keys_RueidisDoMulti-10         48.3kB ± 0%    19.4kB ± 0%  -59.87%  (p=0.000 n=8+10)
/Cluster/128_keys_RueidisMGet-10            75.1kB ± 0%    36.3kB ± 1%  -51.63%  (p=0.000 n=8+10)
/Cluster/128_keys_RueidisMGetCache-10       76.7kB ± 0%    30.6kB ± 1%  -60.13%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisDoMultiCache-10    48.8kB ± 0%    11.6kB ± 2%  -76.30%  (p=0.000 n=10+10)

name                                      old allocs/op  new allocs/op  delta
/OneNode/128_keys_RueidisDoMulti-10            130 ± 0%       130 ± 0%     ~     (all equal)
/OneNode/128_keys_RueidisMGet-10               133 ± 0%       133 ± 0%     ~     (all equal)
/OneNode/128_keys_RueidisMGetCache-10         37.0 ± 0%      20.0 ± 0%  -45.95%  (p=0.000 n=10+10)
/OneNode/128_keys_RueidisDoMultiCache-10      33.0 ± 0%      17.0 ± 0%  -48.48%  (p=0.000 n=10+8)
/Cluster/128_keys_RueidisDoMulti-10            176 ± 0%       141 ± 0%  -19.89%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisMGet-10               181 ± 0%       144 ± 0%  -20.44%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisMGetCache-10         57.0 ± 0%      20.0 ± 0%  -64.91%  (p=0.000 n=10+10)
/Cluster/128_keys_RueidisDoMultiCache-10      52.0 ± 0%      16.0 ± 0%  -69.23%  (p=0.000 n=10+10)
```

Benchmark source:
```go
package sep

import (
	"context"
	"math/rand"
	"strconv"
	"testing"
	"time"

	"github.com/redis/rueidis"
)

var charset = []byte("abcdefghijklmnopqrstuvwxyz")

func randstr(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = charset[rand.Intn(len(charset))]
	}
	return string(b)
}

func Benchmark(b *testing.B) {
	testfn := func(b *testing.B, n int, addresses []string) {
		ns := strconv.Itoa(n)
		makeclient := func(addresses []string) rueidis.Client {
			client, err := rueidis.NewClient(rueidis.ClientOption{
				InitAddress: addresses,
			})
			if err != nil {
				panic(err)
			}
			return client
		}

		// prepare keys
		keys := make([]string, n)
		cmds := make(rueidis.Commands, n)

		{
			client := makeclient(addresses)
			for i := range keys {
				keys[i] = randstr(10)
				cmds[i] = client.B().Set().Key(keys[i]).Value(randstr(50)).Build()
			}
			client.Do(context.Background(), client.B().Flushall().Build())
			resps := client.DoMulti(context.Background(), cmds...)
			if len(resps) != len(keys) {
				panic("worn")
			}
			client.Close()
		}
		b.Run(ns+" RueidisDoMulti", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			commands := make([]rueidis.Completed, len(keys))
			for i := range commands {
				commands[i] = client.B().Get().Key(keys[i]).Build().Pin()
			}
			b.ReportAllocs()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret := client.DoMulti(context.Background(), commands...)
					if len(ret) != len(keys) {
						panic("wrong")
					}
				}
			})
			b.StopTimer()
		})
		b.Run(ns+" RueidisMGet", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			b.ReportAllocs()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret, err := rueidis.MGet(client, context.Background(), keys)
					if err != nil || len(ret) != len(keys) {
						panic(err)
					}
				}
			})
			b.StopTimer()
		})
		b.Run(ns+" RueidisMGetCache", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			b.ReportAllocs()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret, err := rueidis.MGetCache(client, context.Background(), time.Minute, keys)
					if err != nil || len(ret) != len(keys) {
						panic(err)
					}
				}
			})
			b.StopTimer()
		})
		b.Run(ns+" RueidisDoMultiCache", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			commands := make([]rueidis.CacheableTTL, len(keys))
			for i := range commands {
				commands[i] = rueidis.CT(client.B().Get().Key(keys[i]).Cache().Pin(), time.Minute)
			}
			b.ReportAllocs()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret := client.DoMultiCache(context.Background(), commands...)
					if len(ret) != len(keys) {
						panic("wrong")
					}
				}
			})
			b.StopTimer()
		})
	}

	b.Run("OneNode", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"127.0.0.1:6379"})
		}
	})

	b.Run("Cluster", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"})
		}
	})
}
```