### PR TITLE
feat: always using Redis 7.2 CLIENT SETINFO command to set library name

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -78,6 +78,8 @@ func TestNewMux(t *testing.T) {
 			})
 		mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 			ReplyString("OK")
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("QUIT").ReplyString("OK")
 		mock.Close()
 	}()

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -145,6 +145,8 @@ func setup(t *testing.T, option ClientOption) (*pipe, *redisMock, func(), func()
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 		}
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 	}()
 	p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &option)
 	if err != nil {
@@ -271,6 +273,8 @@ func TestNewPipe(t *testing.T) {
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
 				ReplyString("OK")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 		}()
 		p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
 			SelectDB:   1,
@@ -301,6 +305,8 @@ func TestNewPipe(t *testing.T) {
 				})
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN", "NOLOOP").
 				ReplyString("OK")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 		}()
 		p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
 			ClientTrackingOptions: []string{"OPTIN", "NOLOOP"},
@@ -334,6 +340,8 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyError("ERR unknown command `HELLO`")
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyError("ERR unknown subcommand or wrong number of arguments for 'TRACKING'. Try CLIENT HELP")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("QUIT").ReplyString("OK")
 		}()
 		if _, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{}); !errors.Is(err, ErrNoCache) {
@@ -351,6 +359,8 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyError("ERR unknown command `HELLO`")
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("QUIT").ReplyString("OK")
 		}()
 		if _, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{}); !errors.Is(err, ErrNoCache) {
@@ -371,6 +381,8 @@ func TestNewRESP2Pipe(t *testing.T) {
 					{typ: '+', string: "proto"},
 					{typ: ':', integer: 2},
 				}})
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 		}()
 		p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
 			DisableCache: true,
@@ -395,12 +407,16 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyError("ERR unknown command `HELLO`")
 			mock.Expect("SELECT", "1").
 				ReplyError("ERR ACL")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("AUTH", "pa").
 				ReplyString("OK")
 			mock.Expect("CLIENT", "SETNAME", "cn").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
 				ReplyString("OK")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 		}()
 		p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
 			SelectDB:     1,
@@ -428,12 +444,16 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyError("ERR unknown command `HELLO`")
 			mock.Expect("SELECT", "1").
 				ReplyError("ERR ACL")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("AUTH", "ua", "pa").
 				ReplyString("OK")
 			mock.Expect("CLIENT", "SETNAME", "cn").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
 				ReplyString("OK")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 		}()
 		p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
 			SelectDB:     1,
@@ -462,6 +482,8 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyError("ERR unknown command `HELLO`")
 			mock.Expect("SELECT", "1").
 				ReplyError("ERR ACL")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
 			n1.Close()
 			n2.Close()
 		}()

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -76,6 +76,8 @@ func TestNewClusterClient(t *testing.T) {
 			return
 		}
 		slots, _ := slotsResp.ToMessage()
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(slots)
 		mock.Close()
 		close(done)
@@ -108,6 +110,8 @@ func TestNewClusterClientError(t *testing.T) {
 		if err != nil {
 			return
 		}
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "other error"})
 		mock.Expect("QUIT").ReplyString("OK")
 		mock.Close()
@@ -136,6 +140,8 @@ func TestFallBackSingleClient(t *testing.T) {
 		if err != nil {
 			return
 		}
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "ERR This instance has cluster support disabled"})
 		mock.Expect("QUIT").ReplyString("OK")
 		mock.Close()
@@ -169,13 +175,15 @@ func TestForceSingleClient(t *testing.T) {
 		if err != nil {
 			return
 		}
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("QUIT").ReplyString("OK")
 		mock.Close()
 		close(done)
 	}()
 	_, port, _ := net.SplitHostPort(ln.Addr().String())
 	client, err := NewClient(ClientOption{
-		InitAddress: []string{"127.0.0.1:" + port},
+		InitAddress:       []string{"127.0.0.1:" + port},
 		ForceSingleClient: true,
 	})
 	if err != nil {
@@ -247,6 +255,8 @@ func TestTLSClient(t *testing.T) {
 		if err != nil {
 			return
 		}
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "ERR This instance has cluster support disabled"})
 		mock.Expect("QUIT").ReplyString("OK")
 		mock.Close()


### PR DESCRIPTION
https://github.com/redis/go-redis/issues/2654#issuecomment-1651073598