### PR TITLE
perf: use batched lru.Flights to reduce cache contentions

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/redis/rueidis/internal/cmds"
 )
 
 const (
@@ -126,6 +128,96 @@ func (c *lru) Flight(key, cmd string, ttl time.Duration, now time.Time) (v Redis
 ret:
 	c.mu.Unlock()
 	return v, ce
+}
+
+func (c *lru) Flights(now time.Time, multi []CacheableTTL, results []RedisResult, entries map[int]CacheEntry) (missed []int) {
+	var moves []*list.Element
+
+	c.mu.RLock()
+	for i, ct := range multi {
+		key, cmd := cmds.CacheKey(ct.Cmd)
+		if kc, ok := c.store[key]; ok {
+			if ele, ok := kc.cache[cmd]; ok {
+				e := ele.Value.(*cacheEntry)
+				v := e.val
+				if v.typ == 0 {
+					entries[i] = e
+				} else if v.relativePTTL(now) > 0 {
+					results[i] = newResult(v, nil)
+				} else {
+					goto miss1
+				}
+				if atomic.AddUint64(&kc.hits, 1)&moveThreshold == 0 {
+					if moves == nil {
+						moves = make([]*list.Element, 0, len(multi))
+					}
+					moves = append(moves, ele)
+				}
+				continue
+			}
+		}
+	miss1:
+		if missed == nil {
+			missed = make([]int, 0, len(multi))
+		}
+		missed = append(missed, i)
+	}
+	c.mu.RUnlock()
+
+	if len(moves) > 0 {
+		c.mu.Lock()
+		if c.list != nil {
+			for _, ele := range moves {
+				c.list.MoveToBack(ele)
+			}
+		}
+		c.mu.Unlock()
+	}
+
+	if len(missed) == 0 {
+		return missed
+	}
+
+	j := 0
+	c.mu.Lock()
+	if c.store == nil {
+		c.mu.Unlock()
+		return missed
+	}
+	for _, i := range missed {
+		key, cmd := cmds.CacheKey(multi[i].Cmd)
+		kc, ok := c.store[key]
+		if !ok {
+			kc = &keyCache{cache: make(map[string]*list.Element, 1), key: key}
+			c.store[key] = kc
+		}
+		if ele, ok := kc.cache[cmd]; ok {
+			e := ele.Value.(*cacheEntry)
+			v := e.val
+			if v.typ == 0 {
+				entries[i] = e
+			} else if v.relativePTTL(now) > 0 {
+				results[i] = newResult(v, nil)
+			} else {
+				c.list.Remove(ele)
+				c.size -= e.size
+				goto miss2
+			}
+			atomic.AddUint64(&kc.hits, 1)
+			c.list.MoveToBack(ele)
+			continue
+		}
+	miss2:
+		atomic.AddUint64(&kc.miss, 1)
+		v := RedisMessage{}
+		v.setExpireAt(now.Add(multi[i].TTL).UnixMilli())
+		c.list.PushBack(&cacheEntry{cmd: cmd, kc: kc, val: v, ch: make(chan struct{})})
+		kc.cache[cmd] = c.list.Back()
+		missed[j] = i
+		j++
+	}
+	c.mu.Unlock()
+	return missed[:j]
 }
 
 func (c *lru) Update(key, cmd string, value RedisMessage) (pxat int64) {

--- a/lru_test.go
+++ b/lru_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/redis/rueidis/internal/cmds"
 )
 
 const PTTL = 50
@@ -238,6 +240,228 @@ func TestLRU(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("Batch Cache Hit & Expire", func(t *testing.T) {
+		lru := setup(t)
+		if v, _ := lru.Flight("0", "GET", TTL, time.Now()); v.typ == 0 {
+			t.Fatalf("did not get the value from the second Flight")
+		} else if v.string != "0" {
+			t.Fatalf("got unexpected value from the second Flight: %v", v)
+		}
+		time.Sleep(PTTL * time.Millisecond)
+		if v, entry := flights(lru, time.Now(), TTL, "GET", "0"); v.typ != 0 || entry != nil {
+			t.Fatalf("got unexpected value from the Flight after pttl: %v %v", v, entry)
+		}
+	})
+
+	t.Run("Batch Cache Should Not Expire By PTTL -2", func(t *testing.T) {
+		lru := setup(t)
+		if v, entry := lru.Flight("1", "GET", TTL, time.Now()); v.typ != 0 || entry != nil {
+			t.Fatalf("got unexpected value from the Flight after pttl: %v %v", v, entry)
+		}
+		m := RedisMessage{typ: '+', string: "1"}
+		lru.Update("1", "GET", m)
+		if v, _ := flights(lru, time.Now(), TTL, "GET", "1"); v.typ == 0 {
+			t.Fatalf("did not get the value from the second Flight")
+		} else if v.string != "1" {
+			t.Fatalf("got unexpected value from the second Flight: %v", v)
+		}
+	})
+
+	t.Run("Batch Cache Miss Suppress", func(t *testing.T) {
+		count := 5000
+		lru := setup(t)
+		wg := sync.WaitGroup{}
+		wg.Add(count)
+		for i := 0; i < count; i++ {
+			go func() {
+				defer wg.Done()
+				if v, _ := flights(lru, time.Now(), TTL, "GET", "1"); v.typ != 0 {
+					t.Errorf("got unexpected value from the first Flight: %v", v)
+				}
+				if v, _ := flights(lru, time.Now(), TTL, "GET", "2"); v.typ != 0 {
+					t.Errorf("got unexpected value from the first Flight: %v", v)
+				}
+			}()
+		}
+		wg.Wait()
+		lru.mu.RLock()
+		store1 := lru.store["1"]
+		store2 := lru.store["2"]
+		lru.mu.RUnlock()
+		if miss := atomic.LoadUint64(&store1.miss); miss != 1 {
+			t.Fatalf("unexpected miss count %v", miss)
+		}
+		if hits := atomic.LoadUint64(&store1.hits); hits != uint64(count-1) {
+			t.Fatalf("unexpected hits count %v", hits)
+		}
+		if miss := atomic.LoadUint64(&store2.miss); miss != 1 {
+			t.Fatalf("unexpected miss count %v", miss)
+		}
+		if hits := atomic.LoadUint64(&store2.hits); hits != uint64(count-1) {
+			t.Fatalf("unexpected hits count %v", hits)
+		}
+	})
+
+	t.Run("Batch Cache Evict", func(t *testing.T) {
+		lru := setup(t)
+		for i := 1; i <= Entries; i++ {
+			flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i))
+			m := RedisMessage{typ: '+', string: strconv.Itoa(i)}
+			m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
+			lru.Update(strconv.Itoa(i), "GET", m)
+		}
+		if v, entry := flights(lru, time.Now(), TTL, "GET", "1"); v.typ != 0 {
+			t.Fatalf("got evicted value from the first Flight: %v %v", v, entry)
+		}
+		if v, _ := flights(lru, time.Now(), TTL, "GET", strconv.Itoa(Entries)); v.typ == 0 {
+			t.Fatalf("did not get the latest value from the Flight")
+		} else if v.string != strconv.Itoa(Entries) {
+			t.Fatalf("got unexpected value from the Flight: %v", v)
+		}
+	})
+
+	t.Run("Batch Cache Delete", func(t *testing.T) {
+		lru := setup(t)
+		lru.Delete([]RedisMessage{{string: "0"}})
+		if v, _ := flights(lru, time.Now(), TTL, "GET", "0"); v.typ != 0 {
+			t.Fatalf("got unexpected value from the first Flight: %v", v)
+		}
+	})
+
+	t.Run("Batch Cache Flush", func(t *testing.T) {
+		lru := setup(t)
+		for i := 1; i < Entries; i++ {
+			flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i))
+			m := RedisMessage{typ: '+', string: strconv.Itoa(i)}
+			lru.Update(strconv.Itoa(i), "GET", m)
+		}
+		for i := 1; i < Entries; i++ {
+			if v, _ := flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i)); v.string != strconv.Itoa(i) {
+				t.Fatalf("got unexpected value before flush all: %v", v)
+			}
+		}
+		lru.Delete(nil)
+		for i := 1; i <= Entries; i++ {
+			if v, _ := flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i)); v.typ != 0 {
+				t.Fatalf("got unexpected value after flush all: %v", v)
+			}
+		}
+	})
+
+	t.Run("Batch Cache Close", func(t *testing.T) {
+		lru := setup(t)
+		v, entry := flights(lru, time.Now(), TTL, "GET", "1")
+		if v.typ != 0 || entry != nil {
+			t.Fatalf("got unexpected value from the first Flight: %v %v", v, entry)
+		}
+		v, entry = flights(lru, time.Now(), TTL, "GET", "1")
+		if v.typ != 0 || entry == nil { // entry should not be nil in second call
+			t.Fatalf("got unexpected value from the second Flight: %v %v", v, entry)
+		}
+
+		lru.Close(ErrDoCacheAborted)
+
+		if _, err := entry.Wait(context.Background()); err != ErrDoCacheAborted {
+			t.Fatalf("got unexpected value after Close: %v", err)
+		}
+
+		m := RedisMessage{typ: '+', string: "this Update should have no effect"}
+		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
+		lru.Update("1", "GET", m)
+		for i := 0; i < 2; i++ { // entry should be always nil after the first call if Close
+			if v, entry := flights(lru, time.Now(), TTL, "GET", "1"); v.typ != 0 || entry != nil {
+				t.Fatalf("got unexpected value from the first Flight: %v %v", v, entry)
+			}
+		}
+	})
+
+	t.Run("Batch Cache Cancel", func(t *testing.T) {
+		lru := setup(t)
+		v, entry := flights(lru, time.Now(), TTL, "GET", "1")
+		if v.typ != 0 || entry != nil {
+			t.Fatalf("got unexpected value from the first Flight: %v %v", v, entry)
+		}
+		v, entry = flights(lru, time.Now(), TTL, "GET", "1")
+		if v.typ != 0 || entry == nil { // entry should not be nil in second call
+			t.Fatalf("got unexpected value from the second Flight: %v %v", v, entry)
+		}
+		err := errors.New("any")
+
+		go func() {
+			lru.Cancel("1", "GET", err)
+		}()
+
+		if _, err2 := entry.Wait(context.Background()); err2 != err {
+			t.Fatalf("got unexpected value from the CacheEntry.Wait(): %v %v", err, err2)
+		}
+	})
+
+	t.Run("Batch GetTTL", func(t *testing.T) {
+		lru := setup(t)
+		if v := lru.GetTTL("empty", "cmd"); v != -2 {
+			t.Fatalf("unexpected %v", v)
+		}
+		flights(lru, time.Now(), time.Second, "cmd", "key")
+		m := RedisMessage{typ: 1}
+		m.setExpireAt(time.Now().Add(time.Second).UnixMilli())
+		lru.Update("key", "cmd", m)
+		if v := lru.GetTTL("key", "cmd"); !roughly(v, time.Second) {
+			t.Fatalf("unexpected %v", v)
+		}
+	})
+
+	t.Run("Batch Update Message TTL", func(t *testing.T) {
+		t.Run("client side TTL > server side TTL", func(t *testing.T) {
+			lru := setup(t)
+			flights(lru, time.Now(), time.Second*2, "cmd", "key")
+			m := RedisMessage{typ: 1}
+			m.setExpireAt(time.Now().Add(time.Second).UnixMilli())
+			lru.Update("key", "cmd", m)
+			if v, _ := flights(lru, time.Now(), time.Second*2, "cmd", "key"); v.CacheTTL() != 1 {
+				t.Fatalf("unexpected %v", v.CacheTTL())
+			}
+		})
+		t.Run("client side TTL < server side TTL", func(t *testing.T) {
+			lru := setup(t)
+			flights(lru, time.Now(), time.Second*2, "cmd", "key")
+			m := RedisMessage{typ: 1}
+			m.setExpireAt(time.Now().Add(3 * time.Second).UnixMilli())
+			lru.Update("key", "cmd", m)
+			if v, _ := flights(lru, time.Now(), time.Second*2, "cmd", "key"); v.CacheTTL() != 2 {
+				t.Fatalf("unexpected %v", v.CacheTTL())
+			}
+		})
+		t.Run("no server side TTL -1", func(t *testing.T) {
+			lru := setup(t)
+			flights(lru, time.Now(), time.Second*2, "cmd", "key")
+			m := RedisMessage{typ: 1}
+			lru.Update("key", "cmd", m)
+			if v, _ := flights(lru, time.Now(), time.Second*2, "cmd", "key"); v.CacheTTL() != 2 {
+				t.Fatalf("unexpected %v", v.CacheTTL())
+			}
+		})
+		t.Run("no server side TTL -2", func(t *testing.T) {
+			lru := setup(t)
+			flights(lru, time.Now(), time.Second*2, "cmd", "key")
+			m := RedisMessage{typ: 1}
+			lru.Update("key", "cmd", m)
+			if v, _ := flights(lru, time.Now(), time.Second*2, "cmd", "key"); v.CacheTTL() != 2 {
+				t.Fatalf("unexpected %v", v.CacheTTL())
+			}
+		})
+	})
+}
+
+func flights(lru *lru, now time.Time, ttl time.Duration, args ...string) (RedisMessage, CacheEntry) {
+	results := make([]RedisResult, 1)
+	entries := make(map[int]CacheEntry, 1)
+	lru.Flights(now, commands(ttl, args...), results, entries)
+	return results[0].val, entries[0]
+}
+
+func commands(ttl time.Duration, args ...string) []CacheableTTL {
+	return []CacheableTTL{CT(Cacheable(cmds.NewCompleted(args)), ttl)}
 }
 
 func roughly(ttl, expect time.Duration) bool {


### PR DESCRIPTION
Improve throughput by 13% to 42%

```
▶ benchstat old.txt new.txt
name                                 old time/op    new time/op    delta
/OneNode/128_RueidisMGetCache-10       11.7µs ± 2%    10.2µs ± 0%  -13.50%  (p=0.000 n=10+8)
/OneNode/128_RueidisDoMultiCache-10    7.75µs ± 1%    4.58µs ± 1%  -40.85%  (p=0.000 n=10+9)
/Cluster/128_RueidisMGetCache-10       12.9µs ± 4%    10.9µs ± 1%  -15.36%  (p=0.000 n=10+8)
/Cluster/128_RueidisDoMultiCache-10    9.00µs ± 3%    5.22µs ± 4%  -42.07%  (p=0.000 n=10+10)

name                                 old alloc/op   new alloc/op   delta
/OneNode/128_RueidisMGetCache-10       31.0kB ± 1%    31.1kB ± 1%     ~     (p=0.754 n=10+10)
/OneNode/128_RueidisDoMultiCache-10    11.9kB ± 1%    11.8kB ± 1%   -1.31%  (p=0.000 n=10+10)
/Cluster/128_RueidisMGetCache-10       31.2kB ± 1%    31.0kB ± 1%     ~     (p=0.052 n=10+10)
/Cluster/128_RueidisDoMultiCache-10    11.7kB ± 1%    11.7kB ± 1%     ~     (p=0.224 n=10+10)

name                                 old allocs/op  new allocs/op  delta
/OneNode/128_RueidisMGetCache-10         21.0 ± 0%      21.0 ± 0%     ~     (all equal)
/OneNode/128_RueidisDoMultiCache-10      17.0 ± 0%      17.0 ± 0%     ~     (all equal)
/Cluster/128_RueidisMGetCache-10         20.0 ± 0%      20.0 ± 0%     ~     (all equal)
/Cluster/128_RueidisDoMultiCache-10      16.0 ± 0%      16.0 ± 0%     ~     (all equal)
```

Benchmark source:
```go
package sep

import (
	"context"
	"math/rand"
	"strconv"
	"testing"
	"time"

	"github.com/redis/rueidis"
)

var charset = []byte("abcdefghijklmnopqrstuvwxyz")

func randstr(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = charset[rand.Intn(len(charset))]
	}
	return string(b)
}

func Benchmark(b *testing.B) {
	testfn := func(b *testing.B, n int, addresses []string) {
		ns := strconv.Itoa(n)
		makeclient := func(addresses []string) rueidis.Client {
			client, err := rueidis.NewClient(rueidis.ClientOption{
				InitAddress: addresses,
			})
			if err != nil {
				panic(err)
			}
			return client
		}

		// prepare keys
		keys := make([]string, n)
		cmds := make(rueidis.Commands, n)

		{
			client := makeclient(addresses)
			for i := range keys {
				keys[i] = randstr(10)
				cmds[i] = client.B().Set().Key(keys[i]).Value(randstr(50)).Build()
			}
			client.Do(context.Background(), client.B().Flushall().Build())
			resps := client.DoMulti(context.Background(), cmds...)
			if len(resps) != len(keys) {
				panic("worn")
			}
			client.Close()
		}
		b.Run(ns+" RueidisMGetCache", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			b.ReportAllocs()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret, err := rueidis.MGetCache(client, context.Background(), time.Minute, keys)
					if err != nil || len(ret) != len(keys) {
						panic(err)
					}
				}
			})
			b.StopTimer()
		})
		b.Run(ns+" RueidisDoMultiCache", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			commands := make([]rueidis.CacheableTTL, len(keys))
			for i := range commands {
				commands[i] = rueidis.CT(client.B().Get().Key(keys[i]).Cache().Pin(), time.Minute)
			}
			b.ReportAllocs()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret := client.DoMultiCache(context.Background(), commands...)
					if len(ret) != len(keys) {
						panic("wrong")
					}
				}
			})
			b.StopTimer()
		})
	}

	b.Run("OneNode", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"127.0.0.1:6379"})
		}
	})

	b.Run("Cluster", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"})
		}
	})
}

```