### PR TITLE
feat: add ReplicaOnly support for cluster client

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,6 +20,10 @@ func newSingleClient(opt *ClientOption, prev conn, connFn connFn) (*singleClient
 		return nil, ErrNoAddr
 	}
 
+	if opt.ReplicaOnly {
+		return nil, ErrReplicaOnlyNotSupported
+	}
+
 	conn := connFn(opt.InitAddress[0], opt)
 	conn.Override(prev)
 	if err := conn.Dial(); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -167,6 +167,15 @@ func TestNewSingleClientNoNode(t *testing.T) {
 	}
 }
 
+func TestNewSingleClientReplicaOnlyNotSupported(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	if _, err := newSingleClient(&ClientOption{ReplicaOnly: true, InitAddress: []string{"localhost"}}, nil, func(dst string, opt *ClientOption) conn {
+		return nil
+	}); err != ErrReplicaOnlyNotSupported {
+		t.Fatalf("unexpected err %v", err)
+	}
+}
+
 func TestNewSingleClientError(t *testing.T) {
 	v := errors.New("dail err")
 	if _, err := newSingleClient(&ClientOption{InitAddress: []string{""}}, nil, func(dst string, opt *ClientOption) conn {


### PR DESCRIPTION
added ReplicaOnly support for cluster client. 

tested with a cluster with two shards, 3 nodes each.

@rueian could you let me know if this implementation makes sense? I'll add tests later