### PR TITLE
Set readonly flag for FT.SEARCH command

### DIFF
--- a/internal/cmds/gen_search.go
+++ b/internal/cmds/gen_search.go
@@ -3841,7 +3841,7 @@ func (c FtProfileQuerytypeSearch) Query(query string) FtProfileQuery {
 type FtSearch Completed
 
 func (b Builder) FtSearch() (c FtSearch) {
-	c = FtSearch{cs: get(), ks: b.ks}
+	c = FtSearch{cs: get(), ks: b.ks, cf: readonly}
 	c.cs.s = append(c.cs.s, "FT.SEARCH")
 	return c
 }


### PR DESCRIPTION
I tried to use a redis cluster with DoMulti of FT.SEARCH commands and found that it's not marked as a readonly command.
I made sure that redis treats it as readonly with `COMMAND INFO FT.SEARCH`.