### PR TITLE
perf: recycle intermediate allocations in MGet/MSet helpers

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -6,18 +6,52 @@ import (
 	"time"
 
 	intl "github.com/redis/rueidis/internal/cmds"
+	"github.com/redis/rueidis/internal/util"
 )
+
+type mgetcachecmds struct {
+	s []CacheableTTL
+}
+
+func (r *mgetcachecmds) Capacity() int {
+	return cap(r.s)
+}
+
+func (r *mgetcachecmds) ResetLen(n int) {
+	r.s = r.s[:n]
+}
+
+var mgetcachecmdsp = util.NewPool(func(capacity int) *mgetcachecmds {
+	return &mgetcachecmds{s: make([]CacheableTTL, 0, capacity)}
+})
+
+type mgetcmds struct {
+	s []Completed
+}
+
+func (r *mgetcmds) Capacity() int {
+	return cap(r.s)
+}
+
+func (r *mgetcmds) ResetLen(n int) {
+	r.s = r.s[:n]
+}
+
+var mgetcmdsp = util.NewPool(func(capacity int) *mgetcmds {
+	return &mgetcmds{s: make([]Completed, 0, capacity)}
+})
 
 // MGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within same slot into multiple GETs
 func MGetCache(client Client, ctx context.Context, ttl time.Duration, keys []string) (ret map[string]RedisMessage, err error) {
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
-	cmds := make([]CacheableTTL, len(keys))
-	for i := range cmds {
-		cmds[i] = CT(client.B().Get().Key(keys[i]).Cache(), ttl)
+	cmds := mgetcachecmdsp.Get(len(keys), len(keys))
+	defer mgetcachecmdsp.Put(cmds)
+	for i := range cmds.s {
+		cmds.s[i] = CT(client.B().Get().Key(keys[i]).Cache(), ttl)
 	}
-	return doMultiCache(client, ctx, cmds, keys)
+	return doMultiCache(client, ctx, cmds.s, keys)
 }
 
 // MGet is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MGET or multiple GETs
@@ -25,16 +59,18 @@ func MGet(client Client, ctx context.Context, keys []string) (ret map[string]Red
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
+
 	switch client.(type) {
 	case *singleClient, *sentinelClient:
 		return clientMGet(client, ctx, client.B().Mget().Key(keys...).Build(), keys)
 	}
 
-	cmds := make([]Completed, len(keys))
-	for i := range cmds {
-		cmds[i] = client.B().Get().Key(keys[i]).Build()
+	cmds := mgetcmdsp.Get(len(keys), len(keys))
+	defer mgetcmdsp.Put(cmds)
+	for i := range cmds.s {
+		cmds.s[i] = client.B().Get().Key(keys[i]).Build()
 	}
-	return doMultiGet(client, ctx, cmds, keys)
+	return doMultiGet(client, ctx, cmds.s, keys)
 }
 
 // MSet is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MSETs or multiple SETs
@@ -48,13 +84,12 @@ func MSet(client Client, ctx context.Context, kvs map[string]string) map[string]
 		return clientMSet(client, ctx, "MSET", kvs, make(map[string]error, len(kvs)))
 	}
 
-	cmds := make([]Completed, 0, len(kvs))
-	keys := make([]string, 0, len(kvs))
+	cmds := mgetcmdsp.Get(0, len(kvs))
+	defer mgetcmdsp.Put(cmds)
 	for k, v := range kvs {
-		cmds = append(cmds, client.B().Set().Key(k).Value(v).Build())
-		keys = append(keys, k)
+		cmds.s = append(cmds.s, client.B().Set().Key(k).Value(v).Build().Pin())
 	}
-	return doMultiSet(client, ctx, cmds, keys)
+	return doMultiSet(client, ctx, cmds.s)
 }
 
 // MDel is a helper that consults the redis directly with multiple keys by grouping keys within same slot into DELs
@@ -68,11 +103,12 @@ func MDel(client Client, ctx context.Context, keys []string) map[string]error {
 		return clientMDel(client, ctx, keys)
 	}
 
-	cmds := make([]Completed, len(keys))
+	cmds := mgetcmdsp.Get(len(keys), len(keys))
+	defer mgetcmdsp.Put(cmds)
 	for i, k := range keys {
-		cmds[i] = client.B().Del().Key(k).Build()
+		cmds.s[i] = client.B().Del().Key(k).Build().Pin()
 	}
-	return doMultiSet(client, ctx, cmds, keys)
+	return doMultiSet(client, ctx, cmds.s)
 }
 
 // MSetNX is a helper that consults the redis directly with multiple keys by grouping keys within same slot into MSETNXs or multiple SETNXs
@@ -86,13 +122,12 @@ func MSetNX(client Client, ctx context.Context, kvs map[string]string) map[strin
 		return clientMSet(client, ctx, "MSETNX", kvs, make(map[string]error, len(kvs)))
 	}
 
