### PR TITLE
perf: improve throughput of the Do and DoMulti when -cpu=1

### DIFF
--- a/ring_test.go
+++ b/ring_test.go
@@ -30,7 +30,7 @@ func TestRing(t *testing.T) {
 				runtime.Gosched()
 				continue
 			}
-			cmd2, _, ch, cond := ring.NextResultCh()
+			cmd2, _, ch, _, cond := ring.NextResultCh()
 			cond.L.Unlock()
 			cond.Signal()
 			if cmd1.Commands()[0] != cmd2.Commands()[0] {
@@ -53,7 +53,7 @@ func TestRing(t *testing.T) {
 
 		base := [][]string{{"a"}, {"b"}, {"c"}, {"d"}}
 		for cmd := range fixture {
-			go ring.PutMulti(cmds.NewMultiCompleted(append([][]string{{cmd}}, base...)))
+			go ring.PutMulti(cmds.NewMultiCompleted(append([][]string{{cmd}}, base...)), nil)
 		}
 
 		for len(fixture) != 0 {
@@ -62,7 +62,7 @@ func TestRing(t *testing.T) {
 				runtime.Gosched()
 				continue
 			}
-			_, cmd2, ch, cond := ring.NextResultCh()
+			_, cmd2, ch, _, cond := ring.NextResultCh()
 			cond.L.Unlock()
 			cond.Signal()
 			for j := 0; j < len(cmd1); j++ {
@@ -82,7 +82,7 @@ func TestRing(t *testing.T) {
 		if one, multi, _ := ring.NextWriteCmd(); !one.IsEmpty() || multi != nil {
 			t.Fatalf("NextWriteCmd should returns nil if empty")
 		}
-		if one, multi, ch, cond := ring.NextResultCh(); !one.IsEmpty() || multi != nil || ch != nil {
+		if one, multi, ch, _, cond := ring.NextResultCh(); !one.IsEmpty() || multi != nil || ch != nil {
 			t.Fatalf("NextResultCh should returns nil if not NextWriteCmd yet")
 		} else {
 			cond.L.Unlock()
@@ -93,18 +93,18 @@ func TestRing(t *testing.T) {
 		if one, _, _ := ring.NextWriteCmd(); len(one.Commands()) == 0 || one.Commands()[0] != "0" {
 			t.Fatalf("NextWriteCmd should returns next cmd")
 		}
-		if one, _, ch, cond := ring.NextResultCh(); len(one.Commands()) == 0 || one.Commands()[0] != "0" || ch == nil {
+		if one, _, ch, _, cond := ring.NextResultCh(); len(one.Commands()) == 0 || one.Commands()[0] != "0" || ch == nil {
 			t.Fatalf("NextResultCh should returns next cmd after NextWriteCmd")
 		} else {
 			cond.L.Unlock()
 			cond.Signal()
 		}
 
-		ring.PutMulti(cmds.NewMultiCompleted([][]string{{"0"}}))
+		ring.PutMulti(cmds.NewMultiCompleted([][]string{{"0"}}), nil)
 		if _, multi, _ := ring.NextWriteCmd(); len(multi) == 0 || multi[0].Commands()[0] != "0" {
 			t.Fatalf("NextWriteCmd should returns next cmd")
 		}
-		if _, multi, ch, cond := ring.NextResultCh(); len(multi) == 0 || multi[0].Commands()[0] != "0" || ch == nil {
+		if _, multi, ch, _, cond := ring.NextResultCh(); len(multi) == 0 || multi[0].Commands()[0] != "0" || ch == nil {
 			t.Fatalf("NextResultCh should returns next cmd after NextWriteCmd")
 		} else {
 			cond.L.Unlock()
@@ -131,7 +131,7 @@ func TestRing(t *testing.T) {
 		if _, multi, ch := ring.NextWriteCmd(); ch == nil {
 			go func() {
 				time.Sleep(time.Millisecond * 100)
-				ring.PutMulti([]Completed{cmds.QuitCmd})
+				ring.PutMulti([]Completed{cmds.QuitCmd}, nil)
 			}()
 			if _, multi, ch = ring.WaitForWrite(); ch != nil && multi[0].Commands()[0] == cmds.QuitCmd.Commands()[0] {
 				return

--- a/rueidis.go
+++ b/rueidis.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"math"
 	"math/rand"
 	"net"
+	"runtime"
 	"strings"
 	"time"
 
@@ -319,7 +321,9 @@ func NewClient(option ClientOption) (client Client, err error) {
 
 func singleClientMultiplex(multiplex int) int {
 	if multiplex == 0 {
-		multiplex = 2
+		if multiplex = int(math.Log2(float64(runtime.GOMAXPROCS(0)))); multiplex >= 2 {
+			multiplex = 2
+		}
 	}
 	if multiplex < 0 {
 		multiplex = 0


### PR DESCRIPTION
Improve throughput of the `Do` and `DoMulti` by **15%** and **8%** when `-cpu=1`.

```
# go test -run='^$' -bench=. -benchmem -benchtime=2s -count=10 -cpu=1

goos: linux
goarch: amd64
pkg: github.com/redis/rueidis/ben
cpu: AMD EPYC 7B12
                              │   old-1.txt   │              new-1.txt               │
                              │    sec/op     │    sec/op     vs base                │
/OneNode/128_RueidisSingle      102.39µ ±  7%   86.42µ ± 11%  -15.60% (p=0.001 n=10)
/OneNode/128_RueidisDoMulti      242.8µ ±  5%   223.1µ ±  6%   -8.11% (p=0.019 n=10)
geomean                          146.8µ         139.4µ         -5.03%

                              │  old-1.txt   │               new-1.txt                │
                              │     B/op     │     B/op      vs base                  │
/OneNode/128_RueidisSingle       243.50 ± 4%     64.00 ± 0%  -73.72% (p=0.000 n=10)
/OneNode/128_RueidisDoMulti     18.46Ki ± 0%   18.02Ki ± 0%   -2.37% (p=0.000 n=10)
geomean                         2.389Ki        1.700Ki       -28.83%
¹ all samples are equal

                              │ old-1.txt  │              new-1.txt              │
                              │ allocs/op  │ allocs/op   vs base                 │
/OneNode/128_RueidisSingle      1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
/OneNode/128_RueidisDoMulti     131.0 ± 0%   130.0 ± 0%  -0.76% (p=0.000 n=10)
geomean                         27.27        27.22       -0.19%
¹ all samples are equal
```

Benchmark source:
```go
package ops

import (
	"context"
	"github.com/redis/go-redis/v9"
	"github.com/redis/rueidis"
	"math/rand"
	"strconv"
	"testing"
)

var charset = []byte("abcdefghijklmnopqrstuvwxyz")

func randstr(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = charset[rand.Intn(len(charset))]
	}
	return string(b)
}

func Benchmark(b *testing.B) {
	testfn := func(b *testing.B, n int, addresses []string) {
		ns := strconv.Itoa(n)
		makeclient := func(addresses []string) rueidis.Client {
			client, err := rueidis.NewClient(rueidis.ClientOption{
				InitAddress: addresses,
			})
			if err != nil {
				panic(err)
			}
			return client
		}

		// prepare keys
		keys := make(map[string]string, n)
		cmds := make(rueidis.Commands, 0, n)

		{
			client := makeclient(addresses)
			for i := 0; i < n; i++ {
				keys[randstr(10)] = randstr(50)
			}
			for k, v := range keys {
				cmds = append(cmds, client.B().Set().Key(k).Value(v).Build())
			}
			if err := client.Do(context.Background(), client.B().Flushall().Build()).Error(); err != nil {
				panic(err)
			}
			resps := client.DoMulti(context.Background(), cmds...)
			if len(resps) != len(keys) {
				panic("worn")
			}
			client.Close()
		}
		b.Run(ns+" RueidisSingle", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					for k := range keys {
						_, err := client.Do(context.Background(), client.B().Get().Key(k).Build()).ToString()
						if err != nil {
							panic(err)
						}
						break
					}
				}
			})
			b.StopTimer()
		})
		b.Run(ns+" RueidisDoMulti", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			commands := make([]rueidis.Completed, 0, len(keys))
			for k := range keys {
				commands = append(commands, client.B().Get().Key(k).Build().Pin())
			}
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret := client.DoMulti(context.Background(), commands...)
					for _, result := range ret {
						_, err := result.ToString()
						if err != nil {
							panic(err)
						}
					}
				}
			})
			b.StopTimer()
		})
	}

	b.Run("OneNode", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"10.140.0.7:6379"})
		}
	})
}

```