### PR TITLE
perf: reduce allocations of DoMultiCache

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -374,14 +374,14 @@ process:
 	return resp
 }
 
-func (c *clusterClient) _pickMulti(multi []Completed) (retries map[conn]*retry, last uint16) {
+func (c *clusterClient) _pickMulti(multi []Completed) (retries *connretry, last uint16) {
 	last = cmds.InitSlot
 	init := false
 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	count := make(map[conn]int, len(c.conns))
+	count := conncountp.Get(len(c.conns), len(c.conns))
 	for _, cmd := range multi {
 		if cmd.Slot() == cmds.InitSlot {
 			init = true
@@ -391,13 +391,14 @@ func (c *clusterClient) _pickMulti(multi []Completed) (retries map[conn]*retry, 
 		if p == nil {
 			return nil, 0
 		}
-		count[p]++
+		count.m[p]++
 	}
 
-	retries = make(map[conn]*retry, len(count))
-	for cc, n := range count {
-		retries[cc] = retryp.Get(0, n)
+	retries = connretryp.Get(len(count.m), len(count.m))
+	for cc, n := range count.m {
+		retries.m[cc] = retryp.Get(0, n)
 	}
+	conncountp.Put(count)
 
 	for i, cmd := range multi {
 		if cmd.Slot() != cmds.InitSlot {
@@ -407,7 +408,7 @@ func (c *clusterClient) _pickMulti(multi []Completed) (retries map[conn]*retry, 
 				panic(panicMixCxSlot)
 			}
 			cc := c.slots[cmd.Slot()]
-			re := retries[cc]
+			re := retries.m[cc]
 			re.commands = append(re.commands, cmd)
 			re.cIndexes = append(re.cIndexes, i)
 		}
@@ -416,7 +417,7 @@ func (c *clusterClient) _pickMulti(multi []Completed) (retries map[conn]*retry, 
 	return retries, last
 }
 
-func (c *clusterClient) pickMulti(multi []Completed) (map[conn]*retry, uint16, error) {
+func (c *clusterClient) pickMulti(multi []Completed) (*connretry, uint16, error) {
 	conns, slot := c._pickMulti(multi)
 	if conns == nil {
 		if err := c.refresh(); err != nil {
@@ -429,6 +430,52 @@ func (c *clusterClient) pickMulti(multi []Completed) (map[conn]*retry, uint16, e
 	return conns, slot, nil
 }
 
+func (c *clusterClient) doresultfn(ctx context.Context, results *redisresults, retries *connretry, mu *sync.Mutex, cc conn, cIndexes []int, commands []Completed, resps []RedisResult) {
+	for i, resp := range resps {
+		ii := cIndexes[i]
+		cm := commands[i]
+		results.s[ii] = resp
+		addr, mode := c.shouldRefreshRetry(resp.Error(), ctx)
+		if c.retry && mode != RedirectNone && cm.IsReadOnly() {
+			nc := cc
+			if mode != RedirectRetry {
+				nc = c.redirectOrNew(addr, cc)
+			}
+			mu.Lock()
+			nr := retries.m[nc]
+			if nr == nil {
+				nr = retryp.Get(0, len(commands))
+				retries.m[nc] = nr
+			}
+			if mode == RedirectAsk {
+				nr.aIndexes = append(nr.aIndexes, ii)
+				nr.cAskings = append(nr.cAskings, cm)
+			} else {
+				nr.cIndexes = append(nr.cIndexes, ii)
+				nr.commands = append(nr.commands, cm)
+			}
+			mu.Unlock()
+		}
+	}
+}
+
+func (c *clusterClient) doretry(ctx context.Context, cc conn, results *redisresults, retries *connretry, re *retry, mu *sync.Mutex, wg *sync.WaitGroup) {
+	if len(re.commands) != 0 {
+		resps := cc.DoMulti(ctx, re.commands...)
+		c.doresultfn(ctx, results, retries, mu, cc, re.cIndexes, re.commands, resps.s)
+		resultsp.Put(resps)
+	}
+	if len(re.cAskings) != 0 {
+		resps := askingMulti(cc, ctx, re.cAskings)
+		c.doresultfn(ctx, results, retries, mu, cc, re.aIndexes, re.cAskings, resps.s)
+		resultsp.Put(resps)
+	}
+	if ctx.Err() == nil {
+		retryp.Put(re)
+	}
+	wg.Done()
+}
+
 func (c *clusterClient) DoMulti(ctx context.Context, multi ...Completed) []RedisResult {
 	if len(multi) == 0 {
 		return nil
@@ -438,9 +485,10 @@ func (c *clusterClient) DoMulti(ctx context.Context, multi ...Completed) []Redis
 	if err != nil {
 		return fillErrs(len(multi), err)
 	}
+	defer connretryp.Put(retries)
 
-	if len(retries) <= 1 {
-		for _, re := range retries {
+	if len(retries.m) <= 1 {
+		for _, re := range retries.m {
 			retryp.Put(re)
 		}
 		return c.doMulti(ctx, slot, multi)
@@ -450,61 +498,18 @@ func (c *clusterClient) DoMulti(ctx context.Context, multi ...Completed) []Redis
 	var mu sync.Mutex
 
 	results := resultsp.Get(len(multi), len(multi))
-	respsfn := func(cc conn, cIndexes []int, commands []Completed, resps []RedisResult) {
-		for i, resp := range resps {
-			ii := cIndexes[i]
-			cm := commands[i]
-			results.s[ii] = resp
-			addr, mode := c.shouldRefreshRetry(resp.Error(), ctx)
-			if c.retry && mode != RedirectNone && cm.IsReadOnly() {
-				nc := cc
-				if mode != RedirectRetry {
-					nc = c.redirectOrNew(addr, cc)
-				}
-				mu.Lock()
-				nr := retries[nc]
-				if nr == nil {
-					nr = retryp.Get(0, len(commands))
-					retries[nc] = nr
-				}
-				if mode == RedirectAsk {
-					nr.aIndexes = append(nr.aIndexes, ii)
-					nr.cAskings = append(nr.cAskings, cm)
-				} else {
-					nr.cIndexes = append(nr.cIndexes, ii)
-					nr.commands = append(nr.commands, cm)
-				}
-				mu.Unlock()
-			}
-		}
-	}
 
 retry:
-	wg.Add(len(retries))
+	wg.Add(len(retries.m))
 	mu.Lock()
-	for cc, re := range retries {
-		delete(retries, cc)
-		go func(cc conn, re *retry) {
-			if len(re.commands) != 0 {
-				resps := cc.DoMulti(ctx, re.commands...)
-				respsfn(cc, re.cIndexes, re.commands, resps.s)
-				resultsp.Put(resps)
-			}
-			if len(re.cAskings) != 0 {
-				resps := askingMulti(cc, ctx, re.cAskings)
-				respsfn(cc, re.aIndexes, re.cAskings, resps.s)
-				resultsp.Put(resps)
-			}
-			if ctx.Err() == nil {
-				retryp.Put(re)
-			}
-			wg.Done()
-		}(cc, re)
+	for cc, re := range retries.m {
+		delete(retries.m, cc)
+		go c.doretry(ctx, cc, results, retries, re, &mu, &wg)
 	}
 	mu.Unlock()
 	wg.Wait()
 
-	if len(retries) != 0 {
+	if len(retries.m) != 0 {
 		goto retry
 	}
 
@@ -624,27 +629,28 @@ func askingMultiCache(cc conn, ctx context.Context, multi []CacheableTTL) *redis
 	return results
 }
 
-func (c *clusterClient) _pickMultiCache(multi []CacheableTTL) map[conn]*retrycache {
+func (c *clusterClient) _pickMultiCache(multi []CacheableTTL) *connretrycache {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	count := make(map[conn]int, len(c.conns))
+	count := conncountp.Get(len(c.conns), len(c.conns))
 	for _, cmd := range multi {
 		p := c.slots[cmd.Cmd.Slot()]
 		if p == nil {
 			return nil
 		}
-		count[p]++
+		count.m[p]++
 	}
 
-	retries := make(map[conn]*retrycache, len(count))
-	for cc, n := range count {
-		retries[cc] = retrycachep.Get(0, n)
+	retries := connretrycachep.Get(len(count.m), len(count.m))
+	for cc, n := range count.m {
+		retries.m[cc] = retrycachep.Get(0, n)
 	}
+	conncountp.Put(count)
 
 	for i, cmd := range multi {
 		cc := c.slots[cmd.Cmd.Slot()]
-		re := retries[cc]
+		re := retries.m[cc]
 		re.commands = append(re.commands, cmd)
 		re.cIndexes = append(re.cIndexes, i)
 	}
@@ -652,7 +658,7 @@ func (c *clusterClient) _pickMultiCache(multi []CacheableTTL) map[conn]*retrycac
 	return retries
 }
 
-func (c *clusterClient) pickMultiCache(multi []CacheableTTL) (map[conn]*retrycache, error) {
+func (c *clusterClient) pickMultiCache(multi []CacheableTTL) (*connretrycache, error) {
 	conns := c._pickMultiCache(multi)
 	if conns == nil {
 		if err := c.refresh(); err != nil {
@@ -665,6 +671,52 @@ func (c *clusterClient) pickMultiCache(multi []CacheableTTL) (map[conn]*retrycac
 	return conns, nil
 }
 
+func (c *clusterClient) resultcachefn(ctx context.Context, results *redisresults, retries *connretrycache, mu *sync.Mutex, cc conn, cIndexes []int, commands []CacheableTTL, resps []RedisResult) {
+	for i, resp := range resps {
+		ii := cIndexes[i]
+		cm := commands[i]
+		results.s[ii] = resp
+		addr, mode := c.shouldRefreshRetry(resp.Error(), ctx)
+		if c.retry && mode != RedirectNone {
+			nc := cc
+			if mode != RedirectRetry {
+				nc = c.redirectOrNew(addr, cc)
+			}
+			mu.Lock()
+			nr := retries.m[nc]
+			if nr == nil {
+				nr = retrycachep.Get(0, len(commands))
+				retries.m[nc] = nr
+			}
+			if mode == RedirectAsk {
+				nr.aIndexes = append(nr.aIndexes, ii)
+				nr.cAskings = append(nr.cAskings, cm)
+			} else {
+				nr.cIndexes = append(nr.cIndexes, ii)
+				nr.commands = append(nr.commands, cm)
+			}
+			mu.Unlock()
+		}
+	}
+}
+
+func (c *clusterClient) doretrycache(ctx context.Context, cc conn, results *redisresults, retries *connretrycache, re *retrycache, mu *sync.Mutex, wg *sync.WaitGroup) {
+	if len(re.commands) != 0 {
+		resps := cc.DoMultiCache(ctx, re.commands...)
+		c.resultcachefn(ctx, results, retries, mu, cc, re.cIndexes, re.commands, resps.s)
+		resultsp.Put(resps)
+	}
+	if len(re.cAskings) != 0 {
+		resps := askingMultiCache(cc, ctx, re.cAskings)
+		c.resultcachefn(ctx, results, retries, mu, cc, re.aIndexes, re.cAskings, resps.s)
+		resultsp.Put(resps)
+	}
+	if ctx.Err() == nil {
+		retrycachep.Put(re)
+	}
+	wg.Done()
+}
+
 func (c *clusterClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL) []RedisResult {
 	if len(multi) == 0 {
 		return nil
@@ -674,64 +726,24 @@ func (c *clusterClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL)
 	if err != nil {
 		return fillErrs(len(multi), err)
 	}
+	defer connretrycachep.Put(retries)
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
 	results := resultsp.Get(len(multi), len(multi))
-	respsfn := func(cc conn, cIndexes []int, commands []CacheableTTL, resps []RedisResult) {
-		for i, resp := range resps {
-			ii := cIndexes[i]
-			cm := commands[i]
-			results.s[ii] = resp
-			addr, mode := c.shouldRefreshRetry(resp.Error(), ctx)
-			if c.retry && mode != RedirectNone {
-				nc := cc
-				if mode != RedirectRetry {
-					nc = c.redirectOrNew(addr, cc)
-				}
-				mu.Lock()
-				nr := retries[nc]
-				if nr == nil {
-					nr = retrycachep.Get(0, len(commands))
-					retries[nc] = nr
-				}
-				if mode == RedirectAsk {
-					nr.aIndexes = append(nr.aIndexes, ii)
-					nr.cAskings = append(nr.cAskings, cm)
-				} else {
-					nr.cIndexes = append(nr.cIndexes, ii)
-					nr.commands = append(nr.commands, cm)
-				}
-				mu.Unlock()
-			}
-		}
-	}
 
 retry:
-	wg.Add(len(retries))
+	wg.Add(len(retries.m))
 	mu.Lock()
-	for cc, re := range retries {
-		delete(retries, cc)
-		go func(cc conn, re *retrycache) {
-			if len(re.commands) != 0 {
-				resps := cc.DoMultiCache(ctx, re.commands...)
-				respsfn(cc, re.cIndexes, re.commands, resps.s)
-				resultsp.Put(resps)
-			}
-			if len(re.cAskings) != 0 {
-				resps := askingMultiCache(cc, ctx, re.cAskings)
-				respsfn(cc, re.aIndexes, re.cAskings, resps.s)
-				resultsp.Put(resps)
-			}
-			retrycachep.Put(re)
-			wg.Done()
-		}(cc, re)
+	for cc, re := range retries.m {
+		delete(retries.m, cc)
+		go c.doretrycache(ctx, cc, results, retries, re, &mu, &wg)
 	}
 	mu.Unlock()
 	wg.Wait()
 
-	if len(retries) != 0 {
+	if len(retries.m) != 0 {
 		goto retry
 	}
 
@@ -995,3 +1007,60 @@ const (
 	panicMsgCxSlot = "cross slot command in Dedicated is prohibited"
 	panicMixCxSlot = "Mixing no-slot and cross slot commands in DoMulti is prohibited"
 )
+
+type conncount struct {
+	m map[conn]int
+	n int
+}
+
+func (r *conncount) Capacity() int {
+	return r.n
+}
+
+func (r *conncount) ResetLen(n int) {
+	for k := range r.m {
+		delete(r.m, k)
+	}
+}
+
+var conncountp = util.NewPool(func(capacity int) *conncount {
+	return &conncount{m: make(map[conn]int, capacity), n: capacity}
+})
+
+type connretry struct {
+	m map[conn]*retry
+	n int
+}
+
+func (r *connretry) Capacity() int {
+	return r.n
+}
+
+func (r *connretry) ResetLen(n int) {
+	for k := range r.m {
+		delete(r.m, k)
+	}
+}
+
+var connretryp = util.NewPool(func(capacity int) *connretry {
+	return &connretry{m: make(map[conn]*retry, capacity), n: capacity}
+})
+
+type connretrycache struct {
+	m map[conn]*retrycache
+	n int
+}
+
+func (r *connretrycache) Capacity() int {
+	return r.n
+}
+
+func (r *connretrycache) ResetLen(n int) {
+	for k := range r.m {
+		delete(r.m, k)
+	}
+}
+
+var connretrycachep = util.NewPool(func(capacity int) *connretrycache {
+	return &connretrycache{m: make(map[conn]*retrycache, capacity), n: capacity}
+})

--- a/mux.go
+++ b/mux.go
@@ -256,35 +256,39 @@ func (m *mux) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Red
 }
 
 func (m *mux) DoMultiCache(ctx context.Context, multi ...CacheableTTL) (results *redisresults) {
-	var slots map[uint16]int
+	var slots *muxslots
 	var mask = uint16(len(m.wire) - 1)
 
 	if mask == 0 {
 		return m.doMultiCache(ctx, 0, multi)
 	}
 
-	slots = make(map[uint16]int, len(m.wire))
+	slots = muxslotsp.Get(len(m.wire), len(m.wire))
 	for _, cmd := range multi {
-		slots[cmd.Cmd.Slot()&mask]++
+		slots.s[cmd.Cmd.Slot()&mask]++
 	}
 
-	if len(slots) == 1 {
+	if slots.LessThen(2) {
 		return m.doMultiCache(ctx, multi[0].Cmd.Slot()&mask, multi)
 	}
 
-	batches := make(map[uint16]*batchcache, len(m.wire))
-	for slot, count := range slots {
-		batches[slot] = batchcachep.Get(0, count)
+	batches := batchcachemaps.Get(len(m.wire), len(m.wire))
+	for slot, count := range slots.s {
+		if count > 0 {
+			batches.m[uint16(slot)] = batchcachep.Get(0, count)
+		}
 	}
+	muxslotsp.Put(slots)
+
 	for i, cmd := range multi {
-		batch := batches[cmd.Cmd.Slot()&mask]
+		batch := batches.m[cmd.Cmd.Slot()&mask]
 		batch.commands = append(batch.commands, cmd)
 		batch.cIndexes = append(batch.cIndexes, i)
 	}
 
 	results = resultsp.Get(len(multi), len(multi))
-	util.ParallelKeys(m.maxp, batches, func(slot uint16) {
-		batch := batches[slot]
+	util.ParallelKeys(m.maxp, batches.m, func(slot uint16) {
+		batch := batches.m[slot]
 		resp := m.doMultiCache(ctx, slot, batch.commands)
 		for i, r := range resp.s {
 			results.s[batch.cIndexes[i]] = r
@@ -292,9 +296,10 @@ func (m *mux) DoMultiCache(ctx context.Context, multi ...CacheableTTL) (results 
 		resultsp.Put(resp)
 	})
 
-	for _, batch := range batches {
+	for _, batch := range batches.m {
 		batchcachep.Put(batch)
 	}
+	batchcachemaps.Put(batches)
 
 	return results
 }
@@ -367,3 +372,53 @@ func slotfn(n int, ks uint16, noreply bool) uint16 {
 	}
 	return uint16(fastrand(n))
 }
+
+type muxslots struct {
+	s []int
+}
+
+func (r *muxslots) Capacity() int {
+	return cap(r.s)
+}
+
+func (r *muxslots) ResetLen(n int) {
+	r.s = r.s[:n]
+	for i := 0; i < n; i++ {
+		r.s[i] = 0
+	}
+}
+
+func (r *muxslots) LessThen(n int) bool {
+	count := 0
+	for _, value := range r.s {
+		if value > 0 {
+			if count++; count == n {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var muxslotsp = util.NewPool(func(capacity int) *muxslots {
+	return &muxslots{s: make([]int, 0, capacity)}
+})
+
+type batchcachemap struct {
+	m map[uint16]*batchcache
+	n int
+}
+
+func (r *batchcachemap) Capacity() int {
+	return r.n
+}
+
+func (r *batchcachemap) ResetLen(n int) {
+	for k := range r.m {
+		delete(r.m, k)
+	}
+}
+
+var batchcachemaps = util.NewPool(func(capacity int) *batchcachemap {
+	return &batchcachemap{m: make(map[uint16]*batchcache, capacity), n: capacity}
+})


### PR DESCRIPTION
```
▶ benchstat old.txt new.txt
name                                 old time/op    new time/op    delta
/OneNode/128_RueidisDoMulti-10         42.0µs ± 0%    42.1µs ± 0%   +0.33%  (p=0.000 n=20+19)
/OneNode/128_RueidisDoMultiCache-10    4.24µs ± 1%    3.96µs ± 2%   -6.73%  (p=0.000 n=19+20)
/Cluster/128_RueidisDoMulti-10         28.8µs ± 4%    29.1µs ± 4%     ~     (p=0.157 n=20+20)
/Cluster/128_RueidisDoMultiCache-10    4.24µs ± 2%    4.21µs ± 3%   -0.86%  (p=0.037 n=20+20)

name                                 old alloc/op   new alloc/op   delta
/OneNode/128_RueidisDoMulti-10         18.5kB ± 0%    18.5kB ± 0%     ~     (p=0.513 n=20+19)
/OneNode/128_RueidisDoMultiCache-10    11.8kB ± 1%    11.5kB ± 0%   -2.84%  (p=0.000 n=20+20)
/Cluster/128_RueidisDoMulti-10         19.4kB ± 1%    19.0kB ± 1%   -1.80%  (p=0.000 n=20+20)
/Cluster/128_RueidisDoMultiCache-10    11.8kB ± 1%    11.2kB ± 1%   -4.76%  (p=0.000 n=20+20)

name                                 old allocs/op  new allocs/op  delta
/OneNode/128_RueidisDoMulti-10            130 ± 0%       130 ± 0%     ~     (all equal)
/OneNode/128_RueidisDoMultiCache-10      17.0 ± 0%      10.0 ± 0%  -41.18%  (p=0.000 n=18+20)
/Cluster/128_RueidisDoMulti-10            141 ± 0%       135 ± 0%   -4.26%  (p=0.000 n=20+20)
/Cluster/128_RueidisDoMultiCache-10      16.0 ± 0%      10.0 ± 0%  -37.50%  (p=0.000 n=20+20)
```

source
```go
package sep

import (
	"context"
	"github.com/redis/rueidis"
	"math/rand"
	"strconv"
	"testing"
	"time"
)

var charset = []byte("abcdefghijklmnopqrstuvwxyz")

func randstr(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = charset[rand.Intn(len(charset))]
	}
	return string(b)
}

func Benchmark(b *testing.B) {
	testfn := func(b *testing.B, n int, addresses []string) {
		ns := strconv.Itoa(n)
		makeclient := func(addresses []string) rueidis.Client {
			client, err := rueidis.NewClient(rueidis.ClientOption{
				InitAddress: addresses,
			})
			if err != nil {
				panic(err)
			}
			return client
		}

		// prepare keys
		keys := make(map[string]string, n)
		cmds := make(rueidis.Commands, 0, n)

		{
			client := makeclient(addresses)
			for i := 0; i < n; i++ {
				keys[randstr(10)] = randstr(50)
			}
			for k, v := range keys {
				cmds = append(cmds, client.B().Set().Key(k).Value(v).Build())
			}
			if err := client.Do(context.Background(), client.B().Flushall().Build()).Error(); err != nil {
				panic(err)
			}
			resps := client.DoMulti(context.Background(), cmds...)
			if len(resps) != len(keys) {
				panic("worn")
			}
			client.Close()
		}
		b.Run(ns+" RueidisDoMulti", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			commands := make([]rueidis.Completed, 0, len(keys))
			for k := range keys {
				commands = append(commands, client.B().Get().Key(k).Build().Pin())
			}
			b.ResetTimer()
			b.RunParallel(func(pb *testing.PB) {
				for pb.Next() {
					ret := client.DoMulti(context.Background(), commands...)
					for _, result := range ret {
						_, err := result.ToString()
						if err != nil {
							panic(err)
						}
					}
				}
			})
			b.StopTimer()
		})
		b.Run(ns+" RueidisDoMultiCache", func(b *testing.B) {
			client := makeclient(addresses)
			defer client.Close()
			commands := make([]rueidis.CacheableTTL, 0, len(keys))
			for k := range keys {
				commands = append(commands, rueidis.CT(client.B().Get().Key(k).Cache().Pin(), time.Second*3))
			}
			b.ResetTimer()
			b.ReportAllocs()
			b.RunParallel(func(pb *testing.PB) {

				for pb.Next() {
					ret := client.DoMultiCache(context.Background(), commands...)
					for _, result := range ret {
						_, err := result.ToString()
						if err != nil {
							panic(err)
						}
						//if v != keys[commands[i].Cmd.Commands()[1]] {
						//	panic("wrong")
						//}
					}
				}
			})
			b.StopTimer()
		})
	}

	b.Run("OneNode", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"127.0.0.1:6379"})
		}
	})

	b.Run("Cluster", func(b *testing.B) {
		for _, n := range []int{128} {
			testfn(b, n, []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"})
		}
	})
}
```