### PR TITLE
perf: clear builder slices eagerly to help GC

### DIFF
--- a/internal/cmds/builder.go
+++ b/internal/cmds/builder.go
@@ -51,6 +51,9 @@ func get() *CommandSlice {
 }
 
 func Put(cs *CommandSlice) {
+	for i := range cs.s {
+		cs.s[i] = ""
+	}
 	cs.s = cs.s[:0]
 	cs.l = -1
 	cs.r = 0


### PR DESCRIPTION
Related to https://github.com/redis/rueidis/issues/312

Go 1.21 is not yet released. We can use the new `clear` function once it is released.