-	cmds := make([]Completed, 0, len(kvs))
-	keys := make([]string, 0, len(kvs))
+	cmds := mgetcmdsp.Get(0, len(kvs))
+	defer mgetcmdsp.Put(cmds)
 	for k, v := range kvs {
-		cmds = append(cmds, client.B().Set().Key(k).Value(v).Nx().Build())
-		keys = append(keys, k)
+		cmds.s = append(cmds.s, client.B().Set().Key(k).Value(v).Nx().Build().Pin())
 	}
-	return doMultiSet(client, ctx, cmds, keys)
+	return doMultiSet(client, ctx, cmds.s)
 }
 
 // JsonMGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within same slot into multiple JSON.GETs
@@ -100,11 +135,12 @@ func JsonMGetCache(client Client, ctx context.Context, ttl time.Duration, keys [
 	if len(keys) == 0 {
 		return make(map[string]RedisMessage), nil
 	}
-	cmds := make([]CacheableTTL, len(keys))
-	for i := range cmds {
-		cmds[i] = CT(client.B().JsonGet().Key(keys[i]).Path(path).Cache(), ttl)
+	cmds := mgetcachecmdsp.Get(len(keys), len(keys))
+	defer mgetcachecmdsp.Put(cmds)
+	for i := range cmds.s {
+		cmds.s[i] = CT(client.B().JsonGet().Key(keys[i]).Path(path).Cache(), ttl)
 	}
-	return doMultiCache(client, ctx, cmds, keys)
+	return doMultiCache(client, ctx, cmds.s, keys)
 }
 
 // JsonMGet is a helper that consults redis directly with multiple keys by grouping keys within same slot into JSON.MGETs or multiple JSON.GETs
@@ -118,11 +154,12 @@ func JsonMGet(client Client, ctx context.Context, keys []string, path string) (r
 		return clientMGet(client, ctx, client.B().JsonMget().Key(keys...).Path(path).Build(), keys)
 	}
 
-	cmds := make([]Completed, len(keys))
-	for i := range cmds {
-		cmds[i] = client.B().JsonGet().Key(keys[i]).Path(path).Build()
+	cmds := mgetcmdsp.Get(len(keys), len(keys))
+	defer mgetcmdsp.Put(cmds)
+	for i := range cmds.s {
+		cmds.s[i] = client.B().JsonGet().Key(keys[i]).Path(path).Build()
 	}
-	return doMultiGet(client, ctx, cmds, keys)
+	return doMultiGet(client, ctx, cmds.s, keys)
 }
 
 // JsonMSet is a helper that consults redis directly with multiple keys by grouping keys within same slot into JSON.MSETs or multiple JOSN.SETs
@@ -136,13 +173,12 @@ func JsonMSet(client Client, ctx context.Context, kvs map[string]string, path st
 		return clientJSONMSet(client, ctx, kvs, path, make(map[string]error, len(kvs)))
 	}
 
-	cmds := make([]Completed, 0, len(kvs))
-	keys := make([]string, 0, len(kvs))
+	cmds := mgetcmdsp.Get(0, len(kvs))
+	defer mgetcmdsp.Put(cmds)
 	for k, v := range kvs {
-		cmds = append(cmds, client.B().JsonSet().Key(k).Path(path).Value(v).Build())
-		keys = append(keys, k)
+		cmds.s = append(cmds.s, client.B().JsonSet().Key(k).Path(path).Value(v).Build().Pin())
 	}
-	return doMultiSet(client, ctx, cmds, keys)
+	return doMultiSet(client, ctx, cmds.s)
 }
 
 func clientMGet(client Client, ctx context.Context, cmd Completed, keys []string) (ret map[string]RedisMessage, err error) {
@@ -215,11 +251,13 @@ func doMultiGet(cc Client, ctx context.Context, cmds []Completed, keys []string)
 	return ret, nil
 }
 
-func doMultiSet(cc Client, ctx context.Context, cmds []Completed, keys []string) (ret map[string]error) {
-	ret = make(map[string]error, len(keys))
+func doMultiSet(cc Client, ctx context.Context, cmds []Completed) (ret map[string]error) {
+	ret = make(map[string]error, len(cmds))
 	resps := cc.DoMulti(ctx, cmds...)
 	for i, resp := range resps {
-		ret[keys[i]] = resp.Error()
+		if ret[cmds[i].Commands()[1]] = resp.Error(); resp.NonRedisError() == nil {
+			intl.PutCompletedForce(cmds[i])
+		}
 	}
 	resultsp.Put(&redisresults{s: resps})
 	return ret

--- a/internal/cmds/builder.go
+++ b/internal/cmds/builder.go
@@ -50,6 +50,11 @@ func get() *CommandSlice {
 	return pool.Get().(*CommandSlice)
 }
 
+// PutCompletedForce recycles the Completed regardless of the c.cs.r
+func PutCompletedForce(c Completed) {
+	Put(c.cs)
+}
+
 // PutCompleted recycles the Completed
 func PutCompleted(c Completed) {
 	if c.cs.r == 0 {

--- a/internal/cmds/builder_test.go
+++ b/internal/cmds/builder_test.go
@@ -19,6 +19,21 @@ retry:
 	}
 }
 
+func TestPutCompletedForce(t *testing.T) {
+retry:
+	cs1 := get()
+	cs1.s = append(cs1.s, "1", "1", "1", "1", "1")
+	cs1.r = 1 // pin
+	PutCompletedForce(Completed{cs: cs1})
+	cs2 := get()
+	if cs1 != cs2 {
+		goto retry
+	}
+	if len(cs2.s) != 0 {
+		t.Fatalf("PutCompletedForce doesn't clean the CommandSlice")
+	}
+}
+
 func TestPutCacheable(t *testing.T) {
 retry:
 	cs1 := get()


### PR DESCRIPTION
Using the same benchmark of https://github.com/redis/rueidis/pull/287
```
▶ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: rueidis-benchmark/sep
                                    │   old.txt   │              new.txt               │
                                    │   sec/op    │   sec/op     vs base               │
/OneNode/128_RueidisDoMulti-10        41.34µ ± 0%   41.49µ ± 0%  +0.36% (p=0.005 n=10)
/OneNode/128_RueidisMGet-10           21.53µ ± 0%   20.86µ ± 0%  -3.10% (p=0.000 n=10)
/OneNode/128_RueidisMGetCache-10      10.81µ ± 1%   10.19µ ± 1%  -5.75% (p=0.000 n=10)
/OneNode/128_RueidisDoMultiCache-10   4.097µ ± 1%   4.078µ ± 1%       ~ (p=0.137 n=10)
/Cluster/128_RueidisDoMulti-10        30.50µ ± 4%   29.52µ ± 3%       ~ (p=0.075 n=10)
/Cluster/128_RueidisMGet-10           34.63µ ± 4%   33.94µ ± 1%       ~ (p=0.123 n=10)
/Cluster/128_RueidisMGetCache-10      9.207µ ± 2%   9.209µ ± 1%       ~ (p=0.971 n=10)
/Cluster/128_RueidisDoMultiCache-10   4.291µ ± 1%   4.363µ ± 1%  +1.68% (p=0.000 n=10)
geomean                               14.19µ        13.97µ       -1.58%

                                    │   old.txt    │               new.txt                │
                                    │     B/op     │     B/op      vs base                │
/OneNode/128_RueidisDoMulti-10        18.17Ki ± 0%   18.17Ki ± 0%        ~ (p=0.974 n=10)
/OneNode/128_RueidisMGet-10           40.23Ki ± 0%   40.23Ki ± 0%   -0.01% (p=0.003 n=10)
/OneNode/128_RueidisMGetCache-10      30.29Ki ± 1%   26.62Ki ± 0%  -12.11% (p=0.000 n=10)
/OneNode/128_RueidisDoMultiCache-10   11.20Ki ± 1%   11.02Ki ± 0%   -1.54% (p=0.000 n=10)
/Cluster/128_RueidisDoMulti-10        18.65Ki ± 0%   18.58Ki ± 0%        ~ (p=0.075 n=10)
/Cluster/128_RueidisMGet-10           35.10Ki ± 0%   33.16Ki ± 0%   -5.52% (p=0.000 n=10)
/Cluster/128_RueidisMGetCache-10      29.53Ki ± 1%   26.34Ki ± 1%  -10.82% (p=0.000 n=10)
/Cluster/128_RueidisDoMultiCache-10   11.24Ki ± 1%   10.95Ki ± 1%   -2.61% (p=0.000 n=10)
geomean                               21.95Ki        21.02Ki        -4.24%

                                    │   old.txt    │               new.txt                │
                                    │  allocs/op   │ allocs/op   vs base                  │
/OneNode/128_RueidisDoMulti-10         130.0 ±  0%   130.0 ± 0%        ~ (p=1.000 n=10) ¹
/OneNode/128_RueidisMGet-10            132.0 ±  0%   132.0 ± 0%        ~ (p=1.000 n=10) ¹
/OneNode/128_RueidisMGetCache-10       14.00 ±  0%   12.00 ± 0%  -14.29% (p=0.000 n=10)
/OneNode/128_RueidisDoMultiCache-10   10.000 ± 10%   9.000 ± 0%  -10.00% (p=0.005 n=10)
/Cluster/128_RueidisDoMulti-10         135.0 ±  0%   135.0 ± 0%        ~ (p=1.000 n=10) ¹
/Cluster/128_RueidisMGet-10            138.0 ±  0%   137.0 ± 0%   -0.72% (p=0.000 n=10)
/Cluster/128_RueidisMGetCache-10       14.00 ±  0%   13.00 ± 0%   -7.14% (p=0.000 n=10)
/Cluster/128_RueidisDoMultiCache-10    10.00 ±  0%   10.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                39.78         38.12        -4.17%
¹ all samples are equal
```