### PR TITLE
perf: no allocations for redis OK responses

### DIFF
--- a/resp.go
+++ b/resp.go
@@ -150,7 +150,16 @@ func readMap(i *bufio.Reader) (m RedisMessage, err error) {
 	return m, err
 }
 
+const ok = "OK"
+const okrn = "OK\r\n"
+
 func readS(i *bufio.Reader) (string, error) {
+	if peek, _ := i.Peek(2); string(peek) == ok {
+		if peek, _ = i.Peek(4); string(peek) == okrn {
+			_, _ = i.Discard(4)
+			return ok, nil
+		}
+	}
 	bs, err := i.ReadBytes('\n')
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Before:
```
goos: darwin
goarch: arm64
pkg: rueidis-benchmark/single
Benchmark
Benchmark-10    	  372879	      3199 ns/op	       4 B/op	       1 allocs/op
PASS
```

After:
```
goos: darwin
goarch: arm64
pkg: rueidis-benchmark/single
Benchmark
Benchmark-10    	  380086	      3180 ns/op	       0 B/op	       0 allocs/op
PASS
```

```go
package main

import (
	"context"
	"strings"
	"testing"
	"github.com/redis/rueidis"
)

func Benchmark(b *testing.B) {
	client, err := rueidis.NewClient(rueidis.ClientOption{
		InitAddress:       []string{"127.0.0.1:6379"},
		PipelineMultiplex: -1,
	})
	if err != nil {
		panic(err)
	}
	key := strings.Repeat("k", 16)
	val := strings.Repeat("v", 64)
	b.ReportAllocs()
	b.ResetTimer()
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			if err := client.Do(context.Background(), client.B().Set().Key(key).Value(val).Build()).Error(); err != nil {
				panic(err)
			}
		}
	})
}
```