### PR TITLE
feat: rueidis.Incomplete represents an incomplete Redis command

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -5,6 +5,9 @@ import "github.com/redis/rueidis/internal/cmds"
 // Builder represents a command builder. It should only be created from the client.B() method.
 type Builder = cmds.Builder
 
+// Incomplete represents an incomplete Redis command. It should then be completed by calling the Build().
+type Incomplete = cmds.Incomplete
+
 // Completed represents a completed Redis command. It should only be created from the Build() of a command builder.
 type Completed = cmds.Completed
 

--- a/hack/cmds/gen.go
+++ b/hack/cmds/gen.go
@@ -568,7 +568,7 @@ func generate(f io.Writer, structs map[string]goStruct) {
 	for _, name := range names {
 		s := structs[name]
 
-		fmt.Fprintf(f, "type %s Completed\n\n", s.FullName)
+		fmt.Fprintf(f, "type %s Incomplete\n\n", s.FullName)
 
 		if s.Node.Root {
 			printRootBuilder(f, s)
@@ -666,7 +666,7 @@ func printRootBuilder(w io.Writer, root goStruct) {
 	}
 
 	if tag := rootCf(root); tag != "" {
-		fmt.Fprintf(w, "\tc = %s{cs: get(), ks: b.ks, cf: %s}\n", root.FullName, tag)
+		fmt.Fprintf(w, "\tc = %s{cs: get(), ks: b.ks, cf: int16(%s)}\n", root.FullName, tag)
 	} else {
 		fmt.Fprintf(w, "\tc = %s{cs: get(), ks: b.ks}\n", root.FullName)
 	}
@@ -714,7 +714,7 @@ func rootCf(root goStruct) (tag string) {
 func printFinalBuilder(w io.Writer, parent goStruct, method, ss string) {
 	fmt.Fprintf(w, "func (c %s) %s() %s {\n", parent.FullName, method, ss)
 	fmt.Fprintf(w, "\tc.cs.Build()\n")
-	fmt.Fprintf(w, "\treturn %s(c)\n", ss)
+	fmt.Fprintf(w, "\treturn %s{cs: c.cs, cf: uint16(c.cf), ks: c.ks}\n", ss)
 	fmt.Fprintf(w, "}\n\n")
 }
 
@@ -766,7 +766,7 @@ func printBuilder(w io.Writer, parent, next goStruct) {
 
 	for _, cmd := range next.BuildDef.Command {
 		if cmd == "BLOCK" {
-			fmt.Fprintf(w, "\tc.cf = blockTag\n")
+			fmt.Fprintf(w, "\tc.cf = int16(blockTag)\n")
 			break
 		}
 	}

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -81,6 +81,13 @@ func ToBlock(c *Completed) {
 	c.cf |= blockTag
 }
 
+// Incomplete represents an incomplete Redis command. It should then be completed by calling the Build().
+type Incomplete struct {
+	cs *CommandSlice
+	cf int16 // use int16 instead of uint16 to make a difference with Completed
+	ks uint16
+}
+
 // Completed represents a completed Redis command, should be created by the Build() of command builder.
 type Completed struct {
 	cs *CommandSlice

--- a/internal/cmds/gen_bf.go
+++ b/internal/cmds/gen_bf.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type BfAdd Completed
+type BfAdd Incomplete
 
 func (b Builder) BfAdd() (c BfAdd) {
 	c = BfAdd{cs: get(), ks: b.ks}
@@ -22,21 +22,21 @@ func (c BfAdd) Key(key string) BfAddKey {
 	return (BfAddKey)(c)
 }
 
-type BfAddItem Completed
+type BfAddItem Incomplete
 
 func (c BfAddItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfAddKey Completed
+type BfAddKey Incomplete
 
 func (c BfAddKey) Item(item string) BfAddItem {
 	c.cs.s = append(c.cs.s, item)
 	return (BfAddItem)(c)
 }
 
-type BfCard Completed
+type BfCard Incomplete
 
 func (b Builder) BfCard() (c BfCard) {
 	c = BfCard{cs: get(), ks: b.ks}
@@ -54,17 +54,17 @@ func (c BfCard) Key(key string) BfCardKey {
 	return (BfCardKey)(c)
 }
 
-type BfCardKey Completed
+type BfCardKey Incomplete
 
 func (c BfCardKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfExists Completed
+type BfExists Incomplete
 
 func (b Builder) BfExists() (c BfExists) {
-	c = BfExists{cs: get(), ks: b.ks, cf: readonly}
+	c = BfExists{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BF.EXISTS")
 	return c
 }
@@ -79,29 +79,29 @@ func (c BfExists) Key(key string) BfExistsKey {
 	return (BfExistsKey)(c)
 }
 
-type BfExistsItem Completed
+type BfExistsItem Incomplete
 
 func (c BfExistsItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfExistsItem) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfExistsKey Completed
+type BfExistsKey Incomplete
 
 func (c BfExistsKey) Item(item string) BfExistsItem {
 	c.cs.s = append(c.cs.s, item)
 	return (BfExistsItem)(c)
 }
 
-type BfInfo Completed
+type BfInfo Incomplete
 
 func (b Builder) BfInfo() (c BfInfo) {
-	c = BfInfo{cs: get(), ks: b.ks, cf: readonly}
+	c = BfInfo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BF.INFO")
 	return c
 }
@@ -116,7 +116,7 @@ func (c BfInfo) Key(key string) BfInfoKey {
 	return (BfInfoKey)(c)
 }
 
-type BfInfoKey Completed
+type BfInfoKey Incomplete
 
 func (c BfInfoKey) Capacity() BfInfoSingleValueCapacity {
 	c.cs.s = append(c.cs.s, "CAPACITY")
@@ -145,75 +145,75 @@ func (c BfInfoKey) Expansion() BfInfoSingleValueExpansion {
 
 func (c BfInfoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfInfoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInfoSingleValueCapacity Completed
+type BfInfoSingleValueCapacity Incomplete
 
 func (c BfInfoSingleValueCapacity) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfInfoSingleValueCapacity) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInfoSingleValueExpansion Completed
+type BfInfoSingleValueExpansion Incomplete
 
 func (c BfInfoSingleValueExpansion) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfInfoSingleValueExpansion) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInfoSingleValueFilters Completed
+type BfInfoSingleValueFilters Incomplete
 
 func (c BfInfoSingleValueFilters) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfInfoSingleValueFilters) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInfoSingleValueItems Completed
+type BfInfoSingleValueItems Incomplete
 
 func (c BfInfoSingleValueItems) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfInfoSingleValueItems) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInfoSingleValueSize Completed
+type BfInfoSingleValueSize Incomplete
 
 func (c BfInfoSingleValueSize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BfInfoSingleValueSize) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInsert Completed
+type BfInsert Incomplete
 
 func (b Builder) BfInsert() (c BfInsert) {
 	c = BfInsert{cs: get(), ks: b.ks}
@@ -231,7 +231,7 @@ func (c BfInsert) Key(key string) BfInsertKey {
 	return (BfInsertKey)(c)
 }
 
-type BfInsertCapacity Completed
+type BfInsertCapacity Incomplete
 
 func (c BfInsertCapacity) Error(error float64) BfInsertError {
 	c.cs.s = append(c.cs.s, "ERROR", strconv.FormatFloat(error, 'f', -1, 64))
@@ -258,7 +258,7 @@ func (c BfInsertCapacity) Items() BfInsertItems {
 	return (BfInsertItems)(c)
 }
 
-type BfInsertError Completed
+type BfInsertError Incomplete
 
 func (c BfInsertError) Expansion(expansion int64) BfInsertExpansion {
 	c.cs.s = append(c.cs.s, "EXPANSION", strconv.FormatInt(expansion, 10))
@@ -280,7 +280,7 @@ func (c BfInsertError) Items() BfInsertItems {
 	return (BfInsertItems)(c)
 }
 
-type BfInsertExpansion Completed
+type BfInsertExpansion Incomplete
 
 func (c BfInsertExpansion) Nocreate() BfInsertNocreate {
 	c.cs.s = append(c.cs.s, "NOCREATE")
@@ -297,7 +297,7 @@ func (c BfInsertExpansion) Items() BfInsertItems {
 	return (BfInsertItems)(c)
 }
 
-type BfInsertItem Completed
+type BfInsertItem Incomplete
 
 func (c BfInsertItem) Item(item ...string) BfInsertItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -306,17 +306,17 @@ func (c BfInsertItem) Item(item ...string) BfInsertItem {
 
 func (c BfInsertItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfInsertItems Completed
+type BfInsertItems Incomplete
 
 func (c BfInsertItems) Item(item ...string) BfInsertItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (BfInsertItem)(c)
 }
 
-type BfInsertKey Completed
+type BfInsertKey Incomplete
 
 func (c BfInsertKey) Capacity(capacity int64) BfInsertCapacity {
 	c.cs.s = append(c.cs.s, "CAPACITY", strconv.FormatInt(capacity, 10))
@@ -348,7 +348,7 @@ func (c BfInsertKey) Items() BfInsertItems {
 	return (BfInsertItems)(c)
 }
 
-type BfInsertNocreate Completed
+type BfInsertNocreate Incomplete
 
 func (c BfInsertNocreate) Nonscaling() BfInsertNonscaling {
 	c.cs.s = append(c.cs.s, "NONSCALING")
@@ -360,14 +360,14 @@ func (c BfInsertNocreate) Items() BfInsertItems {
 	return (BfInsertItems)(c)
 }
 
-type BfInsertNonscaling Completed
+type BfInsertNonscaling Incomplete
 
 func (c BfInsertNonscaling) Items() BfInsertItems {
 	c.cs.s = append(c.cs.s, "ITEMS")
 	return (BfInsertItems)(c)
 }
 
-type BfLoadchunk Completed
+type BfLoadchunk Incomplete
 
 func (b Builder) BfLoadchunk() (c BfLoadchunk) {
 	c = BfLoadchunk{cs: get(), ks: b.ks}
@@ -385,28 +385,28 @@ func (c BfLoadchunk) Key(key string) BfLoadchunkKey {
 	return (BfLoadchunkKey)(c)
 }
 
-type BfLoadchunkData Completed
+type BfLoadchunkData Incomplete
 
 func (c BfLoadchunkData) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfLoadchunkIterator Completed
+type BfLoadchunkIterator Incomplete
 
 func (c BfLoadchunkIterator) Data(data string) BfLoadchunkData {
 	c.cs.s = append(c.cs.s, data)
 	return (BfLoadchunkData)(c)
 }
 
-type BfLoadchunkKey Completed
+type BfLoadchunkKey Incomplete
 
 func (c BfLoadchunkKey) Iterator(iterator int64) BfLoadchunkIterator {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(iterator, 10))
 	return (BfLoadchunkIterator)(c)
 }
 
-type BfMadd Completed
+type BfMadd Incomplete
 
 func (b Builder) BfMadd() (c BfMadd) {
 	c = BfMadd{cs: get(), ks: b.ks}
@@ -424,7 +424,7 @@ func (c BfMadd) Key(key string) BfMaddKey {
 	return (BfMaddKey)(c)
 }
 
-type BfMaddItem Completed
+type BfMaddItem Incomplete
 
 func (c BfMaddItem) Item(item ...string) BfMaddItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -433,20 +433,20 @@ func (c BfMaddItem) Item(item ...string) BfMaddItem {
 
 func (c BfMaddItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfMaddKey Completed
+type BfMaddKey Incomplete
 
 func (c BfMaddKey) Item(item ...string) BfMaddItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (BfMaddItem)(c)
 }
 
-type BfMexists Completed
+type BfMexists Incomplete
 
 func (b Builder) BfMexists() (c BfMexists) {
-	c = BfMexists{cs: get(), ks: b.ks, cf: readonly}
+	c = BfMexists{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BF.MEXISTS")
 	return c
 }
@@ -461,7 +461,7 @@ func (c BfMexists) Key(key string) BfMexistsKey {
 	return (BfMexistsKey)(c)
 }
 
-type BfMexistsItem Completed
+type BfMexistsItem Incomplete
 
 func (c BfMexistsItem) Item(item ...string) BfMexistsItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -470,17 +470,17 @@ func (c BfMexistsItem) Item(item ...string) BfMexistsItem {
 
 func (c BfMexistsItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfMexistsKey Completed
+type BfMexistsKey Incomplete
 
 func (c BfMexistsKey) Item(item ...string) BfMexistsItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (BfMexistsItem)(c)
 }
 
-type BfReserve Completed
+type BfReserve Incomplete
 
 func (b Builder) BfReserve() (c BfReserve) {
 	c = BfReserve{cs: get(), ks: b.ks}
@@ -498,7 +498,7 @@ func (c BfReserve) Key(key string) BfReserveKey {
 	return (BfReserveKey)(c)
 }
 
-type BfReserveCapacity Completed
+type BfReserveCapacity Incomplete
 
 func (c BfReserveCapacity) Expansion(expansion int64) BfReserveExpansion {
 	c.cs.s = append(c.cs.s, "EXPANSION", strconv.FormatInt(expansion, 10))
@@ -512,17 +512,17 @@ func (c BfReserveCapacity) Nonscaling() BfReserveNonscaling {
 
 func (c BfReserveCapacity) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfReserveErrorRate Completed
+type BfReserveErrorRate Incomplete
 
 func (c BfReserveErrorRate) Capacity(capacity int64) BfReserveCapacity {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(capacity, 10))
 	return (BfReserveCapacity)(c)
 }
 
-type BfReserveExpansion Completed
+type BfReserveExpansion Incomplete
 
 func (c BfReserveExpansion) Nonscaling() BfReserveNonscaling {
 	c.cs.s = append(c.cs.s, "NONSCALING")
@@ -531,27 +531,27 @@ func (c BfReserveExpansion) Nonscaling() BfReserveNonscaling {
 
 func (c BfReserveExpansion) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfReserveKey Completed
+type BfReserveKey Incomplete
 
 func (c BfReserveKey) ErrorRate(errorRate float64) BfReserveErrorRate {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(errorRate, 'f', -1, 64))
 	return (BfReserveErrorRate)(c)
 }
 
-type BfReserveNonscaling Completed
+type BfReserveNonscaling Incomplete
 
 func (c BfReserveNonscaling) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfScandump Completed
+type BfScandump Incomplete
 
 func (b Builder) BfScandump() (c BfScandump) {
-	c = BfScandump{cs: get(), ks: b.ks, cf: readonly}
+	c = BfScandump{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BF.SCANDUMP")
 	return c
 }
@@ -566,14 +566,14 @@ func (c BfScandump) Key(key string) BfScandumpKey {
 	return (BfScandumpKey)(c)
 }
 
-type BfScandumpIterator Completed
+type BfScandumpIterator Incomplete
 
 func (c BfScandumpIterator) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BfScandumpKey Completed
+type BfScandumpKey Incomplete
 
 func (c BfScandumpKey) Iterator(iterator int64) BfScandumpIterator {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(iterator, 10))

--- a/internal/cmds/gen_bitmap.go
+++ b/internal/cmds/gen_bitmap.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type Bitcount Completed
+type Bitcount Incomplete
 
 func (b Builder) Bitcount() (c Bitcount) {
-	c = Bitcount{cs: get(), ks: b.ks, cf: readonly}
+	c = Bitcount{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BITCOUNT")
 	return c
 }
@@ -22,7 +22,7 @@ func (c Bitcount) Key(key string) BitcountKey {
 	return (BitcountKey)(c)
 }
 
-type BitcountIndexEnd Completed
+type BitcountIndexEnd Incomplete
 
 func (c BitcountIndexEnd) Byte() BitcountIndexIndexUnitByte {
 	c.cs.s = append(c.cs.s, "BYTE")
@@ -36,46 +36,46 @@ func (c BitcountIndexEnd) Bit() BitcountIndexIndexUnitBit {
 
 func (c BitcountIndexEnd) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitcountIndexEnd) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitcountIndexIndexUnitBit Completed
+type BitcountIndexIndexUnitBit Incomplete
 
 func (c BitcountIndexIndexUnitBit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitcountIndexIndexUnitBit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitcountIndexIndexUnitByte Completed
+type BitcountIndexIndexUnitByte Incomplete
 
 func (c BitcountIndexIndexUnitByte) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitcountIndexIndexUnitByte) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitcountIndexStart Completed
+type BitcountIndexStart Incomplete
 
 func (c BitcountIndexStart) End(end int64) BitcountIndexEnd {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(end, 10))
 	return (BitcountIndexEnd)(c)
 }
 
-type BitcountKey Completed
+type BitcountKey Incomplete
 
 func (c BitcountKey) Start(start int64) BitcountIndexStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
@@ -84,15 +84,15 @@ func (c BitcountKey) Start(start int64) BitcountIndexStart {
 
 func (c BitcountKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitcountKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Bitfield Completed
+type Bitfield Incomplete
 
 func (b Builder) Bitfield() (c Bitfield) {
 	c = Bitfield{cs: get(), ks: b.ks}
@@ -110,7 +110,7 @@ func (c Bitfield) Key(key string) BitfieldKey {
 	return (BitfieldKey)(c)
 }
 
-type BitfieldKey Completed
+type BitfieldKey Incomplete
 
 func (c BitfieldKey) Get(encoding string, offset int64) BitfieldOperationGet {
 	c.cs.s = append(c.cs.s, "GET", encoding, strconv.FormatInt(offset, 10))
@@ -144,10 +144,10 @@ func (c BitfieldKey) Incrby(encoding string, offset int64, increment int64) Bitf
 
 func (c BitfieldKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitfieldOperationGet Completed
+type BitfieldOperationGet Incomplete
 
 func (c BitfieldOperationGet) OverflowWrap() BitfieldOperationWriteOverflowWrap {
 	c.cs.s = append(c.cs.s, "OVERFLOW", "WRAP")
@@ -174,7 +174,7 @@ func (c BitfieldOperationGet) Incrby(encoding string, offset int64, increment in
 	return (BitfieldOperationWriteSetIncrby)(c)
 }
 
-type BitfieldOperationWriteOverflowFail Completed
+type BitfieldOperationWriteOverflowFail Incomplete
 
 func (c BitfieldOperationWriteOverflowFail) Set(encoding string, offset int64, value int64) BitfieldOperationWriteSetSet {
 	c.cs.s = append(c.cs.s, "SET", encoding, strconv.FormatInt(offset, 10), strconv.FormatInt(value, 10))
@@ -186,7 +186,7 @@ func (c BitfieldOperationWriteOverflowFail) Incrby(encoding string, offset int64
 	return (BitfieldOperationWriteSetIncrby)(c)
 }
 
-type BitfieldOperationWriteOverflowSat Completed
+type BitfieldOperationWriteOverflowSat Incomplete
 
 func (c BitfieldOperationWriteOverflowSat) Set(encoding string, offset int64, value int64) BitfieldOperationWriteSetSet {
 	c.cs.s = append(c.cs.s, "SET", encoding, strconv.FormatInt(offset, 10), strconv.FormatInt(value, 10))
@@ -198,7 +198,7 @@ func (c BitfieldOperationWriteOverflowSat) Incrby(encoding string, offset int64,
 	return (BitfieldOperationWriteSetIncrby)(c)
 }
 
-type BitfieldOperationWriteOverflowWrap Completed
+type BitfieldOperationWriteOverflowWrap Incomplete
 
 func (c BitfieldOperationWriteOverflowWrap) Set(encoding string, offset int64, value int64) BitfieldOperationWriteSetSet {
 	c.cs.s = append(c.cs.s, "SET", encoding, strconv.FormatInt(offset, 10), strconv.FormatInt(value, 10))
@@ -210,7 +210,7 @@ func (c BitfieldOperationWriteOverflowWrap) Incrby(encoding string, offset int64
 	return (BitfieldOperationWriteSetIncrby)(c)
 }
 
-type BitfieldOperationWriteSetIncrby Completed
+type BitfieldOperationWriteSetIncrby Incomplete
 
 func (c BitfieldOperationWriteSetIncrby) Get(encoding string, offset int64) BitfieldOperationGet {
 	c.cs.s = append(c.cs.s, "GET", encoding, strconv.FormatInt(offset, 10))
@@ -244,10 +244,10 @@ func (c BitfieldOperationWriteSetIncrby) Incrby(encoding string, offset int64, i
 
 func (c BitfieldOperationWriteSetIncrby) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitfieldOperationWriteSetSet Completed
+type BitfieldOperationWriteSetSet Incomplete
 
 func (c BitfieldOperationWriteSetSet) Incrby(encoding string, offset int64, increment int64) BitfieldOperationWriteSetIncrby {
 	c.cs.s = append(c.cs.s, "INCRBY", encoding, strconv.FormatInt(offset, 10), strconv.FormatInt(increment, 10))
@@ -281,13 +281,13 @@ func (c BitfieldOperationWriteSetSet) Set(encoding string, offset int64, value i
 
 func (c BitfieldOperationWriteSetSet) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitfieldRo Completed
+type BitfieldRo Incomplete
 
 func (b Builder) BitfieldRo() (c BitfieldRo) {
-	c = BitfieldRo{cs: get(), ks: b.ks, cf: readonly}
+	c = BitfieldRo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BITFIELD_RO")
 	return c
 }
@@ -302,7 +302,7 @@ func (c BitfieldRo) Key(key string) BitfieldRoKey {
 	return (BitfieldRoKey)(c)
 }
 
-type BitfieldRoGet Completed
+type BitfieldRoGet Incomplete
 
 func (c BitfieldRoGet) Get(encoding string, offset int64) BitfieldRoGet {
 	c.cs.s = append(c.cs.s, "GET", encoding, strconv.FormatInt(offset, 10))
@@ -311,15 +311,15 @@ func (c BitfieldRoGet) Get(encoding string, offset int64) BitfieldRoGet {
 
 func (c BitfieldRoGet) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitfieldRoGet) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitfieldRoKey Completed
+type BitfieldRoKey Incomplete
 
 func (c BitfieldRoKey) Get() BitfieldRoGet {
 	return (BitfieldRoGet)(c)
@@ -327,15 +327,15 @@ func (c BitfieldRoKey) Get() BitfieldRoGet {
 
 func (c BitfieldRoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitfieldRoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Bitop Completed
+type Bitop Incomplete
 
 func (b Builder) Bitop() (c Bitop) {
 	c = Bitop{cs: get(), ks: b.ks}
@@ -363,7 +363,7 @@ func (c Bitop) Not() BitopOperationNot {
 	return (BitopOperationNot)(c)
 }
 
-type BitopDestkey Completed
+type BitopDestkey Incomplete
 
 func (c BitopDestkey) Key(key ...string) BitopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -380,7 +380,7 @@ func (c BitopDestkey) Key(key ...string) BitopKey {
 	return (BitopKey)(c)
 }
 
-type BitopKey Completed
+type BitopKey Incomplete
 
 func (c BitopKey) Key(key ...string) BitopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -399,10 +399,10 @@ func (c BitopKey) Key(key ...string) BitopKey {
 
 func (c BitopKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitopOperationAnd Completed
+type BitopOperationAnd Incomplete
 
 func (c BitopOperationAnd) Destkey(destkey string) BitopDestkey {
 	if c.ks&NoSlot == NoSlot {
@@ -414,7 +414,7 @@ func (c BitopOperationAnd) Destkey(destkey string) BitopDestkey {
 	return (BitopDestkey)(c)
 }
 
-type BitopOperationNot Completed
+type BitopOperationNot Incomplete
 
 func (c BitopOperationNot) Destkey(destkey string) BitopDestkey {
 	if c.ks&NoSlot == NoSlot {
@@ -426,7 +426,7 @@ func (c BitopOperationNot) Destkey(destkey string) BitopDestkey {
 	return (BitopDestkey)(c)
 }
 
-type BitopOperationOr Completed
+type BitopOperationOr Incomplete
 
 func (c BitopOperationOr) Destkey(destkey string) BitopDestkey {
 	if c.ks&NoSlot == NoSlot {
@@ -438,7 +438,7 @@ func (c BitopOperationOr) Destkey(destkey string) BitopDestkey {
 	return (BitopDestkey)(c)
 }
 
-type BitopOperationXor Completed
+type BitopOperationXor Incomplete
 
 func (c BitopOperationXor) Destkey(destkey string) BitopDestkey {
 	if c.ks&NoSlot == NoSlot {
@@ -450,10 +450,10 @@ func (c BitopOperationXor) Destkey(destkey string) BitopDestkey {
 	return (BitopDestkey)(c)
 }
 
-type Bitpos Completed
+type Bitpos Incomplete
 
 func (b Builder) Bitpos() (c Bitpos) {
-	c = Bitpos{cs: get(), ks: b.ks, cf: readonly}
+	c = Bitpos{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "BITPOS")
 	return c
 }
@@ -468,7 +468,7 @@ func (c Bitpos) Key(key string) BitposKey {
 	return (BitposKey)(c)
 }
 
-type BitposBit Completed
+type BitposBit Incomplete
 
 func (c BitposBit) Start(start int64) BitposIndexStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
@@ -477,15 +477,15 @@ func (c BitposBit) Start(start int64) BitposIndexStart {
 
 func (c BitposBit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitposBit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitposIndexEndIndexEnd Completed
+type BitposIndexEndIndexEnd Incomplete
 
 func (c BitposIndexEndIndexEnd) Byte() BitposIndexEndIndexIndexUnitByte {
 	c.cs.s = append(c.cs.s, "BYTE")
@@ -499,39 +499,39 @@ func (c BitposIndexEndIndexEnd) Bit() BitposIndexEndIndexIndexUnitBit {
 
 func (c BitposIndexEndIndexEnd) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitposIndexEndIndexEnd) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitposIndexEndIndexIndexUnitBit Completed
+type BitposIndexEndIndexIndexUnitBit Incomplete
 
 func (c BitposIndexEndIndexIndexUnitBit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitposIndexEndIndexIndexUnitBit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitposIndexEndIndexIndexUnitByte Completed
+type BitposIndexEndIndexIndexUnitByte Incomplete
 
 func (c BitposIndexEndIndexIndexUnitByte) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitposIndexEndIndexIndexUnitByte) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitposIndexStart Completed
+type BitposIndexStart Incomplete
 
 func (c BitposIndexStart) End(end int64) BitposIndexEndIndexEnd {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(end, 10))
@@ -540,25 +540,25 @@ func (c BitposIndexStart) End(end int64) BitposIndexEndIndexEnd {
 
 func (c BitposIndexStart) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c BitposIndexStart) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BitposKey Completed
+type BitposKey Incomplete
 
 func (c BitposKey) Bit(bit int64) BitposBit {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bit, 10))
 	return (BitposBit)(c)
 }
 
-type Getbit Completed
+type Getbit Incomplete
 
 func (b Builder) Getbit() (c Getbit) {
-	c = Getbit{cs: get(), ks: b.ks, cf: readonly}
+	c = Getbit{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GETBIT")
 	return c
 }
@@ -573,26 +573,26 @@ func (c Getbit) Key(key string) GetbitKey {
 	return (GetbitKey)(c)
 }
 
-type GetbitKey Completed
+type GetbitKey Incomplete
 
 func (c GetbitKey) Offset(offset int64) GetbitOffset {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(offset, 10))
 	return (GetbitOffset)(c)
 }
 
-type GetbitOffset Completed
+type GetbitOffset Incomplete
 
 func (c GetbitOffset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GetbitOffset) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Setbit Completed
+type Setbit Incomplete
 
 func (b Builder) Setbit() (c Setbit) {
 	c = Setbit{cs: get(), ks: b.ks}
@@ -610,23 +610,23 @@ func (c Setbit) Key(key string) SetbitKey {
 	return (SetbitKey)(c)
 }
 
-type SetbitKey Completed
+type SetbitKey Incomplete
 
 func (c SetbitKey) Offset(offset int64) SetbitOffset {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(offset, 10))
 	return (SetbitOffset)(c)
 }
 
-type SetbitOffset Completed
+type SetbitOffset Incomplete
 
 func (c SetbitOffset) Value(value int64) SetbitValue {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(value, 10))
 	return (SetbitValue)(c)
 }
 
-type SetbitValue Completed
+type SetbitValue Incomplete
 
 func (c SetbitValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_cf.go
+++ b/internal/cmds/gen_cf.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type CfAdd Completed
+type CfAdd Incomplete
 
 func (b Builder) CfAdd() (c CfAdd) {
 	c = CfAdd{cs: get(), ks: b.ks}
@@ -22,21 +22,21 @@ func (c CfAdd) Key(key string) CfAddKey {
 	return (CfAddKey)(c)
 }
 
-type CfAddItem Completed
+type CfAddItem Incomplete
 
 func (c CfAddItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfAddKey Completed
+type CfAddKey Incomplete
 
 func (c CfAddKey) Item(item string) CfAddItem {
 	c.cs.s = append(c.cs.s, item)
 	return (CfAddItem)(c)
 }
 
-type CfAddnx Completed
+type CfAddnx Incomplete
 
 func (b Builder) CfAddnx() (c CfAddnx) {
 	c = CfAddnx{cs: get(), ks: b.ks}
@@ -54,24 +54,24 @@ func (c CfAddnx) Key(key string) CfAddnxKey {
 	return (CfAddnxKey)(c)
 }
 
-type CfAddnxItem Completed
+type CfAddnxItem Incomplete
 
 func (c CfAddnxItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfAddnxKey Completed
+type CfAddnxKey Incomplete
 
 func (c CfAddnxKey) Item(item string) CfAddnxItem {
 	c.cs.s = append(c.cs.s, item)
 	return (CfAddnxItem)(c)
 }
 
-type CfCount Completed
+type CfCount Incomplete
 
 func (b Builder) CfCount() (c CfCount) {
-	c = CfCount{cs: get(), ks: b.ks, cf: readonly}
+	c = CfCount{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "CF.COUNT")
 	return c
 }
@@ -86,26 +86,26 @@ func (c CfCount) Key(key string) CfCountKey {
 	return (CfCountKey)(c)
 }
 
-type CfCountItem Completed
+type CfCountItem Incomplete
 
 func (c CfCountItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c CfCountItem) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfCountKey Completed
+type CfCountKey Incomplete
 
 func (c CfCountKey) Item(item string) CfCountItem {
 	c.cs.s = append(c.cs.s, item)
 	return (CfCountItem)(c)
 }
 
-type CfDel Completed
+type CfDel Incomplete
 
 func (b Builder) CfDel() (c CfDel) {
 	c = CfDel{cs: get(), ks: b.ks}
@@ -123,24 +123,24 @@ func (c CfDel) Key(key string) CfDelKey {
 	return (CfDelKey)(c)
 }
 
-type CfDelItem Completed
+type CfDelItem Incomplete
 
 func (c CfDelItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfDelKey Completed
+type CfDelKey Incomplete
 
 func (c CfDelKey) Item(item string) CfDelItem {
 	c.cs.s = append(c.cs.s, item)
 	return (CfDelItem)(c)
 }
 
-type CfExists Completed
+type CfExists Incomplete
 
 func (b Builder) CfExists() (c CfExists) {
-	c = CfExists{cs: get(), ks: b.ks, cf: readonly}
+	c = CfExists{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "CF.EXISTS")
 	return c
 }
@@ -155,29 +155,29 @@ func (c CfExists) Key(key string) CfExistsKey {
 	return (CfExistsKey)(c)
 }
 
-type CfExistsItem Completed
+type CfExistsItem Incomplete
 
 func (c CfExistsItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c CfExistsItem) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfExistsKey Completed
+type CfExistsKey Incomplete
 
 func (c CfExistsKey) Item(item string) CfExistsItem {
 	c.cs.s = append(c.cs.s, item)
 	return (CfExistsItem)(c)
 }
 
-type CfInfo Completed
+type CfInfo Incomplete
 
 func (b Builder) CfInfo() (c CfInfo) {
-	c = CfInfo{cs: get(), ks: b.ks, cf: readonly}
+	c = CfInfo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "CF.INFO")
 	return c
 }
@@ -192,19 +192,19 @@ func (c CfInfo) Key(key string) CfInfoKey {
 	return (CfInfoKey)(c)
 }
 
-type CfInfoKey Completed
+type CfInfoKey Incomplete
 
 func (c CfInfoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c CfInfoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfInsert Completed
+type CfInsert Incomplete
 
 func (b Builder) CfInsert() (c CfInsert) {
 	c = CfInsert{cs: get(), ks: b.ks}
@@ -222,7 +222,7 @@ func (c CfInsert) Key(key string) CfInsertKey {
 	return (CfInsertKey)(c)
 }
 
-type CfInsertCapacity Completed
+type CfInsertCapacity Incomplete
 
 func (c CfInsertCapacity) Nocreate() CfInsertNocreate {
 	c.cs.s = append(c.cs.s, "NOCREATE")
@@ -234,7 +234,7 @@ func (c CfInsertCapacity) Items() CfInsertItems {
 	return (CfInsertItems)(c)
 }
 
-type CfInsertItem Completed
+type CfInsertItem Incomplete
 
 func (c CfInsertItem) Item(item ...string) CfInsertItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -243,17 +243,17 @@ func (c CfInsertItem) Item(item ...string) CfInsertItem {
 
 func (c CfInsertItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfInsertItems Completed
+type CfInsertItems Incomplete
 
 func (c CfInsertItems) Item(item ...string) CfInsertItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (CfInsertItem)(c)
 }
 
-type CfInsertKey Completed
+type CfInsertKey Incomplete
 
 func (c CfInsertKey) Capacity(capacity int64) CfInsertCapacity {
 	c.cs.s = append(c.cs.s, "CAPACITY", strconv.FormatInt(capacity, 10))
@@ -270,14 +270,14 @@ func (c CfInsertKey) Items() CfInsertItems {
 	return (CfInsertItems)(c)
 }
 
-type CfInsertNocreate Completed
+type CfInsertNocreate Incomplete
 
 func (c CfInsertNocreate) Items() CfInsertItems {
 	c.cs.s = append(c.cs.s, "ITEMS")
 	return (CfInsertItems)(c)
 }
 
-type CfInsertnx Completed
+type CfInsertnx Incomplete
 
 func (b Builder) CfInsertnx() (c CfInsertnx) {
 	c = CfInsertnx{cs: get(), ks: b.ks}
@@ -295,7 +295,7 @@ func (c CfInsertnx) Key(key string) CfInsertnxKey {
 	return (CfInsertnxKey)(c)
 }
 
-type CfInsertnxCapacity Completed
+type CfInsertnxCapacity Incomplete
 
 func (c CfInsertnxCapacity) Nocreate() CfInsertnxNocreate {
 	c.cs.s = append(c.cs.s, "NOCREATE")
@@ -307,7 +307,7 @@ func (c CfInsertnxCapacity) Items() CfInsertnxItems {
 	return (CfInsertnxItems)(c)
 }
 
-type CfInsertnxItem Completed
+type CfInsertnxItem Incomplete
 
 func (c CfInsertnxItem) Item(item ...string) CfInsertnxItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -316,17 +316,17 @@ func (c CfInsertnxItem) Item(item ...string) CfInsertnxItem {
 
 func (c CfInsertnxItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfInsertnxItems Completed
+type CfInsertnxItems Incomplete
 
 func (c CfInsertnxItems) Item(item ...string) CfInsertnxItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (CfInsertnxItem)(c)
 }
 
-type CfInsertnxKey Completed
+type CfInsertnxKey Incomplete
 
 func (c CfInsertnxKey) Capacity(capacity int64) CfInsertnxCapacity {
 	c.cs.s = append(c.cs.s, "CAPACITY", strconv.FormatInt(capacity, 10))
@@ -343,14 +343,14 @@ func (c CfInsertnxKey) Items() CfInsertnxItems {
 	return (CfInsertnxItems)(c)
 }
 
-type CfInsertnxNocreate Completed
+type CfInsertnxNocreate Incomplete
 
 func (c CfInsertnxNocreate) Items() CfInsertnxItems {
 	c.cs.s = append(c.cs.s, "ITEMS")
 	return (CfInsertnxItems)(c)
 }
 
-type CfLoadchunk Completed
+type CfLoadchunk Incomplete
 
 func (b Builder) CfLoadchunk() (c CfLoadchunk) {
 	c = CfLoadchunk{cs: get(), ks: b.ks}
@@ -368,28 +368,28 @@ func (c CfLoadchunk) Key(key string) CfLoadchunkKey {
 	return (CfLoadchunkKey)(c)
 }
 
-type CfLoadchunkData Completed
+type CfLoadchunkData Incomplete
 
 func (c CfLoadchunkData) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfLoadchunkIterator Completed
+type CfLoadchunkIterator Incomplete
 
 func (c CfLoadchunkIterator) Data(data string) CfLoadchunkData {
 	c.cs.s = append(c.cs.s, data)
 	return (CfLoadchunkData)(c)
 }
 
-type CfLoadchunkKey Completed
+type CfLoadchunkKey Incomplete
 
 func (c CfLoadchunkKey) Iterator(iterator int64) CfLoadchunkIterator {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(iterator, 10))
 	return (CfLoadchunkIterator)(c)
 }
 
-type CfMexists Completed
+type CfMexists Incomplete
 
 func (b Builder) CfMexists() (c CfMexists) {
 	c = CfMexists{cs: get(), ks: b.ks}
@@ -407,7 +407,7 @@ func (c CfMexists) Key(key string) CfMexistsKey {
 	return (CfMexistsKey)(c)
 }
 
-type CfMexistsItem Completed
+type CfMexistsItem Incomplete
 
 func (c CfMexistsItem) Item(item ...string) CfMexistsItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -416,17 +416,17 @@ func (c CfMexistsItem) Item(item ...string) CfMexistsItem {
 
 func (c CfMexistsItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfMexistsKey Completed
+type CfMexistsKey Incomplete
 
 func (c CfMexistsKey) Item(item ...string) CfMexistsItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (CfMexistsItem)(c)
 }
 
-type CfReserve Completed
+type CfReserve Incomplete
 
 func (b Builder) CfReserve() (c CfReserve) {
 	c = CfReserve{cs: get(), ks: b.ks}
@@ -444,7 +444,7 @@ func (c CfReserve) Key(key string) CfReserveKey {
 	return (CfReserveKey)(c)
 }
 
-type CfReserveBucketsize Completed
+type CfReserveBucketsize Incomplete
 
 func (c CfReserveBucketsize) Maxiterations(maxiterations int64) CfReserveMaxiterations {
 	c.cs.s = append(c.cs.s, "MAXITERATIONS", strconv.FormatInt(maxiterations, 10))
@@ -458,10 +458,10 @@ func (c CfReserveBucketsize) Expansion(expansion int64) CfReserveExpansion {
 
 func (c CfReserveBucketsize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfReserveCapacity Completed
+type CfReserveCapacity Incomplete
 
 func (c CfReserveCapacity) Bucketsize(bucketsize int64) CfReserveBucketsize {
 	c.cs.s = append(c.cs.s, "BUCKETSIZE", strconv.FormatInt(bucketsize, 10))
@@ -480,24 +480,24 @@ func (c CfReserveCapacity) Expansion(expansion int64) CfReserveExpansion {
 
 func (c CfReserveCapacity) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfReserveExpansion Completed
+type CfReserveExpansion Incomplete
 
 func (c CfReserveExpansion) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfReserveKey Completed
+type CfReserveKey Incomplete
 
 func (c CfReserveKey) Capacity(capacity int64) CfReserveCapacity {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(capacity, 10))
 	return (CfReserveCapacity)(c)
 }
 
-type CfReserveMaxiterations Completed
+type CfReserveMaxiterations Incomplete
 
 func (c CfReserveMaxiterations) Expansion(expansion int64) CfReserveExpansion {
 	c.cs.s = append(c.cs.s, "EXPANSION", strconv.FormatInt(expansion, 10))
@@ -506,13 +506,13 @@ func (c CfReserveMaxiterations) Expansion(expansion int64) CfReserveExpansion {
 
 func (c CfReserveMaxiterations) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfScandump Completed
+type CfScandump Incomplete
 
 func (b Builder) CfScandump() (c CfScandump) {
-	c = CfScandump{cs: get(), ks: b.ks, cf: readonly}
+	c = CfScandump{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "CF.SCANDUMP")
 	return c
 }
@@ -527,14 +527,14 @@ func (c CfScandump) Key(key string) CfScandumpKey {
 	return (CfScandumpKey)(c)
 }
 
-type CfScandumpIterator Completed
+type CfScandumpIterator Incomplete
 
 func (c CfScandumpIterator) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CfScandumpKey Completed
+type CfScandumpKey Incomplete
 
 func (c CfScandumpKey) Iterator(iterator int64) CfScandumpIterator {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(iterator, 10))

--- a/internal/cmds/gen_cluster.go
+++ b/internal/cmds/gen_cluster.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Asking Completed
+type Asking Incomplete
 
 func (b Builder) Asking() (c Asking) {
 	c = Asking{cs: get(), ks: b.ks}
@@ -14,10 +14,10 @@ func (b Builder) Asking() (c Asking) {
 
 func (c Asking) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterAddslots Completed
+type ClusterAddslots Incomplete
 
 func (b Builder) ClusterAddslots() (c ClusterAddslots) {
 	c = ClusterAddslots{cs: get(), ks: b.ks}
@@ -32,7 +32,7 @@ func (c ClusterAddslots) Slot(slot ...int64) ClusterAddslotsSlot {
 	return (ClusterAddslotsSlot)(c)
 }
 
-type ClusterAddslotsSlot Completed
+type ClusterAddslotsSlot Incomplete
 
 func (c ClusterAddslotsSlot) Slot(slot ...int64) ClusterAddslotsSlot {
 	for _, n := range slot {
@@ -43,10 +43,10 @@ func (c ClusterAddslotsSlot) Slot(slot ...int64) ClusterAddslotsSlot {
 
 func (c ClusterAddslotsSlot) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterAddslotsrange Completed
+type ClusterAddslotsrange Incomplete
 
 func (b Builder) ClusterAddslotsrange() (c ClusterAddslotsrange) {
 	c = ClusterAddslotsrange{cs: get(), ks: b.ks}
@@ -58,7 +58,7 @@ func (c ClusterAddslotsrange) StartSlotEndSlot() ClusterAddslotsrangeStartSlotEn
 	return (ClusterAddslotsrangeStartSlotEndSlot)(c)
 }
 
-type ClusterAddslotsrangeStartSlotEndSlot Completed
+type ClusterAddslotsrangeStartSlotEndSlot Incomplete
 
 func (c ClusterAddslotsrangeStartSlotEndSlot) StartSlotEndSlot(startSlot int64, endSlot int64) ClusterAddslotsrangeStartSlotEndSlot {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(startSlot, 10), strconv.FormatInt(endSlot, 10))
@@ -67,10 +67,10 @@ func (c ClusterAddslotsrangeStartSlotEndSlot) StartSlotEndSlot(startSlot int64, 
 
 func (c ClusterAddslotsrangeStartSlotEndSlot) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterBumpepoch Completed
+type ClusterBumpepoch Incomplete
 
 func (b Builder) ClusterBumpepoch() (c ClusterBumpepoch) {
 	c = ClusterBumpepoch{cs: get(), ks: b.ks}
@@ -80,10 +80,10 @@ func (b Builder) ClusterBumpepoch() (c ClusterBumpepoch) {
 
 func (c ClusterBumpepoch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterCountFailureReports Completed
+type ClusterCountFailureReports Incomplete
 
 func (b Builder) ClusterCountFailureReports() (c ClusterCountFailureReports) {
 	c = ClusterCountFailureReports{cs: get(), ks: b.ks}
@@ -96,14 +96,14 @@ func (c ClusterCountFailureReports) NodeId(nodeId string) ClusterCountFailureRep
 	return (ClusterCountFailureReportsNodeId)(c)
 }
 
-type ClusterCountFailureReportsNodeId Completed
+type ClusterCountFailureReportsNodeId Incomplete
 
 func (c ClusterCountFailureReportsNodeId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterCountkeysinslot Completed
+type ClusterCountkeysinslot Incomplete
 
 func (b Builder) ClusterCountkeysinslot() (c ClusterCountkeysinslot) {
 	c = ClusterCountkeysinslot{cs: get(), ks: b.ks}
@@ -116,14 +116,14 @@ func (c ClusterCountkeysinslot) Slot(slot int64) ClusterCountkeysinslotSlot {
 	return (ClusterCountkeysinslotSlot)(c)
 }
 
-type ClusterCountkeysinslotSlot Completed
+type ClusterCountkeysinslotSlot Incomplete
 
 func (c ClusterCountkeysinslotSlot) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterDelslots Completed
+type ClusterDelslots Incomplete
 
 func (b Builder) ClusterDelslots() (c ClusterDelslots) {
 	c = ClusterDelslots{cs: get(), ks: b.ks}
@@ -138,7 +138,7 @@ func (c ClusterDelslots) Slot(slot ...int64) ClusterDelslotsSlot {
 	return (ClusterDelslotsSlot)(c)
 }
 
-type ClusterDelslotsSlot Completed
+type ClusterDelslotsSlot Incomplete
 
 func (c ClusterDelslotsSlot) Slot(slot ...int64) ClusterDelslotsSlot {
 	for _, n := range slot {
@@ -149,10 +149,10 @@ func (c ClusterDelslotsSlot) Slot(slot ...int64) ClusterDelslotsSlot {
 
 func (c ClusterDelslotsSlot) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterDelslotsrange Completed
+type ClusterDelslotsrange Incomplete
 
 func (b Builder) ClusterDelslotsrange() (c ClusterDelslotsrange) {
 	c = ClusterDelslotsrange{cs: get(), ks: b.ks}
@@ -164,7 +164,7 @@ func (c ClusterDelslotsrange) StartSlotEndSlot() ClusterDelslotsrangeStartSlotEn
 	return (ClusterDelslotsrangeStartSlotEndSlot)(c)
 }
 
-type ClusterDelslotsrangeStartSlotEndSlot Completed
+type ClusterDelslotsrangeStartSlotEndSlot Incomplete
 
 func (c ClusterDelslotsrangeStartSlotEndSlot) StartSlotEndSlot(startSlot int64, endSlot int64) ClusterDelslotsrangeStartSlotEndSlot {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(startSlot, 10), strconv.FormatInt(endSlot, 10))
@@ -173,10 +173,10 @@ func (c ClusterDelslotsrangeStartSlotEndSlot) StartSlotEndSlot(startSlot int64, 
 
 func (c ClusterDelslotsrangeStartSlotEndSlot) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterFailover Completed
+type ClusterFailover Incomplete
 
 func (b Builder) ClusterFailover() (c ClusterFailover) {
 	c = ClusterFailover{cs: get(), ks: b.ks}
@@ -196,24 +196,24 @@ func (c ClusterFailover) Takeover() ClusterFailoverOptionsTakeover {
 
 func (c ClusterFailover) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterFailoverOptionsForce Completed
+type ClusterFailoverOptionsForce Incomplete
 
 func (c ClusterFailoverOptionsForce) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterFailoverOptionsTakeover Completed
+type ClusterFailoverOptionsTakeover Incomplete
 
 func (c ClusterFailoverOptionsTakeover) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterFlushslots Completed
+type ClusterFlushslots Incomplete
 
 func (b Builder) ClusterFlushslots() (c ClusterFlushslots) {
 	c = ClusterFlushslots{cs: get(), ks: b.ks}
@@ -223,10 +223,10 @@ func (b Builder) ClusterFlushslots() (c ClusterFlushslots) {
 
 func (c ClusterFlushslots) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterForget Completed
+type ClusterForget Incomplete
 
 func (b Builder) ClusterForget() (c ClusterForget) {
 	c = ClusterForget{cs: get(), ks: b.ks}
@@ -239,14 +239,14 @@ func (c ClusterForget) NodeId(nodeId string) ClusterForgetNodeId {
 	return (ClusterForgetNodeId)(c)
 }
 
-type ClusterForgetNodeId Completed
+type ClusterForgetNodeId Incomplete
 
 func (c ClusterForgetNodeId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterGetkeysinslot Completed
+type ClusterGetkeysinslot Incomplete
 
 func (b Builder) ClusterGetkeysinslot() (c ClusterGetkeysinslot) {
 	c = ClusterGetkeysinslot{cs: get(), ks: b.ks}
@@ -259,21 +259,21 @@ func (c ClusterGetkeysinslot) Slot(slot int64) ClusterGetkeysinslotSlot {
 	return (ClusterGetkeysinslotSlot)(c)
 }
 
-type ClusterGetkeysinslotCount Completed
+type ClusterGetkeysinslotCount Incomplete
 
 func (c ClusterGetkeysinslotCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterGetkeysinslotSlot Completed
+type ClusterGetkeysinslotSlot Incomplete
 
 func (c ClusterGetkeysinslotSlot) Count(count int64) ClusterGetkeysinslotCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
 	return (ClusterGetkeysinslotCount)(c)
 }
 
-type ClusterInfo Completed
+type ClusterInfo Incomplete
 
 func (b Builder) ClusterInfo() (c ClusterInfo) {
 	c = ClusterInfo{cs: get(), ks: b.ks}
@@ -283,10 +283,10 @@ func (b Builder) ClusterInfo() (c ClusterInfo) {
 
 func (c ClusterInfo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterKeyslot Completed
+type ClusterKeyslot Incomplete
 
 func (b Builder) ClusterKeyslot() (c ClusterKeyslot) {
 	c = ClusterKeyslot{cs: get(), ks: b.ks}
@@ -299,14 +299,14 @@ func (c ClusterKeyslot) Key(key string) ClusterKeyslotKey {
 	return (ClusterKeyslotKey)(c)
 }
 
-type ClusterKeyslotKey Completed
+type ClusterKeyslotKey Incomplete
 
 func (c ClusterKeyslotKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterLinks Completed
+type ClusterLinks Incomplete
 
 func (b Builder) ClusterLinks() (c ClusterLinks) {
 	c = ClusterLinks{cs: get(), ks: b.ks}
@@ -316,10 +316,10 @@ func (b Builder) ClusterLinks() (c ClusterLinks) {
 
 func (c ClusterLinks) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterMeet Completed
+type ClusterMeet Incomplete
 
 func (b Builder) ClusterMeet() (c ClusterMeet) {
 	c = ClusterMeet{cs: get(), ks: b.ks}
@@ -332,21 +332,21 @@ func (c ClusterMeet) Ip(ip string) ClusterMeetIp {
 	return (ClusterMeetIp)(c)
 }
 
-type ClusterMeetClusterBusPort Completed
+type ClusterMeetClusterBusPort Incomplete
 
 func (c ClusterMeetClusterBusPort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterMeetIp Completed
+type ClusterMeetIp Incomplete
 
 func (c ClusterMeetIp) Port(port int64) ClusterMeetPort {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(port, 10))
 	return (ClusterMeetPort)(c)
 }
 
-type ClusterMeetPort Completed
+type ClusterMeetPort Incomplete
 
 func (c ClusterMeetPort) ClusterBusPort(clusterBusPort int64) ClusterMeetClusterBusPort {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(clusterBusPort, 10))
@@ -355,10 +355,10 @@ func (c ClusterMeetPort) ClusterBusPort(clusterBusPort int64) ClusterMeetCluster
 
 func (c ClusterMeetPort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterMyid Completed
+type ClusterMyid Incomplete
 
 func (b Builder) ClusterMyid() (c ClusterMyid) {
 	c = ClusterMyid{cs: get(), ks: b.ks}
@@ -368,10 +368,10 @@ func (b Builder) ClusterMyid() (c ClusterMyid) {
 
 func (c ClusterMyid) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterMyshardid Completed
+type ClusterMyshardid Incomplete
 
 func (b Builder) ClusterMyshardid() (c ClusterMyshardid) {
 	c = ClusterMyshardid{cs: get(), ks: b.ks}
@@ -381,10 +381,10 @@ func (b Builder) ClusterMyshardid() (c ClusterMyshardid) {
 
 func (c ClusterMyshardid) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterNodes Completed
+type ClusterNodes Incomplete
 
 func (b Builder) ClusterNodes() (c ClusterNodes) {
 	c = ClusterNodes{cs: get(), ks: b.ks}
@@ -394,10 +394,10 @@ func (b Builder) ClusterNodes() (c ClusterNodes) {
 
 func (c ClusterNodes) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterReplicas Completed
+type ClusterReplicas Incomplete
 
 func (b Builder) ClusterReplicas() (c ClusterReplicas) {
 	c = ClusterReplicas{cs: get(), ks: b.ks}
@@ -410,14 +410,14 @@ func (c ClusterReplicas) NodeId(nodeId string) ClusterReplicasNodeId {
 	return (ClusterReplicasNodeId)(c)
 }
 
-type ClusterReplicasNodeId Completed
+type ClusterReplicasNodeId Incomplete
 
 func (c ClusterReplicasNodeId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterReplicate Completed
+type ClusterReplicate Incomplete
 
 func (b Builder) ClusterReplicate() (c ClusterReplicate) {
 	c = ClusterReplicate{cs: get(), ks: b.ks}
@@ -430,14 +430,14 @@ func (c ClusterReplicate) NodeId(nodeId string) ClusterReplicateNodeId {
 	return (ClusterReplicateNodeId)(c)
 }
 
-type ClusterReplicateNodeId Completed
+type ClusterReplicateNodeId Incomplete
 
 func (c ClusterReplicateNodeId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterReset Completed
+type ClusterReset Incomplete
 
 func (b Builder) ClusterReset() (c ClusterReset) {
 	c = ClusterReset{cs: get(), ks: b.ks}
@@ -457,24 +457,24 @@ func (c ClusterReset) Soft() ClusterResetResetTypeSoft {
 
 func (c ClusterReset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterResetResetTypeHard Completed
+type ClusterResetResetTypeHard Incomplete
 
 func (c ClusterResetResetTypeHard) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterResetResetTypeSoft Completed
+type ClusterResetResetTypeSoft Incomplete
 
 func (c ClusterResetResetTypeSoft) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSaveconfig Completed
+type ClusterSaveconfig Incomplete
 
 func (b Builder) ClusterSaveconfig() (c ClusterSaveconfig) {
 	c = ClusterSaveconfig{cs: get(), ks: b.ks}
@@ -484,10 +484,10 @@ func (b Builder) ClusterSaveconfig() (c ClusterSaveconfig) {
 
 func (c ClusterSaveconfig) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSetConfigEpoch Completed
+type ClusterSetConfigEpoch Incomplete
 
 func (b Builder) ClusterSetConfigEpoch() (c ClusterSetConfigEpoch) {
 	c = ClusterSetConfigEpoch{cs: get(), ks: b.ks}
@@ -500,14 +500,14 @@ func (c ClusterSetConfigEpoch) ConfigEpoch(configEpoch int64) ClusterSetConfigEp
 	return (ClusterSetConfigEpochConfigEpoch)(c)
 }
 
-type ClusterSetConfigEpochConfigEpoch Completed
+type ClusterSetConfigEpochConfigEpoch Incomplete
 
 func (c ClusterSetConfigEpochConfigEpoch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSetslot Completed
+type ClusterSetslot Incomplete
 
 func (b Builder) ClusterSetslot() (c ClusterSetslot) {
 	c = ClusterSetslot{cs: get(), ks: b.ks}
@@ -520,14 +520,14 @@ func (c ClusterSetslot) Slot(slot int64) ClusterSetslotSlot {
 	return (ClusterSetslotSlot)(c)
 }
 
-type ClusterSetslotNodeId Completed
+type ClusterSetslotNodeId Incomplete
 
 func (c ClusterSetslotNodeId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSetslotSlot Completed
+type ClusterSetslotSlot Incomplete
 
 func (c ClusterSetslotSlot) Importing() ClusterSetslotSubcommandImporting {
 	c.cs.s = append(c.cs.s, "IMPORTING")
@@ -549,7 +549,7 @@ func (c ClusterSetslotSlot) Node() ClusterSetslotSubcommandNode {
 	return (ClusterSetslotSubcommandNode)(c)
 }
 
-type ClusterSetslotSubcommandImporting Completed
+type ClusterSetslotSubcommandImporting Incomplete
 
 func (c ClusterSetslotSubcommandImporting) NodeId(nodeId string) ClusterSetslotNodeId {
 	c.cs.s = append(c.cs.s, nodeId)
@@ -558,10 +558,10 @@ func (c ClusterSetslotSubcommandImporting) NodeId(nodeId string) ClusterSetslotN
 
 func (c ClusterSetslotSubcommandImporting) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSetslotSubcommandMigrating Completed
+type ClusterSetslotSubcommandMigrating Incomplete
 
 func (c ClusterSetslotSubcommandMigrating) NodeId(nodeId string) ClusterSetslotNodeId {
 	c.cs.s = append(c.cs.s, nodeId)
@@ -570,10 +570,10 @@ func (c ClusterSetslotSubcommandMigrating) NodeId(nodeId string) ClusterSetslotN
 
 func (c ClusterSetslotSubcommandMigrating) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSetslotSubcommandNode Completed
+type ClusterSetslotSubcommandNode Incomplete
 
 func (c ClusterSetslotSubcommandNode) NodeId(nodeId string) ClusterSetslotNodeId {
 	c.cs.s = append(c.cs.s, nodeId)
@@ -582,10 +582,10 @@ func (c ClusterSetslotSubcommandNode) NodeId(nodeId string) ClusterSetslotNodeId
 
 func (c ClusterSetslotSubcommandNode) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSetslotSubcommandStable Completed
+type ClusterSetslotSubcommandStable Incomplete
 
 func (c ClusterSetslotSubcommandStable) NodeId(nodeId string) ClusterSetslotNodeId {
 	c.cs.s = append(c.cs.s, nodeId)
@@ -594,10 +594,10 @@ func (c ClusterSetslotSubcommandStable) NodeId(nodeId string) ClusterSetslotNode
 
 func (c ClusterSetslotSubcommandStable) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterShards Completed
+type ClusterShards Incomplete
 
 func (b Builder) ClusterShards() (c ClusterShards) {
 	c = ClusterShards{cs: get(), ks: b.ks}
@@ -607,10 +607,10 @@ func (b Builder) ClusterShards() (c ClusterShards) {
 
 func (c ClusterShards) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSlaves Completed
+type ClusterSlaves Incomplete
 
 func (b Builder) ClusterSlaves() (c ClusterSlaves) {
 	c = ClusterSlaves{cs: get(), ks: b.ks}
@@ -623,14 +623,14 @@ func (c ClusterSlaves) NodeId(nodeId string) ClusterSlavesNodeId {
 	return (ClusterSlavesNodeId)(c)
 }
 
-type ClusterSlavesNodeId Completed
+type ClusterSlavesNodeId Incomplete
 
 func (c ClusterSlavesNodeId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClusterSlots Completed
+type ClusterSlots Incomplete
 
 func (b Builder) ClusterSlots() (c ClusterSlots) {
 	c = ClusterSlots{cs: get(), ks: b.ks}
@@ -640,10 +640,10 @@ func (b Builder) ClusterSlots() (c ClusterSlots) {
 
 func (c ClusterSlots) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Readonly Completed
+type Readonly Incomplete
 
 func (b Builder) Readonly() (c Readonly) {
 	c = Readonly{cs: get(), ks: b.ks}
@@ -653,10 +653,10 @@ func (b Builder) Readonly() (c Readonly) {
 
 func (c Readonly) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Readwrite Completed
+type Readwrite Incomplete
 
 func (b Builder) Readwrite() (c Readwrite) {
 	c = Readwrite{cs: get(), ks: b.ks}
@@ -666,5 +666,5 @@ func (b Builder) Readwrite() (c Readwrite) {
 
 func (c Readwrite) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_cms.go
+++ b/internal/cmds/gen_cms.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type CmsIncrby Completed
+type CmsIncrby Incomplete
 
 func (b Builder) CmsIncrby() (c CmsIncrby) {
 	c = CmsIncrby{cs: get(), ks: b.ks}
@@ -22,7 +22,7 @@ func (c CmsIncrby) Key(key string) CmsIncrbyKey {
 	return (CmsIncrbyKey)(c)
 }
 
-type CmsIncrbyItemsIncrement Completed
+type CmsIncrbyItemsIncrement Incomplete
 
 func (c CmsIncrbyItemsIncrement) Item(item string) CmsIncrbyItemsItem {
 	c.cs.s = append(c.cs.s, item)
@@ -31,27 +31,27 @@ func (c CmsIncrbyItemsIncrement) Item(item string) CmsIncrbyItemsItem {
 
 func (c CmsIncrbyItemsIncrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsIncrbyItemsItem Completed
+type CmsIncrbyItemsItem Incomplete
 
 func (c CmsIncrbyItemsItem) Increment(increment int64) CmsIncrbyItemsIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(increment, 10))
 	return (CmsIncrbyItemsIncrement)(c)
 }
 
-type CmsIncrbyKey Completed
+type CmsIncrbyKey Incomplete
 
 func (c CmsIncrbyKey) Item(item string) CmsIncrbyItemsItem {
 	c.cs.s = append(c.cs.s, item)
 	return (CmsIncrbyItemsItem)(c)
 }
 
-type CmsInfo Completed
+type CmsInfo Incomplete
 
 func (b Builder) CmsInfo() (c CmsInfo) {
-	c = CmsInfo{cs: get(), ks: b.ks, cf: readonly}
+	c = CmsInfo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "CMS.INFO")
 	return c
 }
@@ -66,19 +66,19 @@ func (c CmsInfo) Key(key string) CmsInfoKey {
 	return (CmsInfoKey)(c)
 }
 
-type CmsInfoKey Completed
+type CmsInfoKey Incomplete
 
 func (c CmsInfoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c CmsInfoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsInitbydim Completed
+type CmsInitbydim Incomplete
 
 func (b Builder) CmsInitbydim() (c CmsInitbydim) {
 	c = CmsInitbydim{cs: get(), ks: b.ks}
@@ -96,28 +96,28 @@ func (c CmsInitbydim) Key(key string) CmsInitbydimKey {
 	return (CmsInitbydimKey)(c)
 }
 
-type CmsInitbydimDepth Completed
+type CmsInitbydimDepth Incomplete
 
 func (c CmsInitbydimDepth) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsInitbydimKey Completed
+type CmsInitbydimKey Incomplete
 
 func (c CmsInitbydimKey) Width(width int64) CmsInitbydimWidth {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(width, 10))
 	return (CmsInitbydimWidth)(c)
 }
 
-type CmsInitbydimWidth Completed
+type CmsInitbydimWidth Incomplete
 
 func (c CmsInitbydimWidth) Depth(depth int64) CmsInitbydimDepth {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(depth, 10))
 	return (CmsInitbydimDepth)(c)
 }
 
-type CmsInitbyprob Completed
+type CmsInitbyprob Incomplete
 
 func (b Builder) CmsInitbyprob() (c CmsInitbyprob) {
 	c = CmsInitbyprob{cs: get(), ks: b.ks}
@@ -135,28 +135,28 @@ func (c CmsInitbyprob) Key(key string) CmsInitbyprobKey {
 	return (CmsInitbyprobKey)(c)
 }
 
-type CmsInitbyprobError Completed
+type CmsInitbyprobError Incomplete
 
 func (c CmsInitbyprobError) Probability(probability float64) CmsInitbyprobProbability {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(probability, 'f', -1, 64))
 	return (CmsInitbyprobProbability)(c)
 }
 
-type CmsInitbyprobKey Completed
+type CmsInitbyprobKey Incomplete
 
 func (c CmsInitbyprobKey) Error(error float64) CmsInitbyprobError {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(error, 'f', -1, 64))
 	return (CmsInitbyprobError)(c)
 }
 
-type CmsInitbyprobProbability Completed
+type CmsInitbyprobProbability Incomplete
 
 func (c CmsInitbyprobProbability) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsMerge Completed
+type CmsMerge Incomplete
 
 func (b Builder) CmsMerge() (c CmsMerge) {
 	c = CmsMerge{cs: get(), ks: b.ks}
@@ -174,14 +174,14 @@ func (c CmsMerge) Destination(destination string) CmsMergeDestination {
 	return (CmsMergeDestination)(c)
 }
 
-type CmsMergeDestination Completed
+type CmsMergeDestination Incomplete
 
 func (c CmsMergeDestination) Numkeys(numkeys int64) CmsMergeNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (CmsMergeNumkeys)(c)
 }
 
-type CmsMergeNumkeys Completed
+type CmsMergeNumkeys Incomplete
 
 func (c CmsMergeNumkeys) Source(source ...string) CmsMergeSource {
 	if c.ks&NoSlot == NoSlot {
@@ -198,7 +198,7 @@ func (c CmsMergeNumkeys) Source(source ...string) CmsMergeSource {
 	return (CmsMergeSource)(c)
 }
 
-type CmsMergeSource Completed
+type CmsMergeSource Incomplete
 
 func (c CmsMergeSource) Source(source ...string) CmsMergeSource {
 	if c.ks&NoSlot == NoSlot {
@@ -222,10 +222,10 @@ func (c CmsMergeSource) Weights() CmsMergeWeightWeights {
 
 func (c CmsMergeSource) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsMergeWeightWeight Completed
+type CmsMergeWeightWeight Incomplete
 
 func (c CmsMergeWeightWeight) Weight(weight ...float64) CmsMergeWeightWeight {
 	for _, n := range weight {
@@ -236,10 +236,10 @@ func (c CmsMergeWeightWeight) Weight(weight ...float64) CmsMergeWeightWeight {
 
 func (c CmsMergeWeightWeight) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsMergeWeightWeights Completed
+type CmsMergeWeightWeights Incomplete
 
 func (c CmsMergeWeightWeights) Weight(weight ...float64) CmsMergeWeightWeight {
 	for _, n := range weight {
@@ -248,10 +248,10 @@ func (c CmsMergeWeightWeights) Weight(weight ...float64) CmsMergeWeightWeight {
 	return (CmsMergeWeightWeight)(c)
 }
 
-type CmsQuery Completed
+type CmsQuery Incomplete
 
 func (b Builder) CmsQuery() (c CmsQuery) {
-	c = CmsQuery{cs: get(), ks: b.ks, cf: readonly}
+	c = CmsQuery{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "CMS.QUERY")
 	return c
 }
@@ -266,7 +266,7 @@ func (c CmsQuery) Key(key string) CmsQueryKey {
 	return (CmsQueryKey)(c)
 }
 
-type CmsQueryItem Completed
+type CmsQueryItem Incomplete
 
 func (c CmsQueryItem) Item(item ...string) CmsQueryItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -275,15 +275,15 @@ func (c CmsQueryItem) Item(item ...string) CmsQueryItem {
 
 func (c CmsQueryItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c CmsQueryItem) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CmsQueryKey Completed
+type CmsQueryKey Incomplete
 
 func (c CmsQueryKey) Item(item ...string) CmsQueryItem {
 	c.cs.s = append(c.cs.s, item...)

--- a/internal/cmds/gen_connection.go
+++ b/internal/cmds/gen_connection.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Auth Completed
+type Auth Incomplete
 
 func (b Builder) Auth() (c Auth) {
 	c = Auth{cs: get(), ks: b.ks}
@@ -22,21 +22,21 @@ func (c Auth) Password(password string) AuthPassword {
 	return (AuthPassword)(c)
 }
 
-type AuthPassword Completed
+type AuthPassword Incomplete
 
 func (c AuthPassword) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AuthUsername Completed
+type AuthUsername Incomplete
 
 func (c AuthUsername) Password(password string) AuthPassword {
 	c.cs.s = append(c.cs.s, password)
 	return (AuthPassword)(c)
 }
 
-type ClientCaching Completed
+type ClientCaching Incomplete
 
 func (b Builder) ClientCaching() (c ClientCaching) {
 	c = ClientCaching{cs: get(), ks: b.ks}
@@ -54,21 +54,21 @@ func (c ClientCaching) No() ClientCachingModeNo {
 	return (ClientCachingModeNo)(c)
 }
 
-type ClientCachingModeNo Completed
+type ClientCachingModeNo Incomplete
 
 func (c ClientCachingModeNo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientCachingModeYes Completed
+type ClientCachingModeYes Incomplete
 
 func (c ClientCachingModeYes) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientGetname Completed
+type ClientGetname Incomplete
 
 func (b Builder) ClientGetname() (c ClientGetname) {
 	c = ClientGetname{cs: get(), ks: b.ks}
@@ -78,10 +78,10 @@ func (b Builder) ClientGetname() (c ClientGetname) {
 
 func (c ClientGetname) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientGetredir Completed
+type ClientGetredir Incomplete
 
 func (b Builder) ClientGetredir() (c ClientGetredir) {
 	c = ClientGetredir{cs: get(), ks: b.ks}
@@ -91,10 +91,10 @@ func (b Builder) ClientGetredir() (c ClientGetredir) {
 
 func (c ClientGetredir) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientId Completed
+type ClientId Incomplete
 
 func (b Builder) ClientId() (c ClientId) {
 	c = ClientId{cs: get(), ks: b.ks}
@@ -104,10 +104,10 @@ func (b Builder) ClientId() (c ClientId) {
 
 func (c ClientId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientInfo Completed
+type ClientInfo Incomplete
 
 func (b Builder) ClientInfo() (c ClientInfo) {
 	c = ClientInfo{cs: get(), ks: b.ks}
@@ -117,10 +117,10 @@ func (b Builder) ClientInfo() (c ClientInfo) {
 
 func (c ClientInfo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKill Completed
+type ClientKill Incomplete
 
 func (b Builder) ClientKill() (c ClientKill) {
 	c = ClientKill{cs: get(), ks: b.ks}
@@ -185,10 +185,10 @@ func (c ClientKill) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKill) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillAddr Completed
+type ClientKillAddr Incomplete
 
 func (c ClientKillAddr) Laddr(ipPort string) ClientKillLaddr {
 	c.cs.s = append(c.cs.s, "LADDR", ipPort)
@@ -207,10 +207,10 @@ func (c ClientKillAddr) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillAddr) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillId Completed
+type ClientKillId Incomplete
 
 func (c ClientKillId) TypeNormal() ClientKillTypeNormal {
 	c.cs.s = append(c.cs.s, "TYPE", "NORMAL")
@@ -259,10 +259,10 @@ func (c ClientKillId) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillIpPort Completed
+type ClientKillIpPort Incomplete
 
 func (c ClientKillIpPort) Id(clientId int64) ClientKillId {
 	c.cs.s = append(c.cs.s, "ID", strconv.FormatInt(clientId, 10))
@@ -316,10 +316,10 @@ func (c ClientKillIpPort) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillIpPort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillLaddr Completed
+type ClientKillLaddr Incomplete
 
 func (c ClientKillLaddr) SkipmeYes() ClientKillSkipmeYes {
 	c.cs.s = append(c.cs.s, "SKIPME", "YES")
@@ -333,24 +333,24 @@ func (c ClientKillLaddr) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillLaddr) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillSkipmeNo Completed
+type ClientKillSkipmeNo Incomplete
 
 func (c ClientKillSkipmeNo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillSkipmeYes Completed
+type ClientKillSkipmeYes Incomplete
 
 func (c ClientKillSkipmeYes) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillTypeMaster Completed
+type ClientKillTypeMaster Incomplete
 
 func (c ClientKillTypeMaster) User(username string) ClientKillUser {
 	c.cs.s = append(c.cs.s, "USER", username)
@@ -379,10 +379,10 @@ func (c ClientKillTypeMaster) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillTypeMaster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillTypeNormal Completed
+type ClientKillTypeNormal Incomplete
 
 func (c ClientKillTypeNormal) User(username string) ClientKillUser {
 	c.cs.s = append(c.cs.s, "USER", username)
@@ -411,10 +411,10 @@ func (c ClientKillTypeNormal) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillTypeNormal) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillTypePubsub Completed
+type ClientKillTypePubsub Incomplete
 
 func (c ClientKillTypePubsub) User(username string) ClientKillUser {
 	c.cs.s = append(c.cs.s, "USER", username)
@@ -443,10 +443,10 @@ func (c ClientKillTypePubsub) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillTypePubsub) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillTypeReplica Completed
+type ClientKillTypeReplica Incomplete
 
 func (c ClientKillTypeReplica) User(username string) ClientKillUser {
 	c.cs.s = append(c.cs.s, "USER", username)
@@ -475,10 +475,10 @@ func (c ClientKillTypeReplica) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillTypeReplica) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientKillUser Completed
+type ClientKillUser Incomplete
 
 func (c ClientKillUser) Addr(ipPort string) ClientKillAddr {
 	c.cs.s = append(c.cs.s, "ADDR", ipPort)
@@ -502,10 +502,10 @@ func (c ClientKillUser) SkipmeNo() ClientKillSkipmeNo {
 
 func (c ClientKillUser) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientList Completed
+type ClientList Incomplete
 
 func (b Builder) ClientList() (c ClientList) {
 	c = ClientList{cs: get(), ks: b.ks}
@@ -540,10 +540,10 @@ func (c ClientList) Id() ClientListIdId {
 
 func (c ClientList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientListIdClientId Completed
+type ClientListIdClientId Incomplete
 
 func (c ClientListIdClientId) ClientId(clientId ...int64) ClientListIdClientId {
 	for _, n := range clientId {
@@ -554,10 +554,10 @@ func (c ClientListIdClientId) ClientId(clientId ...int64) ClientListIdClientId {
 
 func (c ClientListIdClientId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientListIdId Completed
+type ClientListIdId Incomplete
 
 func (c ClientListIdId) ClientId(clientId ...int64) ClientListIdClientId {
 	for _, n := range clientId {
@@ -566,7 +566,7 @@ func (c ClientListIdId) ClientId(clientId ...int64) ClientListIdClientId {
 	return (ClientListIdClientId)(c)
 }
 
-type ClientListTypeMaster Completed
+type ClientListTypeMaster Incomplete
 
 func (c ClientListTypeMaster) Id() ClientListIdId {
 	c.cs.s = append(c.cs.s, "ID")
@@ -575,10 +575,10 @@ func (c ClientListTypeMaster) Id() ClientListIdId {
 
 func (c ClientListTypeMaster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientListTypeNormal Completed
+type ClientListTypeNormal Incomplete
 
 func (c ClientListTypeNormal) Id() ClientListIdId {
 	c.cs.s = append(c.cs.s, "ID")
@@ -587,10 +587,10 @@ func (c ClientListTypeNormal) Id() ClientListIdId {
 
 func (c ClientListTypeNormal) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientListTypePubsub Completed
+type ClientListTypePubsub Incomplete
 
 func (c ClientListTypePubsub) Id() ClientListIdId {
 	c.cs.s = append(c.cs.s, "ID")
@@ -599,10 +599,10 @@ func (c ClientListTypePubsub) Id() ClientListIdId {
 
 func (c ClientListTypePubsub) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientListTypeReplica Completed
+type ClientListTypeReplica Incomplete
 
 func (c ClientListTypeReplica) Id() ClientListIdId {
 	c.cs.s = append(c.cs.s, "ID")
@@ -611,10 +611,10 @@ func (c ClientListTypeReplica) Id() ClientListIdId {
 
 func (c ClientListTypeReplica) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientNoEvict Completed
+type ClientNoEvict Incomplete
 
 func (b Builder) ClientNoEvict() (c ClientNoEvict) {
 	c = ClientNoEvict{cs: get(), ks: b.ks}
@@ -632,21 +632,21 @@ func (c ClientNoEvict) Off() ClientNoEvictEnabledOff {
 	return (ClientNoEvictEnabledOff)(c)
 }
 
-type ClientNoEvictEnabledOff Completed
+type ClientNoEvictEnabledOff Incomplete
 
 func (c ClientNoEvictEnabledOff) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientNoEvictEnabledOn Completed
+type ClientNoEvictEnabledOn Incomplete
 
 func (c ClientNoEvictEnabledOn) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientNoTouch Completed
+type ClientNoTouch Incomplete
 
 func (b Builder) ClientNoTouch() (c ClientNoTouch) {
 	c = ClientNoTouch{cs: get(), ks: b.ks}
@@ -664,24 +664,24 @@ func (c ClientNoTouch) Off() ClientNoTouchEnabledOff {
 	return (ClientNoTouchEnabledOff)(c)
 }
 
-type ClientNoTouchEnabledOff Completed
+type ClientNoTouchEnabledOff Incomplete
 
 func (c ClientNoTouchEnabledOff) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientNoTouchEnabledOn Completed
+type ClientNoTouchEnabledOn Incomplete
 
 func (c ClientNoTouchEnabledOn) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientPause Completed
+type ClientPause Incomplete
 
 func (b Builder) ClientPause() (c ClientPause) {
-	c = ClientPause{cs: get(), ks: b.ks, cf: blockTag}
+	c = ClientPause{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "CLIENT", "PAUSE")
 	return c
 }
@@ -691,21 +691,21 @@ func (c ClientPause) Timeout(timeout int64) ClientPauseTimeout {
 	return (ClientPauseTimeout)(c)
 }
 
-type ClientPauseModeAll Completed
+type ClientPauseModeAll Incomplete
 
 func (c ClientPauseModeAll) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientPauseModeWrite Completed
+type ClientPauseModeWrite Incomplete
 
 func (c ClientPauseModeWrite) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientPauseTimeout Completed
+type ClientPauseTimeout Incomplete
 
 func (c ClientPauseTimeout) Write() ClientPauseModeWrite {
 	c.cs.s = append(c.cs.s, "WRITE")
@@ -719,10 +719,10 @@ func (c ClientPauseTimeout) All() ClientPauseModeAll {
 
 func (c ClientPauseTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientReply Completed
+type ClientReply Incomplete
 
 func (b Builder) ClientReply() (c ClientReply) {
 	c = ClientReply{cs: get(), ks: b.ks}
@@ -745,28 +745,28 @@ func (c ClientReply) Skip() ClientReplyReplyModeSkip {
 	return (ClientReplyReplyModeSkip)(c)
 }
 
-type ClientReplyReplyModeOff Completed
+type ClientReplyReplyModeOff Incomplete
 
 func (c ClientReplyReplyModeOff) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientReplyReplyModeOn Completed
+type ClientReplyReplyModeOn Incomplete
 
 func (c ClientReplyReplyModeOn) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientReplyReplyModeSkip Completed
+type ClientReplyReplyModeSkip Incomplete
 
 func (c ClientReplyReplyModeSkip) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientSetinfo Completed
+type ClientSetinfo Incomplete
 
 func (b Builder) ClientSetinfo() (c ClientSetinfo) {
 	c = ClientSetinfo{cs: get(), ks: b.ks}
@@ -779,21 +779,21 @@ func (c ClientSetinfo) Libname(libname string) ClientSetinfoAttrLibname {
 	return (ClientSetinfoAttrLibname)(c)
 }
 
-type ClientSetinfoAttrLibname Completed
+type ClientSetinfoAttrLibname Incomplete
 
 func (c ClientSetinfoAttrLibname) Libver(libver string) ClientSetinfoAttrLibver {
 	c.cs.s = append(c.cs.s, libver)
 	return (ClientSetinfoAttrLibver)(c)
 }
 
-type ClientSetinfoAttrLibver Completed
+type ClientSetinfoAttrLibver Incomplete
 
 func (c ClientSetinfoAttrLibver) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientSetname Completed
+type ClientSetname Incomplete
 
 func (b Builder) ClientSetname() (c ClientSetname) {
 	c = ClientSetname{cs: get(), ks: b.ks}
@@ -806,14 +806,14 @@ func (c ClientSetname) ConnectionName(connectionName string) ClientSetnameConnec
 	return (ClientSetnameConnectionName)(c)
 }
 
-type ClientSetnameConnectionName Completed
+type ClientSetnameConnectionName Incomplete
 
 func (c ClientSetnameConnectionName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTracking Completed
+type ClientTracking Incomplete
 
 func (b Builder) ClientTracking() (c ClientTracking) {
 	c = ClientTracking{cs: get(), ks: b.ks}
@@ -831,7 +831,7 @@ func (c ClientTracking) Off() ClientTrackingStatusOff {
 	return (ClientTrackingStatusOff)(c)
 }
 
-type ClientTrackingBcast Completed
+type ClientTrackingBcast Incomplete
 
 func (c ClientTrackingBcast) Optin() ClientTrackingOptin {
 	c.cs.s = append(c.cs.s, "OPTIN")
@@ -850,17 +850,17 @@ func (c ClientTrackingBcast) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingBcast) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingNoloop Completed
+type ClientTrackingNoloop Incomplete
 
 func (c ClientTrackingNoloop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingOptin Completed
+type ClientTrackingOptin Incomplete
 
 func (c ClientTrackingOptin) Optout() ClientTrackingOptout {
 	c.cs.s = append(c.cs.s, "OPTOUT")
@@ -874,10 +874,10 @@ func (c ClientTrackingOptin) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingOptin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingOptout Completed
+type ClientTrackingOptout Incomplete
 
 func (c ClientTrackingOptout) Noloop() ClientTrackingNoloop {
 	c.cs.s = append(c.cs.s, "NOLOOP")
@@ -886,10 +886,10 @@ func (c ClientTrackingOptout) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingOptout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingPrefix Completed
+type ClientTrackingPrefix Incomplete
 
 func (c ClientTrackingPrefix) Prefix(prefix string) ClientTrackingPrefix {
 	c.cs.s = append(c.cs.s, "PREFIX", prefix)
@@ -918,10 +918,10 @@ func (c ClientTrackingPrefix) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingPrefix) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingRedirect Completed
+type ClientTrackingRedirect Incomplete
 
 func (c ClientTrackingRedirect) Prefix() ClientTrackingPrefix {
 	return (ClientTrackingPrefix)(c)
@@ -949,10 +949,10 @@ func (c ClientTrackingRedirect) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingRedirect) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingStatusOff Completed
+type ClientTrackingStatusOff Incomplete
 
 func (c ClientTrackingStatusOff) Redirect(clientId int64) ClientTrackingRedirect {
 	c.cs.s = append(c.cs.s, "REDIRECT", strconv.FormatInt(clientId, 10))
@@ -985,10 +985,10 @@ func (c ClientTrackingStatusOff) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingStatusOff) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackingStatusOn Completed
+type ClientTrackingStatusOn Incomplete
 
 func (c ClientTrackingStatusOn) Redirect(clientId int64) ClientTrackingRedirect {
 	c.cs.s = append(c.cs.s, "REDIRECT", strconv.FormatInt(clientId, 10))
@@ -1021,10 +1021,10 @@ func (c ClientTrackingStatusOn) Noloop() ClientTrackingNoloop {
 
 func (c ClientTrackingStatusOn) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientTrackinginfo Completed
+type ClientTrackinginfo Incomplete
 
 func (b Builder) ClientTrackinginfo() (c ClientTrackinginfo) {
 	c = ClientTrackinginfo{cs: get(), ks: b.ks}
@@ -1034,10 +1034,10 @@ func (b Builder) ClientTrackinginfo() (c ClientTrackinginfo) {
 
 func (c ClientTrackinginfo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientUnblock Completed
+type ClientUnblock Incomplete
 
 func (b Builder) ClientUnblock() (c ClientUnblock) {
 	c = ClientUnblock{cs: get(), ks: b.ks}
@@ -1050,7 +1050,7 @@ func (c ClientUnblock) ClientId(clientId int64) ClientUnblockClientId {
 	return (ClientUnblockClientId)(c)
 }
 
-type ClientUnblockClientId Completed
+type ClientUnblockClientId Incomplete
 
 func (c ClientUnblockClientId) Timeout() ClientUnblockUnblockTypeTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT")
@@ -1064,24 +1064,24 @@ func (c ClientUnblockClientId) Error() ClientUnblockUnblockTypeError {
 
 func (c ClientUnblockClientId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientUnblockUnblockTypeError Completed
+type ClientUnblockUnblockTypeError Incomplete
 
 func (c ClientUnblockUnblockTypeError) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientUnblockUnblockTypeTimeout Completed
+type ClientUnblockUnblockTypeTimeout Incomplete
 
 func (c ClientUnblockUnblockTypeTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ClientUnpause Completed
+type ClientUnpause Incomplete
 
 func (b Builder) ClientUnpause() (c ClientUnpause) {
 	c = ClientUnpause{cs: get(), ks: b.ks}
@@ -1091,10 +1091,10 @@ func (b Builder) ClientUnpause() (c ClientUnpause) {
 
 func (c ClientUnpause) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Echo Completed
+type Echo Incomplete
 
 func (b Builder) Echo() (c Echo) {
 	c = Echo{cs: get(), ks: b.ks}
@@ -1107,14 +1107,14 @@ func (c Echo) Message(message string) EchoMessage {
 	return (EchoMessage)(c)
 }
 
-type EchoMessage Completed
+type EchoMessage Incomplete
 
 func (c EchoMessage) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hello Completed
+type Hello Incomplete
 
 func (b Builder) Hello() (c Hello) {
 	c = Hello{cs: get(), ks: b.ks}
@@ -1129,10 +1129,10 @@ func (c Hello) Protover(protover int64) HelloArgumentsProtover {
 
 func (c Hello) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HelloArgumentsAuth Completed
+type HelloArgumentsAuth Incomplete
 
 func (c HelloArgumentsAuth) Setname(clientname string) HelloArgumentsSetname {
 	c.cs.s = append(c.cs.s, "SETNAME", clientname)
@@ -1141,10 +1141,10 @@ func (c HelloArgumentsAuth) Setname(clientname string) HelloArgumentsSetname {
 
 func (c HelloArgumentsAuth) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HelloArgumentsProtover Completed
+type HelloArgumentsProtover Incomplete
 
 func (c HelloArgumentsProtover) Auth(username string, password string) HelloArgumentsAuth {
 	c.cs.s = append(c.cs.s, "AUTH", username, password)
@@ -1158,17 +1158,17 @@ func (c HelloArgumentsProtover) Setname(clientname string) HelloArgumentsSetname
 
 func (c HelloArgumentsProtover) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HelloArgumentsSetname Completed
+type HelloArgumentsSetname Incomplete
 
 func (c HelloArgumentsSetname) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Ping Completed
+type Ping Incomplete
 
 func (b Builder) Ping() (c Ping) {
 	c = Ping{cs: get(), ks: b.ks}
@@ -1183,17 +1183,17 @@ func (c Ping) Message(message string) PingMessage {
 
 func (c Ping) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PingMessage Completed
+type PingMessage Incomplete
 
 func (c PingMessage) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Quit Completed
+type Quit Incomplete
 
 func (b Builder) Quit() (c Quit) {
 	c = Quit{cs: get(), ks: b.ks}
@@ -1203,10 +1203,10 @@ func (b Builder) Quit() (c Quit) {
 
 func (c Quit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Reset Completed
+type Reset Incomplete
 
 func (b Builder) Reset() (c Reset) {
 	c = Reset{cs: get(), ks: b.ks}
@@ -1216,10 +1216,10 @@ func (b Builder) Reset() (c Reset) {
 
 func (c Reset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Select Completed
+type Select Incomplete
 
 func (b Builder) Select() (c Select) {
 	c = Select{cs: get(), ks: b.ks}
@@ -1232,9 +1232,9 @@ func (c Select) Index(index int64) SelectIndex {
 	return (SelectIndex)(c)
 }
 
-type SelectIndex Completed
+type SelectIndex Incomplete
 
 func (c SelectIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_gears.go
+++ b/internal/cmds/gen_gears.go
@@ -2,7 +2,7 @@
 
 package cmds
 
-type RgAbortexecution Completed
+type RgAbortexecution Incomplete
 
 func (b Builder) RgAbortexecution() (c RgAbortexecution) {
 	c = RgAbortexecution{cs: get(), ks: b.ks}
@@ -15,14 +15,14 @@ func (c RgAbortexecution) Id(id string) RgAbortexecutionId {
 	return (RgAbortexecutionId)(c)
 }
 
-type RgAbortexecutionId Completed
+type RgAbortexecutionId Incomplete
 
 func (c RgAbortexecutionId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgConfigget Completed
+type RgConfigget Incomplete
 
 func (b Builder) RgConfigget() (c RgConfigget) {
 	c = RgConfigget{cs: get(), ks: b.ks}
@@ -35,7 +35,7 @@ func (c RgConfigget) Key(key ...string) RgConfiggetKey {
 	return (RgConfiggetKey)(c)
 }
 
-type RgConfiggetKey Completed
+type RgConfiggetKey Incomplete
 
 func (c RgConfiggetKey) Key(key ...string) RgConfiggetKey {
 	c.cs.s = append(c.cs.s, key...)
@@ -44,10 +44,10 @@ func (c RgConfiggetKey) Key(key ...string) RgConfiggetKey {
 
 func (c RgConfiggetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgConfigset Completed
+type RgConfigset Incomplete
 
 func (b Builder) RgConfigset() (c RgConfigset) {
 	c = RgConfigset{cs: get(), ks: b.ks}
@@ -59,7 +59,7 @@ func (c RgConfigset) KeyValue() RgConfigsetKeyValue {
 	return (RgConfigsetKeyValue)(c)
 }
 
-type RgConfigsetKeyValue Completed
+type RgConfigsetKeyValue Incomplete
 
 func (c RgConfigsetKeyValue) KeyValue(key string, value string) RgConfigsetKeyValue {
 	c.cs.s = append(c.cs.s, key, value)
@@ -68,10 +68,10 @@ func (c RgConfigsetKeyValue) KeyValue(key string, value string) RgConfigsetKeyVa
 
 func (c RgConfigsetKeyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgDropexecution Completed
+type RgDropexecution Incomplete
 
 func (b Builder) RgDropexecution() (c RgDropexecution) {
 	c = RgDropexecution{cs: get(), ks: b.ks}
@@ -84,14 +84,14 @@ func (c RgDropexecution) Id(id string) RgDropexecutionId {
 	return (RgDropexecutionId)(c)
 }
 
-type RgDropexecutionId Completed
+type RgDropexecutionId Incomplete
 
 func (c RgDropexecutionId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgDumpexecutions Completed
+type RgDumpexecutions Incomplete
 
 func (b Builder) RgDumpexecutions() (c RgDumpexecutions) {
 	c = RgDumpexecutions{cs: get(), ks: b.ks}
@@ -101,10 +101,10 @@ func (b Builder) RgDumpexecutions() (c RgDumpexecutions) {
 
 func (c RgDumpexecutions) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgDumpregistrations Completed
+type RgDumpregistrations Incomplete
 
 func (b Builder) RgDumpregistrations() (c RgDumpregistrations) {
 	c = RgDumpregistrations{cs: get(), ks: b.ks}
@@ -114,10 +114,10 @@ func (b Builder) RgDumpregistrations() (c RgDumpregistrations) {
 
 func (c RgDumpregistrations) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgGetexecution Completed
+type RgGetexecution Incomplete
 
 func (b Builder) RgGetexecution() (c RgGetexecution) {
 	c = RgGetexecution{cs: get(), ks: b.ks}
@@ -130,7 +130,7 @@ func (c RgGetexecution) Id(id string) RgGetexecutionId {
 	return (RgGetexecutionId)(c)
 }
 
-type RgGetexecutionId Completed
+type RgGetexecutionId Incomplete
 
 func (c RgGetexecutionId) Shard() RgGetexecutionModeShard {
 	c.cs.s = append(c.cs.s, "SHARD")
@@ -144,24 +144,24 @@ func (c RgGetexecutionId) Cluster() RgGetexecutionModeCluster {
 
 func (c RgGetexecutionId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgGetexecutionModeCluster Completed
+type RgGetexecutionModeCluster Incomplete
 
 func (c RgGetexecutionModeCluster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgGetexecutionModeShard Completed
+type RgGetexecutionModeShard Incomplete
 
 func (c RgGetexecutionModeShard) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgGetresults Completed
+type RgGetresults Incomplete
 
 func (b Builder) RgGetresults() (c RgGetresults) {
 	c = RgGetresults{cs: get(), ks: b.ks}
@@ -174,14 +174,14 @@ func (c RgGetresults) Id(id string) RgGetresultsId {
 	return (RgGetresultsId)(c)
 }
 
-type RgGetresultsId Completed
+type RgGetresultsId Incomplete
 
 func (c RgGetresultsId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgGetresultsblocking Completed
+type RgGetresultsblocking Incomplete
 
 func (b Builder) RgGetresultsblocking() (c RgGetresultsblocking) {
 	c = RgGetresultsblocking{cs: get(), ks: b.ks}
@@ -194,14 +194,14 @@ func (c RgGetresultsblocking) Id(id string) RgGetresultsblockingId {
 	return (RgGetresultsblockingId)(c)
 }
 
-type RgGetresultsblockingId Completed
+type RgGetresultsblockingId Incomplete
 
 func (c RgGetresultsblockingId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgInfocluster Completed
+type RgInfocluster Incomplete
 
 func (b Builder) RgInfocluster() (c RgInfocluster) {
 	c = RgInfocluster{cs: get(), ks: b.ks}
@@ -211,10 +211,10 @@ func (b Builder) RgInfocluster() (c RgInfocluster) {
 
 func (c RgInfocluster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPydumpreqs Completed
+type RgPydumpreqs Incomplete
 
 func (b Builder) RgPydumpreqs() (c RgPydumpreqs) {
 	c = RgPydumpreqs{cs: get(), ks: b.ks}
@@ -224,10 +224,10 @@ func (b Builder) RgPydumpreqs() (c RgPydumpreqs) {
 
 func (c RgPydumpreqs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecute Completed
+type RgPyexecute Incomplete
 
 func (b Builder) RgPyexecute() (c RgPyexecute) {
 	c = RgPyexecute{cs: get(), ks: b.ks}
@@ -240,7 +240,7 @@ func (c RgPyexecute) Function(function string) RgPyexecuteFunction {
 	return (RgPyexecuteFunction)(c)
 }
 
-type RgPyexecuteDescription Completed
+type RgPyexecuteDescription Incomplete
 
 func (c RgPyexecuteDescription) Upgrade() RgPyexecuteUpgrade {
 	c.cs.s = append(c.cs.s, "UPGRADE")
@@ -260,10 +260,10 @@ func (c RgPyexecuteDescription) Requirements(requirement ...string) RgPyexecuteR
 
 func (c RgPyexecuteDescription) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecuteFunction Completed
+type RgPyexecuteFunction Incomplete
 
 func (c RgPyexecuteFunction) Unblocking() RgPyexecuteUnblocking {
 	c.cs.s = append(c.cs.s, "UNBLOCKING")
@@ -298,10 +298,10 @@ func (c RgPyexecuteFunction) Requirements(requirement ...string) RgPyexecuteRequ
 
 func (c RgPyexecuteFunction) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecuteId Completed
+type RgPyexecuteId Incomplete
 
 func (c RgPyexecuteId) Description(description string) RgPyexecuteDescription {
 	c.cs.s = append(c.cs.s, "DESCRIPTION", description)
@@ -326,10 +326,10 @@ func (c RgPyexecuteId) Requirements(requirement ...string) RgPyexecuteRequiremen
 
 func (c RgPyexecuteId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecuteReplaceWith Completed
+type RgPyexecuteReplaceWith Incomplete
 
 func (c RgPyexecuteReplaceWith) Requirements(requirement ...string) RgPyexecuteRequirementsRequirements {
 	c.cs.s = append(c.cs.s, "REQUIREMENTS")
@@ -339,10 +339,10 @@ func (c RgPyexecuteReplaceWith) Requirements(requirement ...string) RgPyexecuteR
 
 func (c RgPyexecuteReplaceWith) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecuteRequirementsRequirements Completed
+type RgPyexecuteRequirementsRequirements Incomplete
 
 func (c RgPyexecuteRequirementsRequirements) Requirements(requirement ...string) RgPyexecuteRequirementsRequirements {
 	c.cs.s = append(c.cs.s, "REQUIREMENTS")
@@ -352,10 +352,10 @@ func (c RgPyexecuteRequirementsRequirements) Requirements(requirement ...string)
 
 func (c RgPyexecuteRequirementsRequirements) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecuteUnblocking Completed
+type RgPyexecuteUnblocking Incomplete
 
 func (c RgPyexecuteUnblocking) Id(id string) RgPyexecuteId {
 	c.cs.s = append(c.cs.s, "ID", id)
@@ -385,10 +385,10 @@ func (c RgPyexecuteUnblocking) Requirements(requirement ...string) RgPyexecuteRe
 
 func (c RgPyexecuteUnblocking) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPyexecuteUpgrade Completed
+type RgPyexecuteUpgrade Incomplete
 
 func (c RgPyexecuteUpgrade) ReplaceWith(replaceWith string) RgPyexecuteReplaceWith {
 	c.cs.s = append(c.cs.s, "REPLACE_WITH", replaceWith)
@@ -403,10 +403,10 @@ func (c RgPyexecuteUpgrade) Requirements(requirement ...string) RgPyexecuteRequi
 
 func (c RgPyexecuteUpgrade) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgPystats Completed
+type RgPystats Incomplete
 
 func (b Builder) RgPystats() (c RgPystats) {
 	c = RgPystats{cs: get(), ks: b.ks}
@@ -416,10 +416,10 @@ func (b Builder) RgPystats() (c RgPystats) {
 
 func (c RgPystats) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgRefreshcluster Completed
+type RgRefreshcluster Incomplete
 
 func (b Builder) RgRefreshcluster() (c RgRefreshcluster) {
 	c = RgRefreshcluster{cs: get(), ks: b.ks}
@@ -429,10 +429,10 @@ func (b Builder) RgRefreshcluster() (c RgRefreshcluster) {
 
 func (c RgRefreshcluster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgTrigger Completed
+type RgTrigger Incomplete
 
 func (b Builder) RgTrigger() (c RgTrigger) {
 	c = RgTrigger{cs: get(), ks: b.ks}
@@ -445,7 +445,7 @@ func (c RgTrigger) Trigger(trigger string) RgTriggerTrigger {
 	return (RgTriggerTrigger)(c)
 }
 
-type RgTriggerArgument Completed
+type RgTriggerArgument Incomplete
 
 func (c RgTriggerArgument) Argument(argument ...string) RgTriggerArgument {
 	c.cs.s = append(c.cs.s, argument...)
@@ -454,17 +454,17 @@ func (c RgTriggerArgument) Argument(argument ...string) RgTriggerArgument {
 
 func (c RgTriggerArgument) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RgTriggerTrigger Completed
+type RgTriggerTrigger Incomplete
 
 func (c RgTriggerTrigger) Argument(argument ...string) RgTriggerArgument {
 	c.cs.s = append(c.cs.s, argument...)
 	return (RgTriggerArgument)(c)
 }
 
-type RgUnregister Completed
+type RgUnregister Incomplete
 
 func (b Builder) RgUnregister() (c RgUnregister) {
 	c = RgUnregister{cs: get(), ks: b.ks}
@@ -477,9 +477,9 @@ func (c RgUnregister) Id(id string) RgUnregisterId {
 	return (RgUnregisterId)(c)
 }
 
-type RgUnregisterId Completed
+type RgUnregisterId Incomplete
 
 func (c RgUnregisterId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_generic.go
+++ b/internal/cmds/gen_generic.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Copy Completed
+type Copy Incomplete
 
 func (b Builder) Copy() (c Copy) {
 	c = Copy{cs: get(), ks: b.ks}
@@ -22,7 +22,7 @@ func (c Copy) Source(source string) CopySource {
 	return (CopySource)(c)
 }
 
-type CopyDb Completed
+type CopyDb Incomplete
 
 func (c CopyDb) Replace() CopyReplace {
 	c.cs.s = append(c.cs.s, "REPLACE")
@@ -31,10 +31,10 @@ func (c CopyDb) Replace() CopyReplace {
 
 func (c CopyDb) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CopyDestination Completed
+type CopyDestination Incomplete
 
 func (c CopyDestination) Db(destinationDb int64) CopyDb {
 	c.cs.s = append(c.cs.s, "DB", strconv.FormatInt(destinationDb, 10))
@@ -48,17 +48,17 @@ func (c CopyDestination) Replace() CopyReplace {
 
 func (c CopyDestination) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CopyReplace Completed
+type CopyReplace Incomplete
 
 func (c CopyReplace) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CopySource Completed
+type CopySource Incomplete
 
 func (c CopySource) Destination(destination string) CopyDestination {
 	if c.ks&NoSlot == NoSlot {
@@ -70,7 +70,7 @@ func (c CopySource) Destination(destination string) CopyDestination {
 	return (CopyDestination)(c)
 }
 
-type Del Completed
+type Del Incomplete
 
 func (b Builder) Del() (c Del) {
 	c = Del{cs: get(), ks: b.ks}
@@ -93,7 +93,7 @@ func (c Del) Key(key ...string) DelKey {
 	return (DelKey)(c)
 }
 
-type DelKey Completed
+type DelKey Incomplete
 
 func (c DelKey) Key(key ...string) DelKey {
 	if c.ks&NoSlot == NoSlot {
@@ -112,13 +112,13 @@ func (c DelKey) Key(key ...string) DelKey {
 
 func (c DelKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Dump Completed
+type Dump Incomplete
 
 func (b Builder) Dump() (c Dump) {
-	c = Dump{cs: get(), ks: b.ks, cf: readonly}
+	c = Dump{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "DUMP")
 	return c
 }
@@ -133,17 +133,17 @@ func (c Dump) Key(key string) DumpKey {
 	return (DumpKey)(c)
 }
 
-type DumpKey Completed
+type DumpKey Incomplete
 
 func (c DumpKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Exists Completed
+type Exists Incomplete
 
 func (b Builder) Exists() (c Exists) {
-	c = Exists{cs: get(), ks: b.ks, cf: readonly}
+	c = Exists{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "EXISTS")
 	return c
 }
@@ -163,7 +163,7 @@ func (c Exists) Key(key ...string) ExistsKey {
 	return (ExistsKey)(c)
 }
 
-type ExistsKey Completed
+type ExistsKey Incomplete
 
 func (c ExistsKey) Key(key ...string) ExistsKey {
 	if c.ks&NoSlot == NoSlot {
@@ -182,10 +182,10 @@ func (c ExistsKey) Key(key ...string) ExistsKey {
 
 func (c ExistsKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Expire Completed
+type Expire Incomplete
 
 func (b Builder) Expire() (c Expire) {
 	c = Expire{cs: get(), ks: b.ks}
@@ -203,42 +203,42 @@ func (c Expire) Key(key string) ExpireKey {
 	return (ExpireKey)(c)
 }
 
-type ExpireConditionGt Completed
+type ExpireConditionGt Incomplete
 
 func (c ExpireConditionGt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireConditionLt Completed
+type ExpireConditionLt Incomplete
 
 func (c ExpireConditionLt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireConditionNx Completed
+type ExpireConditionNx Incomplete
 
 func (c ExpireConditionNx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireConditionXx Completed
+type ExpireConditionXx Incomplete
 
 func (c ExpireConditionXx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireKey Completed
+type ExpireKey Incomplete
 
 func (c ExpireKey) Seconds(seconds int64) ExpireSeconds {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(seconds, 10))
 	return (ExpireSeconds)(c)
 }
 
-type ExpireSeconds Completed
+type ExpireSeconds Incomplete
 
 func (c ExpireSeconds) Nx() ExpireConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -262,10 +262,10 @@ func (c ExpireSeconds) Lt() ExpireConditionLt {
 
 func (c ExpireSeconds) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Expireat Completed
+type Expireat Incomplete
 
 func (b Builder) Expireat() (c Expireat) {
 	c = Expireat{cs: get(), ks: b.ks}
@@ -283,42 +283,42 @@ func (c Expireat) Key(key string) ExpireatKey {
 	return (ExpireatKey)(c)
 }
 
-type ExpireatConditionGt Completed
+type ExpireatConditionGt Incomplete
 
 func (c ExpireatConditionGt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireatConditionLt Completed
+type ExpireatConditionLt Incomplete
 
 func (c ExpireatConditionLt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireatConditionNx Completed
+type ExpireatConditionNx Incomplete
 
 func (c ExpireatConditionNx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireatConditionXx Completed
+type ExpireatConditionXx Incomplete
 
 func (c ExpireatConditionXx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ExpireatKey Completed
+type ExpireatKey Incomplete
 
 func (c ExpireatKey) Timestamp(timestamp int64) ExpireatTimestamp {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(timestamp, 10))
 	return (ExpireatTimestamp)(c)
 }
 
-type ExpireatTimestamp Completed
+type ExpireatTimestamp Incomplete
 
 func (c ExpireatTimestamp) Nx() ExpireatConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -342,13 +342,13 @@ func (c ExpireatTimestamp) Lt() ExpireatConditionLt {
 
 func (c ExpireatTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Expiretime Completed
+type Expiretime Incomplete
 
 func (b Builder) Expiretime() (c Expiretime) {
-	c = Expiretime{cs: get(), ks: b.ks, cf: readonly}
+	c = Expiretime{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "EXPIRETIME")
 	return c
 }
@@ -363,22 +363,22 @@ func (c Expiretime) Key(key string) ExpiretimeKey {
 	return (ExpiretimeKey)(c)
 }
 
-type ExpiretimeKey Completed
+type ExpiretimeKey Incomplete
 
 func (c ExpiretimeKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ExpiretimeKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Keys Completed
+type Keys Incomplete
 
 func (b Builder) Keys() (c Keys) {
-	c = Keys{cs: get(), ks: b.ks, cf: readonly}
+	c = Keys{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "KEYS")
 	return c
 }
@@ -388,17 +388,17 @@ func (c Keys) Pattern(pattern string) KeysPattern {
 	return (KeysPattern)(c)
 }
 
-type KeysPattern Completed
+type KeysPattern Incomplete
 
 func (c KeysPattern) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Migrate Completed
+type Migrate Incomplete
 
 func (b Builder) Migrate() (c Migrate) {
-	c = Migrate{cs: get(), ks: b.ks, cf: blockTag}
+	c = Migrate{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "MIGRATE")
 	return c
 }
@@ -408,7 +408,7 @@ func (c Migrate) Host(host string) MigrateHost {
 	return (MigrateHost)(c)
 }
 
-type MigrateAuthAuth Completed
+type MigrateAuthAuth Incomplete
 
 func (c MigrateAuthAuth) Auth2(username string, password string) MigrateAuthAuth2 {
 	c.cs.s = append(c.cs.s, "AUTH2", username, password)
@@ -433,10 +433,10 @@ func (c MigrateAuthAuth) Keys(key ...string) MigrateKeys {
 
 func (c MigrateAuthAuth) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MigrateAuthAuth2 Completed
+type MigrateAuthAuth2 Incomplete
 
 func (c MigrateAuthAuth2) Keys(key ...string) MigrateKeys {
 	if c.ks&NoSlot == NoSlot {
@@ -456,10 +456,10 @@ func (c MigrateAuthAuth2) Keys(key ...string) MigrateKeys {
 
 func (c MigrateAuthAuth2) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MigrateCopy Completed
+type MigrateCopy Incomplete
 
 func (c MigrateCopy) Replace() MigrateReplace {
 	c.cs.s = append(c.cs.s, "REPLACE")
@@ -494,31 +494,31 @@ func (c MigrateCopy) Keys(key ...string) MigrateKeys {
 
 func (c MigrateCopy) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MigrateDestinationDb Completed
+type MigrateDestinationDb Incomplete
 
 func (c MigrateDestinationDb) Timeout(timeout int64) MigrateTimeout {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(timeout, 10))
 	return (MigrateTimeout)(c)
 }
 
-type MigrateHost Completed
+type MigrateHost Incomplete
 
 func (c MigrateHost) Port(port int64) MigratePort {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(port, 10))
 	return (MigratePort)(c)
 }
 
-type MigrateKey Completed
+type MigrateKey Incomplete
 
 func (c MigrateKey) DestinationDb(destinationDb int64) MigrateDestinationDb {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(destinationDb, 10))
 	return (MigrateDestinationDb)(c)
 }
 
-type MigrateKeys Completed
+type MigrateKeys Incomplete
 
 func (c MigrateKeys) Keys(key ...string) MigrateKeys {
 	if c.ks&NoSlot == NoSlot {
@@ -538,10 +538,10 @@ func (c MigrateKeys) Keys(key ...string) MigrateKeys {
 
 func (c MigrateKeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MigratePort Completed
+type MigratePort Incomplete
 
 func (c MigratePort) Key(key string) MigrateKey {
 	if c.ks&NoSlot == NoSlot {
@@ -553,7 +553,7 @@ func (c MigratePort) Key(key string) MigrateKey {
 	return (MigrateKey)(c)
 }
 
-type MigrateReplace Completed
+type MigrateReplace Incomplete
 
 func (c MigrateReplace) Auth(password string) MigrateAuthAuth {
 	c.cs.s = append(c.cs.s, "AUTH", password)
@@ -583,10 +583,10 @@ func (c MigrateReplace) Keys(key ...string) MigrateKeys {
 
 func (c MigrateReplace) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MigrateTimeout Completed
+type MigrateTimeout Incomplete
 
 func (c MigrateTimeout) Copy() MigrateCopy {
 	c.cs.s = append(c.cs.s, "COPY")
@@ -626,10 +626,10 @@ func (c MigrateTimeout) Keys(key ...string) MigrateKeys {
 
 func (c MigrateTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Move Completed
+type Move Incomplete
 
 func (b Builder) Move() (c Move) {
 	c = Move{cs: get(), ks: b.ks}
@@ -647,24 +647,24 @@ func (c Move) Key(key string) MoveKey {
 	return (MoveKey)(c)
 }
 
-type MoveDb Completed
+type MoveDb Incomplete
 
 func (c MoveDb) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MoveKey Completed
+type MoveKey Incomplete
 
 func (c MoveKey) Db(db int64) MoveDb {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(db, 10))
 	return (MoveDb)(c)
 }
 
-type ObjectEncoding Completed
+type ObjectEncoding Incomplete
 
 func (b Builder) ObjectEncoding() (c ObjectEncoding) {
-	c = ObjectEncoding{cs: get(), ks: b.ks, cf: readonly}
+	c = ObjectEncoding{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "OBJECT", "ENCODING")
 	return c
 }
@@ -679,17 +679,17 @@ func (c ObjectEncoding) Key(key string) ObjectEncodingKey {
 	return (ObjectEncodingKey)(c)
 }
 
-type ObjectEncodingKey Completed
+type ObjectEncodingKey Incomplete
 
 func (c ObjectEncodingKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ObjectFreq Completed
+type ObjectFreq Incomplete
 
 func (b Builder) ObjectFreq() (c ObjectFreq) {
-	c = ObjectFreq{cs: get(), ks: b.ks, cf: readonly}
+	c = ObjectFreq{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "OBJECT", "FREQ")
 	return c
 }
@@ -704,30 +704,30 @@ func (c ObjectFreq) Key(key string) ObjectFreqKey {
 	return (ObjectFreqKey)(c)
 }
 
-type ObjectFreqKey Completed
+type ObjectFreqKey Incomplete
 
 func (c ObjectFreqKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ObjectHelp Completed
+type ObjectHelp Incomplete
 
 func (b Builder) ObjectHelp() (c ObjectHelp) {
-	c = ObjectHelp{cs: get(), ks: b.ks, cf: readonly}
+	c = ObjectHelp{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "OBJECT", "HELP")
 	return c
 }
 
 func (c ObjectHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ObjectIdletime Completed
+type ObjectIdletime Incomplete
 
 func (b Builder) ObjectIdletime() (c ObjectIdletime) {
-	c = ObjectIdletime{cs: get(), ks: b.ks, cf: readonly}
+	c = ObjectIdletime{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "OBJECT", "IDLETIME")
 	return c
 }
@@ -742,17 +742,17 @@ func (c ObjectIdletime) Key(key string) ObjectIdletimeKey {
 	return (ObjectIdletimeKey)(c)
 }
 
-type ObjectIdletimeKey Completed
+type ObjectIdletimeKey Incomplete
 
 func (c ObjectIdletimeKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ObjectRefcount Completed
+type ObjectRefcount Incomplete
 
 func (b Builder) ObjectRefcount() (c ObjectRefcount) {
-	c = ObjectRefcount{cs: get(), ks: b.ks, cf: readonly}
+	c = ObjectRefcount{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "OBJECT", "REFCOUNT")
 	return c
 }
@@ -767,14 +767,14 @@ func (c ObjectRefcount) Key(key string) ObjectRefcountKey {
 	return (ObjectRefcountKey)(c)
 }
 
-type ObjectRefcountKey Completed
+type ObjectRefcountKey Incomplete
 
 func (c ObjectRefcountKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Persist Completed
+type Persist Incomplete
 
 func (b Builder) Persist() (c Persist) {
 	c = Persist{cs: get(), ks: b.ks}
@@ -792,14 +792,14 @@ func (c Persist) Key(key string) PersistKey {
 	return (PersistKey)(c)
 }
 
-type PersistKey Completed
+type PersistKey Incomplete
 
 func (c PersistKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Pexpire Completed
+type Pexpire Incomplete
 
 func (b Builder) Pexpire() (c Pexpire) {
 	c = Pexpire{cs: get(), ks: b.ks}
@@ -817,42 +817,42 @@ func (c Pexpire) Key(key string) PexpireKey {
 	return (PexpireKey)(c)
 }
 
-type PexpireConditionGt Completed
+type PexpireConditionGt Incomplete
 
 func (c PexpireConditionGt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireConditionLt Completed
+type PexpireConditionLt Incomplete
 
 func (c PexpireConditionLt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireConditionNx Completed
+type PexpireConditionNx Incomplete
 
 func (c PexpireConditionNx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireConditionXx Completed
+type PexpireConditionXx Incomplete
 
 func (c PexpireConditionXx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireKey Completed
+type PexpireKey Incomplete
 
 func (c PexpireKey) Milliseconds(milliseconds int64) PexpireMilliseconds {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(milliseconds, 10))
 	return (PexpireMilliseconds)(c)
 }
 
-type PexpireMilliseconds Completed
+type PexpireMilliseconds Incomplete
 
 func (c PexpireMilliseconds) Nx() PexpireConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -876,10 +876,10 @@ func (c PexpireMilliseconds) Lt() PexpireConditionLt {
 
 func (c PexpireMilliseconds) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Pexpireat Completed
+type Pexpireat Incomplete
 
 func (b Builder) Pexpireat() (c Pexpireat) {
 	c = Pexpireat{cs: get(), ks: b.ks}
@@ -897,42 +897,42 @@ func (c Pexpireat) Key(key string) PexpireatKey {
 	return (PexpireatKey)(c)
 }
 
-type PexpireatConditionGt Completed
+type PexpireatConditionGt Incomplete
 
 func (c PexpireatConditionGt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireatConditionLt Completed
+type PexpireatConditionLt Incomplete
 
 func (c PexpireatConditionLt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireatConditionNx Completed
+type PexpireatConditionNx Incomplete
 
 func (c PexpireatConditionNx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireatConditionXx Completed
+type PexpireatConditionXx Incomplete
 
 func (c PexpireatConditionXx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PexpireatKey Completed
+type PexpireatKey Incomplete
 
 func (c PexpireatKey) MillisecondsTimestamp(millisecondsTimestamp int64) PexpireatMillisecondsTimestamp {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(millisecondsTimestamp, 10))
 	return (PexpireatMillisecondsTimestamp)(c)
 }
 
-type PexpireatMillisecondsTimestamp Completed
+type PexpireatMillisecondsTimestamp Incomplete
 
 func (c PexpireatMillisecondsTimestamp) Nx() PexpireatConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -956,13 +956,13 @@ func (c PexpireatMillisecondsTimestamp) Lt() PexpireatConditionLt {
 
 func (c PexpireatMillisecondsTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Pexpiretime Completed
+type Pexpiretime Incomplete
 
 func (b Builder) Pexpiretime() (c Pexpiretime) {
-	c = Pexpiretime{cs: get(), ks: b.ks, cf: readonly}
+	c = Pexpiretime{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PEXPIRETIME")
 	return c
 }
@@ -977,22 +977,22 @@ func (c Pexpiretime) Key(key string) PexpiretimeKey {
 	return (PexpiretimeKey)(c)
 }
 
-type PexpiretimeKey Completed
+type PexpiretimeKey Incomplete
 
 func (c PexpiretimeKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c PexpiretimeKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Pttl Completed
+type Pttl Incomplete
 
 func (b Builder) Pttl() (c Pttl) {
-	c = Pttl{cs: get(), ks: b.ks, cf: readonly}
+	c = Pttl{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PTTL")
 	return c
 }
@@ -1007,32 +1007,32 @@ func (c Pttl) Key(key string) PttlKey {
 	return (PttlKey)(c)
 }
 
-type PttlKey Completed
+type PttlKey Incomplete
 
 func (c PttlKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c PttlKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Randomkey Completed
+type Randomkey Incomplete
 
 func (b Builder) Randomkey() (c Randomkey) {
-	c = Randomkey{cs: get(), ks: b.ks, cf: readonly}
+	c = Randomkey{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "RANDOMKEY")
 	return c
 }
 
 func (c Randomkey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Rename Completed
+type Rename Incomplete
 
 func (b Builder) Rename() (c Rename) {
 	c = Rename{cs: get(), ks: b.ks}
@@ -1050,7 +1050,7 @@ func (c Rename) Key(key string) RenameKey {
 	return (RenameKey)(c)
 }
 
-type RenameKey Completed
+type RenameKey Incomplete
 
 func (c RenameKey) Newkey(newkey string) RenameNewkey {
 	if c.ks&NoSlot == NoSlot {
@@ -1062,14 +1062,14 @@ func (c RenameKey) Newkey(newkey string) RenameNewkey {
 	return (RenameNewkey)(c)
 }
 
-type RenameNewkey Completed
+type RenameNewkey Incomplete
 
 func (c RenameNewkey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Renamenx Completed
+type Renamenx Incomplete
 
 func (b Builder) Renamenx() (c Renamenx) {
 	c = Renamenx{cs: get(), ks: b.ks}
@@ -1087,7 +1087,7 @@ func (c Renamenx) Key(key string) RenamenxKey {
 	return (RenamenxKey)(c)
 }
 
-type RenamenxKey Completed
+type RenamenxKey Incomplete
 
 func (c RenamenxKey) Newkey(newkey string) RenamenxNewkey {
 	if c.ks&NoSlot == NoSlot {
@@ -1099,14 +1099,14 @@ func (c RenamenxKey) Newkey(newkey string) RenamenxNewkey {
 	return (RenamenxNewkey)(c)
 }
 
-type RenamenxNewkey Completed
+type RenamenxNewkey Incomplete
 
 func (c RenamenxNewkey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Restore Completed
+type Restore Incomplete
 
 func (b Builder) Restore() (c Restore) {
 	c = Restore{cs: get(), ks: b.ks}
@@ -1124,7 +1124,7 @@ func (c Restore) Key(key string) RestoreKey {
 	return (RestoreKey)(c)
 }
 
-type RestoreAbsttl Completed
+type RestoreAbsttl Incomplete
 
 func (c RestoreAbsttl) Idletime(seconds int64) RestoreIdletime {
 	c.cs.s = append(c.cs.s, "IDLETIME", strconv.FormatInt(seconds, 10))
@@ -1138,17 +1138,17 @@ func (c RestoreAbsttl) Freq(frequency int64) RestoreFreq {
 
 func (c RestoreAbsttl) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RestoreFreq Completed
+type RestoreFreq Incomplete
 
 func (c RestoreFreq) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RestoreIdletime Completed
+type RestoreIdletime Incomplete
 
 func (c RestoreIdletime) Freq(frequency int64) RestoreFreq {
 	c.cs.s = append(c.cs.s, "FREQ", strconv.FormatInt(frequency, 10))
@@ -1157,17 +1157,17 @@ func (c RestoreIdletime) Freq(frequency int64) RestoreFreq {
 
 func (c RestoreIdletime) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RestoreKey Completed
+type RestoreKey Incomplete
 
 func (c RestoreKey) Ttl(ttl int64) RestoreTtl {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(ttl, 10))
 	return (RestoreTtl)(c)
 }
 
-type RestoreReplace Completed
+type RestoreReplace Incomplete
 
 func (c RestoreReplace) Absttl() RestoreAbsttl {
 	c.cs.s = append(c.cs.s, "ABSTTL")
@@ -1186,10 +1186,10 @@ func (c RestoreReplace) Freq(frequency int64) RestoreFreq {
 
 func (c RestoreReplace) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RestoreSerializedValue Completed
+type RestoreSerializedValue Incomplete
 
 func (c RestoreSerializedValue) Replace() RestoreReplace {
 	c.cs.s = append(c.cs.s, "REPLACE")
@@ -1213,20 +1213,20 @@ func (c RestoreSerializedValue) Freq(frequency int64) RestoreFreq {
 
 func (c RestoreSerializedValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RestoreTtl Completed
+type RestoreTtl Incomplete
 
 func (c RestoreTtl) SerializedValue(serializedValue string) RestoreSerializedValue {
 	c.cs.s = append(c.cs.s, serializedValue)
 	return (RestoreSerializedValue)(c)
 }
 
-type Scan Completed
+type Scan Incomplete
 
 func (b Builder) Scan() (c Scan) {
-	c = Scan{cs: get(), ks: b.ks, cf: readonly}
+	c = Scan{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SCAN")
 	return c
 }
@@ -1236,7 +1236,7 @@ func (c Scan) Cursor(cursor uint64) ScanCursor {
 	return (ScanCursor)(c)
 }
 
-type ScanCount Completed
+type ScanCount Incomplete
 
 func (c ScanCount) Type(typ string) ScanType {
 	c.cs.s = append(c.cs.s, "TYPE", typ)
@@ -1245,10 +1245,10 @@ func (c ScanCount) Type(typ string) ScanType {
 
 func (c ScanCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScanCursor Completed
+type ScanCursor Incomplete
 
 func (c ScanCursor) Match(pattern string) ScanMatch {
 	c.cs.s = append(c.cs.s, "MATCH", pattern)
@@ -1267,10 +1267,10 @@ func (c ScanCursor) Type(typ string) ScanType {
 
 func (c ScanCursor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScanMatch Completed
+type ScanMatch Incomplete
 
 func (c ScanMatch) Count(count int64) ScanCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1284,17 +1284,17 @@ func (c ScanMatch) Type(typ string) ScanType {
 
 func (c ScanMatch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScanType Completed
+type ScanType Incomplete
 
 func (c ScanType) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sort Completed
+type Sort Incomplete
 
 func (b Builder) Sort() (c Sort) {
 	c = Sort{cs: get(), ks: b.ks}
@@ -1312,7 +1312,7 @@ func (c Sort) Key(key string) SortKey {
 	return (SortKey)(c)
 }
 
-type SortBy Completed
+type SortBy Incomplete
 
 func (c SortBy) Limit(offset int64, count int64) SortLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -1350,10 +1350,10 @@ func (c SortBy) Store(destination string) SortStore {
 
 func (c SortBy) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortGet Completed
+type SortGet Incomplete
 
 func (c SortGet) Get(pattern string) SortGet {
 	c.cs.s = append(c.cs.s, "GET", pattern)
@@ -1387,10 +1387,10 @@ func (c SortGet) Store(destination string) SortStore {
 
 func (c SortGet) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortKey Completed
+type SortKey Incomplete
 
 func (c SortKey) By(pattern string) SortBy {
 	c.cs.s = append(c.cs.s, "BY", pattern)
@@ -1433,10 +1433,10 @@ func (c SortKey) Store(destination string) SortStore {
 
 func (c SortKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortLimit Completed
+type SortLimit Incomplete
 
 func (c SortLimit) Get() SortGet {
 	return (SortGet)(c)
@@ -1469,10 +1469,10 @@ func (c SortLimit) Store(destination string) SortStore {
 
 func (c SortLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortOrderAsc Completed
+type SortOrderAsc Incomplete
 
 func (c SortOrderAsc) Alpha() SortSortingAlpha {
 	c.cs.s = append(c.cs.s, "ALPHA")
@@ -1491,10 +1491,10 @@ func (c SortOrderAsc) Store(destination string) SortStore {
 
 func (c SortOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortOrderDesc Completed
+type SortOrderDesc Incomplete
 
 func (c SortOrderDesc) Alpha() SortSortingAlpha {
 	c.cs.s = append(c.cs.s, "ALPHA")
@@ -1513,13 +1513,13 @@ func (c SortOrderDesc) Store(destination string) SortStore {
 
 func (c SortOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRo Completed
+type SortRo Incomplete
 
 func (b Builder) SortRo() (c SortRo) {
-	c = SortRo{cs: get(), ks: b.ks, cf: readonly}
+	c = SortRo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SORT_RO")
 	return c
 }
@@ -1534,7 +1534,7 @@ func (c SortRo) Key(key string) SortRoKey {
 	return (SortRoKey)(c)
 }
 
-type SortRoBy Completed
+type SortRoBy Incomplete
 
 func (c SortRoBy) Limit(offset int64, count int64) SortRoLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -1562,15 +1562,15 @@ func (c SortRoBy) Alpha() SortRoSortingAlpha {
 
 func (c SortRoBy) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoBy) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRoGet Completed
+type SortRoGet Incomplete
 
 func (c SortRoGet) Get(pattern string) SortRoGet {
 	c.cs.s = append(c.cs.s, "GET", pattern)
@@ -1594,15 +1594,15 @@ func (c SortRoGet) Alpha() SortRoSortingAlpha {
 
 func (c SortRoGet) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoGet) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRoKey Completed
+type SortRoKey Incomplete
 
 func (c SortRoKey) By(pattern string) SortRoBy {
 	c.cs.s = append(c.cs.s, "BY", pattern)
@@ -1635,15 +1635,15 @@ func (c SortRoKey) Alpha() SortRoSortingAlpha {
 
 func (c SortRoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRoLimit Completed
+type SortRoLimit Incomplete
 
 func (c SortRoLimit) Get() SortRoGet {
 	return (SortRoGet)(c)
@@ -1666,15 +1666,15 @@ func (c SortRoLimit) Alpha() SortRoSortingAlpha {
 
 func (c SortRoLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoLimit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRoOrderAsc Completed
+type SortRoOrderAsc Incomplete
 
 func (c SortRoOrderAsc) Alpha() SortRoSortingAlpha {
 	c.cs.s = append(c.cs.s, "ALPHA")
@@ -1683,15 +1683,15 @@ func (c SortRoOrderAsc) Alpha() SortRoSortingAlpha {
 
 func (c SortRoOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoOrderAsc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRoOrderDesc Completed
+type SortRoOrderDesc Incomplete
 
 func (c SortRoOrderDesc) Alpha() SortRoSortingAlpha {
 	c.cs.s = append(c.cs.s, "ALPHA")
@@ -1700,27 +1700,27 @@ func (c SortRoOrderDesc) Alpha() SortRoSortingAlpha {
 
 func (c SortRoOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoOrderDesc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortRoSortingAlpha Completed
+type SortRoSortingAlpha Incomplete
 
 func (c SortRoSortingAlpha) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SortRoSortingAlpha) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortSortingAlpha Completed
+type SortSortingAlpha Incomplete
 
 func (c SortSortingAlpha) Store(destination string) SortStore {
 	if c.ks&NoSlot == NoSlot {
@@ -1734,20 +1734,20 @@ func (c SortSortingAlpha) Store(destination string) SortStore {
 
 func (c SortSortingAlpha) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SortStore Completed
+type SortStore Incomplete
 
 func (c SortStore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Touch Completed
+type Touch Incomplete
 
 func (b Builder) Touch() (c Touch) {
-	c = Touch{cs: get(), ks: b.ks, cf: readonly}
+	c = Touch{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TOUCH")
 	return c
 }
@@ -1767,7 +1767,7 @@ func (c Touch) Key(key ...string) TouchKey {
 	return (TouchKey)(c)
 }
 
-type TouchKey Completed
+type TouchKey Incomplete
 
 func (c TouchKey) Key(key ...string) TouchKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1786,13 +1786,13 @@ func (c TouchKey) Key(key ...string) TouchKey {
 
 func (c TouchKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Ttl Completed
+type Ttl Incomplete
 
 func (b Builder) Ttl() (c Ttl) {
-	c = Ttl{cs: get(), ks: b.ks, cf: readonly}
+	c = Ttl{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TTL")
 	return c
 }
@@ -1807,22 +1807,22 @@ func (c Ttl) Key(key string) TtlKey {
 	return (TtlKey)(c)
 }
 
-type TtlKey Completed
+type TtlKey Incomplete
 
 func (c TtlKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c TtlKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Type Completed
+type Type Incomplete
 
 func (b Builder) Type() (c Type) {
-	c = Type{cs: get(), ks: b.ks, cf: readonly}
+	c = Type{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TYPE")
 	return c
 }
@@ -1837,19 +1837,19 @@ func (c Type) Key(key string) TypeKey {
 	return (TypeKey)(c)
 }
 
-type TypeKey Completed
+type TypeKey Incomplete
 
 func (c TypeKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c TypeKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Unlink Completed
+type Unlink Incomplete
 
 func (b Builder) Unlink() (c Unlink) {
 	c = Unlink{cs: get(), ks: b.ks}
@@ -1872,7 +1872,7 @@ func (c Unlink) Key(key ...string) UnlinkKey {
 	return (UnlinkKey)(c)
 }
 
-type UnlinkKey Completed
+type UnlinkKey Incomplete
 
 func (c UnlinkKey) Key(key ...string) UnlinkKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1891,13 +1891,13 @@ func (c UnlinkKey) Key(key ...string) UnlinkKey {
 
 func (c UnlinkKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Wait Completed
+type Wait Incomplete
 
 func (b Builder) Wait() (c Wait) {
-	c = Wait{cs: get(), ks: b.ks, cf: blockTag}
+	c = Wait{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "WAIT")
 	return c
 }
@@ -1907,24 +1907,24 @@ func (c Wait) Numreplicas(numreplicas int64) WaitNumreplicas {
 	return (WaitNumreplicas)(c)
 }
 
-type WaitNumreplicas Completed
+type WaitNumreplicas Incomplete
 
 func (c WaitNumreplicas) Timeout(timeout int64) WaitTimeout {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(timeout, 10))
 	return (WaitTimeout)(c)
 }
 
-type WaitTimeout Completed
+type WaitTimeout Incomplete
 
 func (c WaitTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Waitaof Completed
+type Waitaof Incomplete
 
 func (b Builder) Waitaof() (c Waitaof) {
-	c = Waitaof{cs: get(), ks: b.ks, cf: blockTag}
+	c = Waitaof{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "WAITAOF")
 	return c
 }
@@ -1934,23 +1934,23 @@ func (c Waitaof) Numlocal(numlocal int64) WaitaofNumlocal {
 	return (WaitaofNumlocal)(c)
 }
 
-type WaitaofNumlocal Completed
+type WaitaofNumlocal Incomplete
 
 func (c WaitaofNumlocal) Numreplicas(numreplicas int64) WaitaofNumreplicas {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numreplicas, 10))
 	return (WaitaofNumreplicas)(c)
 }
 
-type WaitaofNumreplicas Completed
+type WaitaofNumreplicas Incomplete
 
 func (c WaitaofNumreplicas) Timeout(timeout int64) WaitaofTimeout {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(timeout, 10))
 	return (WaitaofTimeout)(c)
 }
 
-type WaitaofTimeout Completed
+type WaitaofTimeout Incomplete
 
 func (c WaitaofTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_geo.go
+++ b/internal/cmds/gen_geo.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Geoadd Completed
+type Geoadd Incomplete
 
 func (b Builder) Geoadd() (c Geoadd) {
 	c = Geoadd{cs: get(), ks: b.ks}
@@ -22,13 +22,13 @@ func (c Geoadd) Key(key string) GeoaddKey {
 	return (GeoaddKey)(c)
 }
 
-type GeoaddChangeCh Completed
+type GeoaddChangeCh Incomplete
 
 func (c GeoaddChangeCh) LongitudeLatitudeMember() GeoaddLongitudeLatitudeMember {
 	return (GeoaddLongitudeLatitudeMember)(c)
 }
 
-type GeoaddConditionNx Completed
+type GeoaddConditionNx Incomplete
 
 func (c GeoaddConditionNx) Ch() GeoaddChangeCh {
 	c.cs.s = append(c.cs.s, "CH")
@@ -39,7 +39,7 @@ func (c GeoaddConditionNx) LongitudeLatitudeMember() GeoaddLongitudeLatitudeMemb
 	return (GeoaddLongitudeLatitudeMember)(c)
 }
 
-type GeoaddConditionXx Completed
+type GeoaddConditionXx Incomplete
 
 func (c GeoaddConditionXx) Ch() GeoaddChangeCh {
 	c.cs.s = append(c.cs.s, "CH")
@@ -50,7 +50,7 @@ func (c GeoaddConditionXx) LongitudeLatitudeMember() GeoaddLongitudeLatitudeMemb
 	return (GeoaddLongitudeLatitudeMember)(c)
 }
 
-type GeoaddKey Completed
+type GeoaddKey Incomplete
 
 func (c GeoaddKey) Nx() GeoaddConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -71,7 +71,7 @@ func (c GeoaddKey) LongitudeLatitudeMember() GeoaddLongitudeLatitudeMember {
 	return (GeoaddLongitudeLatitudeMember)(c)
 }
 
-type GeoaddLongitudeLatitudeMember Completed
+type GeoaddLongitudeLatitudeMember Incomplete
 
 func (c GeoaddLongitudeLatitudeMember) LongitudeLatitudeMember(longitude float64, latitude float64, member string) GeoaddLongitudeLatitudeMember {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(longitude, 'f', -1, 64), strconv.FormatFloat(latitude, 'f', -1, 64), member)
@@ -80,13 +80,13 @@ func (c GeoaddLongitudeLatitudeMember) LongitudeLatitudeMember(longitude float64
 
 func (c GeoaddLongitudeLatitudeMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Geodist Completed
+type Geodist Incomplete
 
 func (b Builder) Geodist() (c Geodist) {
-	c = Geodist{cs: get(), ks: b.ks, cf: readonly}
+	c = Geodist{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GEODIST")
 	return c
 }
@@ -101,21 +101,21 @@ func (c Geodist) Key(key string) GeodistKey {
 	return (GeodistKey)(c)
 }
 
-type GeodistKey Completed
+type GeodistKey Incomplete
 
 func (c GeodistKey) Member1(member1 string) GeodistMember1 {
 	c.cs.s = append(c.cs.s, member1)
 	return (GeodistMember1)(c)
 }
 
-type GeodistMember1 Completed
+type GeodistMember1 Incomplete
 
 func (c GeodistMember1) Member2(member2 string) GeodistMember2 {
 	c.cs.s = append(c.cs.s, member2)
 	return (GeodistMember2)(c)
 }
 
-type GeodistMember2 Completed
+type GeodistMember2 Incomplete
 
 func (c GeodistMember2) M() GeodistUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -139,66 +139,66 @@ func (c GeodistMember2) Mi() GeodistUnitMi {
 
 func (c GeodistMember2) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeodistMember2) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeodistUnitFt Completed
+type GeodistUnitFt Incomplete
 
 func (c GeodistUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeodistUnitFt) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeodistUnitKm Completed
+type GeodistUnitKm Incomplete
 
 func (c GeodistUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeodistUnitKm) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeodistUnitM Completed
+type GeodistUnitM Incomplete
 
 func (c GeodistUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeodistUnitM) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeodistUnitMi Completed
+type GeodistUnitMi Incomplete
 
 func (c GeodistUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeodistUnitMi) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Geohash Completed
+type Geohash Incomplete
 
 func (b Builder) Geohash() (c Geohash) {
-	c = Geohash{cs: get(), ks: b.ks, cf: readonly}
+	c = Geohash{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GEOHASH")
 	return c
 }
@@ -213,7 +213,7 @@ func (c Geohash) Key(key string) GeohashKey {
 	return (GeohashKey)(c)
 }
 
-type GeohashKey Completed
+type GeohashKey Incomplete
 
 func (c GeohashKey) Member(member ...string) GeohashMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -222,15 +222,15 @@ func (c GeohashKey) Member(member ...string) GeohashMember {
 
 func (c GeohashKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeohashKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeohashMember Completed
+type GeohashMember Incomplete
 
 func (c GeohashMember) Member(member ...string) GeohashMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -239,18 +239,18 @@ func (c GeohashMember) Member(member ...string) GeohashMember {
 
 func (c GeohashMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeohashMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Geopos Completed
+type Geopos Incomplete
 
 func (b Builder) Geopos() (c Geopos) {
-	c = Geopos{cs: get(), ks: b.ks, cf: readonly}
+	c = Geopos{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GEOPOS")
 	return c
 }
@@ -265,7 +265,7 @@ func (c Geopos) Key(key string) GeoposKey {
 	return (GeoposKey)(c)
 }
 
-type GeoposKey Completed
+type GeoposKey Incomplete
 
 func (c GeoposKey) Member(member ...string) GeoposMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -274,15 +274,15 @@ func (c GeoposKey) Member(member ...string) GeoposMember {
 
 func (c GeoposKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoposKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoposMember Completed
+type GeoposMember Incomplete
 
 func (c GeoposMember) Member(member ...string) GeoposMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -291,15 +291,15 @@ func (c GeoposMember) Member(member ...string) GeoposMember {
 
 func (c GeoposMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoposMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Georadius Completed
+type Georadius Incomplete
 
 func (b Builder) Georadius() (c Georadius) {
 	c = Georadius{cs: get(), ks: b.ks}
@@ -317,7 +317,7 @@ func (c Georadius) Key(key string) GeoradiusKey {
 	return (GeoradiusKey)(c)
 }
 
-type GeoradiusCountAny Completed
+type GeoradiusCountAny Incomplete
 
 func (c GeoradiusCountAny) Asc() GeoradiusOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -351,10 +351,10 @@ func (c GeoradiusCountAny) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusCountAny) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusCountCount Completed
+type GeoradiusCountCount Incomplete
 
 func (c GeoradiusCountCount) Any() GeoradiusCountAny {
 	c.cs.s = append(c.cs.s, "ANY")
@@ -393,31 +393,31 @@ func (c GeoradiusCountCount) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusKey Completed
+type GeoradiusKey Incomplete
 
 func (c GeoradiusKey) Longitude(longitude float64) GeoradiusLongitude {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(longitude, 'f', -1, 64))
 	return (GeoradiusLongitude)(c)
 }
 
-type GeoradiusLatitude Completed
+type GeoradiusLatitude Incomplete
 
 func (c GeoradiusLatitude) Radius(radius float64) GeoradiusRadius {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(radius, 'f', -1, 64))
 	return (GeoradiusRadius)(c)
 }
 
-type GeoradiusLongitude Completed
+type GeoradiusLongitude Incomplete
 
 func (c GeoradiusLongitude) Latitude(latitude float64) GeoradiusLatitude {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(latitude, 'f', -1, 64))
 	return (GeoradiusLatitude)(c)
 }
 
-type GeoradiusOrderAsc Completed
+type GeoradiusOrderAsc Incomplete
 
 func (c GeoradiusOrderAsc) Store(key string) GeoradiusStoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -441,10 +441,10 @@ func (c GeoradiusOrderAsc) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusOrderDesc Completed
+type GeoradiusOrderDesc Incomplete
 
 func (c GeoradiusOrderDesc) Store(key string) GeoradiusStoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -468,10 +468,10 @@ func (c GeoradiusOrderDesc) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRadius Completed
+type GeoradiusRadius Incomplete
 
 func (c GeoradiusRadius) M() GeoradiusUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -493,10 +493,10 @@ func (c GeoradiusRadius) Mi() GeoradiusUnitMi {
 	return (GeoradiusUnitMi)(c)
 }
 
-type GeoradiusRo Completed
+type GeoradiusRo Incomplete
 
 func (b Builder) GeoradiusRo() (c GeoradiusRo) {
-	c = GeoradiusRo{cs: get(), ks: b.ks, cf: readonly}
+	c = GeoradiusRo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GEORADIUS_RO")
 	return c
 }
@@ -511,7 +511,7 @@ func (c GeoradiusRo) Key(key string) GeoradiusRoKey {
 	return (GeoradiusRoKey)(c)
 }
 
-type GeoradiusRoCountAny Completed
+type GeoradiusRoCountAny Incomplete
 
 func (c GeoradiusRoCountAny) Asc() GeoradiusRoOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -525,15 +525,15 @@ func (c GeoradiusRoCountAny) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoCountAny) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoCountAny) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoCountCount Completed
+type GeoradiusRoCountCount Incomplete
 
 func (c GeoradiusRoCountCount) Any() GeoradiusRoCountAny {
 	c.cs.s = append(c.cs.s, "ANY")
@@ -552,60 +552,60 @@ func (c GeoradiusRoCountCount) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoCountCount) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoKey Completed
+type GeoradiusRoKey Incomplete
 
 func (c GeoradiusRoKey) Longitude(longitude float64) GeoradiusRoLongitude {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(longitude, 'f', -1, 64))
 	return (GeoradiusRoLongitude)(c)
 }
 
-type GeoradiusRoLatitude Completed
+type GeoradiusRoLatitude Incomplete
 
 func (c GeoradiusRoLatitude) Radius(radius float64) GeoradiusRoRadius {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(radius, 'f', -1, 64))
 	return (GeoradiusRoRadius)(c)
 }
 
-type GeoradiusRoLongitude Completed
+type GeoradiusRoLongitude Incomplete
 
 func (c GeoradiusRoLongitude) Latitude(latitude float64) GeoradiusRoLatitude {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(latitude, 'f', -1, 64))
 	return (GeoradiusRoLatitude)(c)
 }
 
-type GeoradiusRoOrderAsc Completed
+type GeoradiusRoOrderAsc Incomplete
 
 func (c GeoradiusRoOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoOrderAsc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoOrderDesc Completed
+type GeoradiusRoOrderDesc Incomplete
 
 func (c GeoradiusRoOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoOrderDesc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoRadius Completed
+type GeoradiusRoRadius Incomplete
 
 func (c GeoradiusRoRadius) M() GeoradiusRoUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -627,7 +627,7 @@ func (c GeoradiusRoRadius) Mi() GeoradiusRoUnitMi {
 	return (GeoradiusRoUnitMi)(c)
 }
 
-type GeoradiusRoUnitFt Completed
+type GeoradiusRoUnitFt Incomplete
 
 func (c GeoradiusRoUnitFt) Withcoord() GeoradiusRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -661,15 +661,15 @@ func (c GeoradiusRoUnitFt) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoUnitFt) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoUnitKm Completed
+type GeoradiusRoUnitKm Incomplete
 
 func (c GeoradiusRoUnitKm) Withcoord() GeoradiusRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -703,15 +703,15 @@ func (c GeoradiusRoUnitKm) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoUnitKm) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoUnitM Completed
+type GeoradiusRoUnitM Incomplete
 
 func (c GeoradiusRoUnitM) Withcoord() GeoradiusRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -745,15 +745,15 @@ func (c GeoradiusRoUnitM) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoUnitM) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoUnitMi Completed
+type GeoradiusRoUnitMi Incomplete
 
 func (c GeoradiusRoUnitMi) Withcoord() GeoradiusRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -787,15 +787,15 @@ func (c GeoradiusRoUnitMi) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoUnitMi) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoWithcoord Completed
+type GeoradiusRoWithcoord Incomplete
 
 func (c GeoradiusRoWithcoord) Withdist() GeoradiusRoWithdist {
 	c.cs.s = append(c.cs.s, "WITHDIST")
@@ -824,15 +824,15 @@ func (c GeoradiusRoWithcoord) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoWithcoord) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoWithcoord) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoWithdist Completed
+type GeoradiusRoWithdist Incomplete
 
 func (c GeoradiusRoWithdist) Withhash() GeoradiusRoWithhash {
 	c.cs.s = append(c.cs.s, "WITHHASH")
@@ -856,15 +856,15 @@ func (c GeoradiusRoWithdist) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoWithdist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoWithdist) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusRoWithhash Completed
+type GeoradiusRoWithhash Incomplete
 
 func (c GeoradiusRoWithhash) Count(count int64) GeoradiusRoCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -883,29 +883,29 @@ func (c GeoradiusRoWithhash) Desc() GeoradiusRoOrderDesc {
 
 func (c GeoradiusRoWithhash) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusRoWithhash) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusStoreKey Completed
+type GeoradiusStoreKey Incomplete
 
 func (c GeoradiusStoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusStoredistKey Completed
+type GeoradiusStoredistKey Incomplete
 
 func (c GeoradiusStoredistKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusUnitFt Completed
+type GeoradiusUnitFt Incomplete
 
 func (c GeoradiusUnitFt) Withcoord() GeoradiusWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -959,10 +959,10 @@ func (c GeoradiusUnitFt) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusUnitKm Completed
+type GeoradiusUnitKm Incomplete
 
 func (c GeoradiusUnitKm) Withcoord() GeoradiusWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1016,10 +1016,10 @@ func (c GeoradiusUnitKm) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusUnitM Completed
+type GeoradiusUnitM Incomplete
 
 func (c GeoradiusUnitM) Withcoord() GeoradiusWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1073,10 +1073,10 @@ func (c GeoradiusUnitM) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusUnitMi Completed
+type GeoradiusUnitMi Incomplete
 
 func (c GeoradiusUnitMi) Withcoord() GeoradiusWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1130,10 +1130,10 @@ func (c GeoradiusUnitMi) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusWithcoord Completed
+type GeoradiusWithcoord Incomplete
 
 func (c GeoradiusWithcoord) Withdist() GeoradiusWithdist {
 	c.cs.s = append(c.cs.s, "WITHDIST")
@@ -1182,10 +1182,10 @@ func (c GeoradiusWithcoord) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusWithcoord) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusWithdist Completed
+type GeoradiusWithdist Incomplete
 
 func (c GeoradiusWithdist) Withhash() GeoradiusWithhash {
 	c.cs.s = append(c.cs.s, "WITHHASH")
@@ -1229,10 +1229,10 @@ func (c GeoradiusWithdist) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusWithdist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusWithhash Completed
+type GeoradiusWithhash Incomplete
 
 func (c GeoradiusWithhash) Count(count int64) GeoradiusCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1271,10 +1271,10 @@ func (c GeoradiusWithhash) Storedist(key string) GeoradiusStoredistKey {
 
 func (c GeoradiusWithhash) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Georadiusbymember Completed
+type Georadiusbymember Incomplete
 
 func (b Builder) Georadiusbymember() (c Georadiusbymember) {
 	c = Georadiusbymember{cs: get(), ks: b.ks}
@@ -1292,7 +1292,7 @@ func (c Georadiusbymember) Key(key string) GeoradiusbymemberKey {
 	return (GeoradiusbymemberKey)(c)
 }
 
-type GeoradiusbymemberCountAny Completed
+type GeoradiusbymemberCountAny Incomplete
 
 func (c GeoradiusbymemberCountAny) Asc() GeoradiusbymemberOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -1326,10 +1326,10 @@ func (c GeoradiusbymemberCountAny) Storedist(key string) GeoradiusbymemberStoreS
 
 func (c GeoradiusbymemberCountAny) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberCountCount Completed
+type GeoradiusbymemberCountCount Incomplete
 
 func (c GeoradiusbymemberCountCount) Any() GeoradiusbymemberCountAny {
 	c.cs.s = append(c.cs.s, "ANY")
@@ -1368,24 +1368,24 @@ func (c GeoradiusbymemberCountCount) Storedist(key string) GeoradiusbymemberStor
 
 func (c GeoradiusbymemberCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberKey Completed
+type GeoradiusbymemberKey Incomplete
 
 func (c GeoradiusbymemberKey) Member(member string) GeoradiusbymemberMember {
 	c.cs.s = append(c.cs.s, member)
 	return (GeoradiusbymemberMember)(c)
 }
 
-type GeoradiusbymemberMember Completed
+type GeoradiusbymemberMember Incomplete
 
 func (c GeoradiusbymemberMember) Radius(radius float64) GeoradiusbymemberRadius {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(radius, 'f', -1, 64))
 	return (GeoradiusbymemberRadius)(c)
 }
 
-type GeoradiusbymemberOrderAsc Completed
+type GeoradiusbymemberOrderAsc Incomplete
 
 func (c GeoradiusbymemberOrderAsc) Store(key string) GeoradiusbymemberStoreStoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1409,10 +1409,10 @@ func (c GeoradiusbymemberOrderAsc) Storedist(key string) GeoradiusbymemberStoreS
 
 func (c GeoradiusbymemberOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberOrderDesc Completed
+type GeoradiusbymemberOrderDesc Incomplete
 
 func (c GeoradiusbymemberOrderDesc) Store(key string) GeoradiusbymemberStoreStoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1436,10 +1436,10 @@ func (c GeoradiusbymemberOrderDesc) Storedist(key string) GeoradiusbymemberStore
 
 func (c GeoradiusbymemberOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRadius Completed
+type GeoradiusbymemberRadius Incomplete
 
 func (c GeoradiusbymemberRadius) M() GeoradiusbymemberUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -1461,10 +1461,10 @@ func (c GeoradiusbymemberRadius) Mi() GeoradiusbymemberUnitMi {
 	return (GeoradiusbymemberUnitMi)(c)
 }
 
-type GeoradiusbymemberRo Completed
+type GeoradiusbymemberRo Incomplete
 
 func (b Builder) GeoradiusbymemberRo() (c GeoradiusbymemberRo) {
-	c = GeoradiusbymemberRo{cs: get(), ks: b.ks, cf: readonly}
+	c = GeoradiusbymemberRo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GEORADIUSBYMEMBER_RO")
 	return c
 }
@@ -1479,7 +1479,7 @@ func (c GeoradiusbymemberRo) Key(key string) GeoradiusbymemberRoKey {
 	return (GeoradiusbymemberRoKey)(c)
 }
 
-type GeoradiusbymemberRoCountAny Completed
+type GeoradiusbymemberRoCountAny Incomplete
 
 func (c GeoradiusbymemberRoCountAny) Asc() GeoradiusbymemberRoOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -1493,15 +1493,15 @@ func (c GeoradiusbymemberRoCountAny) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoCountAny) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoCountAny) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoCountCount Completed
+type GeoradiusbymemberRoCountCount Incomplete
 
 func (c GeoradiusbymemberRoCountCount) Any() GeoradiusbymemberRoCountAny {
 	c.cs.s = append(c.cs.s, "ANY")
@@ -1520,53 +1520,53 @@ func (c GeoradiusbymemberRoCountCount) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoCountCount) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoKey Completed
+type GeoradiusbymemberRoKey Incomplete
 
 func (c GeoradiusbymemberRoKey) Member(member string) GeoradiusbymemberRoMember {
 	c.cs.s = append(c.cs.s, member)
 	return (GeoradiusbymemberRoMember)(c)
 }
 
-type GeoradiusbymemberRoMember Completed
+type GeoradiusbymemberRoMember Incomplete
 
 func (c GeoradiusbymemberRoMember) Radius(radius float64) GeoradiusbymemberRoRadius {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(radius, 'f', -1, 64))
 	return (GeoradiusbymemberRoRadius)(c)
 }
 
-type GeoradiusbymemberRoOrderAsc Completed
+type GeoradiusbymemberRoOrderAsc Incomplete
 
 func (c GeoradiusbymemberRoOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoOrderAsc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoOrderDesc Completed
+type GeoradiusbymemberRoOrderDesc Incomplete
 
 func (c GeoradiusbymemberRoOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoOrderDesc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoRadius Completed
+type GeoradiusbymemberRoRadius Incomplete
 
 func (c GeoradiusbymemberRoRadius) M() GeoradiusbymemberRoUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -1588,7 +1588,7 @@ func (c GeoradiusbymemberRoRadius) Mi() GeoradiusbymemberRoUnitMi {
 	return (GeoradiusbymemberRoUnitMi)(c)
 }
 
-type GeoradiusbymemberRoUnitFt Completed
+type GeoradiusbymemberRoUnitFt Incomplete
 
 func (c GeoradiusbymemberRoUnitFt) Withcoord() GeoradiusbymemberRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1622,15 +1622,15 @@ func (c GeoradiusbymemberRoUnitFt) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoUnitFt) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoUnitKm Completed
+type GeoradiusbymemberRoUnitKm Incomplete
 
 func (c GeoradiusbymemberRoUnitKm) Withcoord() GeoradiusbymemberRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1664,15 +1664,15 @@ func (c GeoradiusbymemberRoUnitKm) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoUnitKm) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoUnitM Completed
+type GeoradiusbymemberRoUnitM Incomplete
 
 func (c GeoradiusbymemberRoUnitM) Withcoord() GeoradiusbymemberRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1706,15 +1706,15 @@ func (c GeoradiusbymemberRoUnitM) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoUnitM) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoUnitMi Completed
+type GeoradiusbymemberRoUnitMi Incomplete
 
 func (c GeoradiusbymemberRoUnitMi) Withcoord() GeoradiusbymemberRoWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1748,15 +1748,15 @@ func (c GeoradiusbymemberRoUnitMi) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoUnitMi) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoWithcoord Completed
+type GeoradiusbymemberRoWithcoord Incomplete
 
 func (c GeoradiusbymemberRoWithcoord) Withdist() GeoradiusbymemberRoWithdist {
 	c.cs.s = append(c.cs.s, "WITHDIST")
@@ -1785,15 +1785,15 @@ func (c GeoradiusbymemberRoWithcoord) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoWithcoord) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoWithcoord) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoWithdist Completed
+type GeoradiusbymemberRoWithdist Incomplete
 
 func (c GeoradiusbymemberRoWithdist) Withhash() GeoradiusbymemberRoWithhash {
 	c.cs.s = append(c.cs.s, "WITHHASH")
@@ -1817,15 +1817,15 @@ func (c GeoradiusbymemberRoWithdist) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoWithdist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoWithdist) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberRoWithhash Completed
+type GeoradiusbymemberRoWithhash Incomplete
 
 func (c GeoradiusbymemberRoWithhash) Count(count int64) GeoradiusbymemberRoCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1844,29 +1844,29 @@ func (c GeoradiusbymemberRoWithhash) Desc() GeoradiusbymemberRoOrderDesc {
 
 func (c GeoradiusbymemberRoWithhash) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeoradiusbymemberRoWithhash) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberStoreStoreKey Completed
+type GeoradiusbymemberStoreStoreKey Incomplete
 
 func (c GeoradiusbymemberStoreStoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberStoreStoredistKey Completed
+type GeoradiusbymemberStoreStoredistKey Incomplete
 
 func (c GeoradiusbymemberStoreStoredistKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberUnitFt Completed
+type GeoradiusbymemberUnitFt Incomplete
 
 func (c GeoradiusbymemberUnitFt) Withcoord() GeoradiusbymemberWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1920,10 +1920,10 @@ func (c GeoradiusbymemberUnitFt) Storedist(key string) GeoradiusbymemberStoreSto
 
 func (c GeoradiusbymemberUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberUnitKm Completed
+type GeoradiusbymemberUnitKm Incomplete
 
 func (c GeoradiusbymemberUnitKm) Withcoord() GeoradiusbymemberWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -1977,10 +1977,10 @@ func (c GeoradiusbymemberUnitKm) Storedist(key string) GeoradiusbymemberStoreSto
 
 func (c GeoradiusbymemberUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberUnitM Completed
+type GeoradiusbymemberUnitM Incomplete
 
 func (c GeoradiusbymemberUnitM) Withcoord() GeoradiusbymemberWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -2034,10 +2034,10 @@ func (c GeoradiusbymemberUnitM) Storedist(key string) GeoradiusbymemberStoreStor
 
 func (c GeoradiusbymemberUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberUnitMi Completed
+type GeoradiusbymemberUnitMi Incomplete
 
 func (c GeoradiusbymemberUnitMi) Withcoord() GeoradiusbymemberWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -2091,10 +2091,10 @@ func (c GeoradiusbymemberUnitMi) Storedist(key string) GeoradiusbymemberStoreSto
 
 func (c GeoradiusbymemberUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberWithcoord Completed
+type GeoradiusbymemberWithcoord Incomplete
 
 func (c GeoradiusbymemberWithcoord) Withdist() GeoradiusbymemberWithdist {
 	c.cs.s = append(c.cs.s, "WITHDIST")
@@ -2143,10 +2143,10 @@ func (c GeoradiusbymemberWithcoord) Storedist(key string) GeoradiusbymemberStore
 
 func (c GeoradiusbymemberWithcoord) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberWithdist Completed
+type GeoradiusbymemberWithdist Incomplete
 
 func (c GeoradiusbymemberWithdist) Withhash() GeoradiusbymemberWithhash {
 	c.cs.s = append(c.cs.s, "WITHHASH")
@@ -2190,10 +2190,10 @@ func (c GeoradiusbymemberWithdist) Storedist(key string) GeoradiusbymemberStoreS
 
 func (c GeoradiusbymemberWithdist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeoradiusbymemberWithhash Completed
+type GeoradiusbymemberWithhash Incomplete
 
 func (c GeoradiusbymemberWithhash) Count(count int64) GeoradiusbymemberCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -2232,13 +2232,13 @@ func (c GeoradiusbymemberWithhash) Storedist(key string) GeoradiusbymemberStoreS
 
 func (c GeoradiusbymemberWithhash) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Geosearch Completed
+type Geosearch Incomplete
 
 func (b Builder) Geosearch() (c Geosearch) {
-	c = Geosearch{cs: get(), ks: b.ks, cf: readonly}
+	c = Geosearch{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GEOSEARCH")
 	return c
 }
@@ -2253,14 +2253,14 @@ func (c Geosearch) Key(key string) GeosearchKey {
 	return (GeosearchKey)(c)
 }
 
-type GeosearchCircleBoxBybox Completed
+type GeosearchCircleBoxBybox Incomplete
 
 func (c GeosearchCircleBoxBybox) Height(height float64) GeosearchCircleBoxHeight {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(height, 'f', -1, 64))
 	return (GeosearchCircleBoxHeight)(c)
 }
 
-type GeosearchCircleBoxHeight Completed
+type GeosearchCircleBoxHeight Incomplete
 
 func (c GeosearchCircleBoxHeight) M() GeosearchCircleBoxUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -2282,7 +2282,7 @@ func (c GeosearchCircleBoxHeight) Mi() GeosearchCircleBoxUnitMi {
 	return (GeosearchCircleBoxUnitMi)(c)
 }
 
-type GeosearchCircleBoxUnitFt Completed
+type GeosearchCircleBoxUnitFt Incomplete
 
 func (c GeosearchCircleBoxUnitFt) Asc() GeosearchOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -2316,15 +2316,15 @@ func (c GeosearchCircleBoxUnitFt) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleBoxUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleBoxUnitFt) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleBoxUnitKm Completed
+type GeosearchCircleBoxUnitKm Incomplete
 
 func (c GeosearchCircleBoxUnitKm) Asc() GeosearchOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -2358,15 +2358,15 @@ func (c GeosearchCircleBoxUnitKm) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleBoxUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleBoxUnitKm) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleBoxUnitM Completed
+type GeosearchCircleBoxUnitM Incomplete
 
 func (c GeosearchCircleBoxUnitM) Asc() GeosearchOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -2400,15 +2400,15 @@ func (c GeosearchCircleBoxUnitM) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleBoxUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleBoxUnitM) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleBoxUnitMi Completed
+type GeosearchCircleBoxUnitMi Incomplete
 
 func (c GeosearchCircleBoxUnitMi) Asc() GeosearchOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -2442,15 +2442,15 @@ func (c GeosearchCircleBoxUnitMi) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleBoxUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleBoxUnitMi) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleCircleByradius Completed
+type GeosearchCircleCircleByradius Incomplete
 
 func (c GeosearchCircleCircleByradius) M() GeosearchCircleCircleUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -2472,7 +2472,7 @@ func (c GeosearchCircleCircleByradius) Mi() GeosearchCircleCircleUnitMi {
 	return (GeosearchCircleCircleUnitMi)(c)
 }
 
-type GeosearchCircleCircleUnitFt Completed
+type GeosearchCircleCircleUnitFt Incomplete
 
 func (c GeosearchCircleCircleUnitFt) Bybox(width float64) GeosearchCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -2511,15 +2511,15 @@ func (c GeosearchCircleCircleUnitFt) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleCircleUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleCircleUnitFt) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleCircleUnitKm Completed
+type GeosearchCircleCircleUnitKm Incomplete
 
 func (c GeosearchCircleCircleUnitKm) Bybox(width float64) GeosearchCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -2558,15 +2558,15 @@ func (c GeosearchCircleCircleUnitKm) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleCircleUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleCircleUnitKm) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleCircleUnitM Completed
+type GeosearchCircleCircleUnitM Incomplete
 
 func (c GeosearchCircleCircleUnitM) Bybox(width float64) GeosearchCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -2605,15 +2605,15 @@ func (c GeosearchCircleCircleUnitM) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleCircleUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleCircleUnitM) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCircleCircleUnitMi Completed
+type GeosearchCircleCircleUnitMi Incomplete
 
 func (c GeosearchCircleCircleUnitMi) Bybox(width float64) GeosearchCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -2652,15 +2652,15 @@ func (c GeosearchCircleCircleUnitMi) Withhash() GeosearchWithhash {
 
 func (c GeosearchCircleCircleUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCircleCircleUnitMi) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCountAny Completed
+type GeosearchCountAny Incomplete
 
 func (c GeosearchCountAny) Withcoord() GeosearchWithcoord {
 	c.cs.s = append(c.cs.s, "WITHCOORD")
@@ -2679,15 +2679,15 @@ func (c GeosearchCountAny) Withhash() GeosearchWithhash {
 
 func (c GeosearchCountAny) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCountAny) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchCountCount Completed
+type GeosearchCountCount Incomplete
 
 func (c GeosearchCountCount) Any() GeosearchCountAny {
 	c.cs.s = append(c.cs.s, "ANY")
@@ -2711,15 +2711,15 @@ func (c GeosearchCountCount) Withhash() GeosearchWithhash {
 
 func (c GeosearchCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchCountCount) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchFrommemberFromlonlat Completed
+type GeosearchFrommemberFromlonlat Incomplete
 
 func (c GeosearchFrommemberFromlonlat) Byradius(radius float64) GeosearchCircleCircleByradius {
 	c.cs.s = append(c.cs.s, "BYRADIUS", strconv.FormatFloat(radius, 'f', -1, 64))
@@ -2731,7 +2731,7 @@ func (c GeosearchFrommemberFromlonlat) Bybox(width float64) GeosearchCircleBoxBy
 	return (GeosearchCircleBoxBybox)(c)
 }
 
-type GeosearchFrommemberFrommember Completed
+type GeosearchFrommemberFrommember Incomplete
 
 func (c GeosearchFrommemberFrommember) Fromlonlat(longitude float64, latitude float64) GeosearchFrommemberFromlonlat {
 	c.cs.s = append(c.cs.s, "FROMLONLAT", strconv.FormatFloat(longitude, 'f', -1, 64), strconv.FormatFloat(latitude, 'f', -1, 64))
@@ -2748,7 +2748,7 @@ func (c GeosearchFrommemberFrommember) Bybox(width float64) GeosearchCircleBoxBy
 	return (GeosearchCircleBoxBybox)(c)
 }
 
-type GeosearchKey Completed
+type GeosearchKey Incomplete
 
 func (c GeosearchKey) Frommember(member string) GeosearchFrommemberFrommember {
 	c.cs.s = append(c.cs.s, "FROMMEMBER", member)
@@ -2760,7 +2760,7 @@ func (c GeosearchKey) Fromlonlat(longitude float64, latitude float64) GeosearchF
 	return (GeosearchFrommemberFromlonlat)(c)
 }
 
-type GeosearchOrderAsc Completed
+type GeosearchOrderAsc Incomplete
 
 func (c GeosearchOrderAsc) Count(count int64) GeosearchCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -2784,15 +2784,15 @@ func (c GeosearchOrderAsc) Withhash() GeosearchWithhash {
 
 func (c GeosearchOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchOrderAsc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchOrderDesc Completed
+type GeosearchOrderDesc Incomplete
 
 func (c GeosearchOrderDesc) Count(count int64) GeosearchCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -2816,15 +2816,15 @@ func (c GeosearchOrderDesc) Withhash() GeosearchWithhash {
 
 func (c GeosearchOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchOrderDesc) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchWithcoord Completed
+type GeosearchWithcoord Incomplete
 
 func (c GeosearchWithcoord) Withdist() GeosearchWithdist {
 	c.cs.s = append(c.cs.s, "WITHDIST")
@@ -2838,15 +2838,15 @@ func (c GeosearchWithcoord) Withhash() GeosearchWithhash {
 
 func (c GeosearchWithcoord) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchWithcoord) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchWithdist Completed
+type GeosearchWithdist Incomplete
 
 func (c GeosearchWithdist) Withhash() GeosearchWithhash {
 	c.cs.s = append(c.cs.s, "WITHHASH")
@@ -2855,27 +2855,27 @@ func (c GeosearchWithdist) Withhash() GeosearchWithhash {
 
 func (c GeosearchWithdist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchWithdist) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchWithhash Completed
+type GeosearchWithhash Incomplete
 
 func (c GeosearchWithhash) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GeosearchWithhash) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Geosearchstore Completed
+type Geosearchstore Incomplete
 
 func (b Builder) Geosearchstore() (c Geosearchstore) {
 	c = Geosearchstore{cs: get(), ks: b.ks}
@@ -2893,14 +2893,14 @@ func (c Geosearchstore) Destination(destination string) GeosearchstoreDestinatio
 	return (GeosearchstoreDestination)(c)
 }
 
-type GeosearchstoreCircleBoxBybox Completed
+type GeosearchstoreCircleBoxBybox Incomplete
 
 func (c GeosearchstoreCircleBoxBybox) Height(height float64) GeosearchstoreCircleBoxHeight {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(height, 'f', -1, 64))
 	return (GeosearchstoreCircleBoxHeight)(c)
 }
 
-type GeosearchstoreCircleBoxHeight Completed
+type GeosearchstoreCircleBoxHeight Incomplete
 
 func (c GeosearchstoreCircleBoxHeight) M() GeosearchstoreCircleBoxUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -2922,7 +2922,7 @@ func (c GeosearchstoreCircleBoxHeight) Mi() GeosearchstoreCircleBoxUnitMi {
 	return (GeosearchstoreCircleBoxUnitMi)(c)
 }
 
-type GeosearchstoreCircleBoxUnitFt Completed
+type GeosearchstoreCircleBoxUnitFt Incomplete
 
 func (c GeosearchstoreCircleBoxUnitFt) Asc() GeosearchstoreOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -2946,10 +2946,10 @@ func (c GeosearchstoreCircleBoxUnitFt) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleBoxUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleBoxUnitKm Completed
+type GeosearchstoreCircleBoxUnitKm Incomplete
 
 func (c GeosearchstoreCircleBoxUnitKm) Asc() GeosearchstoreOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -2973,10 +2973,10 @@ func (c GeosearchstoreCircleBoxUnitKm) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleBoxUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleBoxUnitM Completed
+type GeosearchstoreCircleBoxUnitM Incomplete
 
 func (c GeosearchstoreCircleBoxUnitM) Asc() GeosearchstoreOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -3000,10 +3000,10 @@ func (c GeosearchstoreCircleBoxUnitM) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleBoxUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleBoxUnitMi Completed
+type GeosearchstoreCircleBoxUnitMi Incomplete
 
 func (c GeosearchstoreCircleBoxUnitMi) Asc() GeosearchstoreOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -3027,10 +3027,10 @@ func (c GeosearchstoreCircleBoxUnitMi) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleBoxUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleCircleByradius Completed
+type GeosearchstoreCircleCircleByradius Incomplete
 
 func (c GeosearchstoreCircleCircleByradius) M() GeosearchstoreCircleCircleUnitM {
 	c.cs.s = append(c.cs.s, "m")
@@ -3052,7 +3052,7 @@ func (c GeosearchstoreCircleCircleByradius) Mi() GeosearchstoreCircleCircleUnitM
 	return (GeosearchstoreCircleCircleUnitMi)(c)
 }
 
-type GeosearchstoreCircleCircleUnitFt Completed
+type GeosearchstoreCircleCircleUnitFt Incomplete
 
 func (c GeosearchstoreCircleCircleUnitFt) Bybox(width float64) GeosearchstoreCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -3081,10 +3081,10 @@ func (c GeosearchstoreCircleCircleUnitFt) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleCircleUnitFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleCircleUnitKm Completed
+type GeosearchstoreCircleCircleUnitKm Incomplete
 
 func (c GeosearchstoreCircleCircleUnitKm) Bybox(width float64) GeosearchstoreCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -3113,10 +3113,10 @@ func (c GeosearchstoreCircleCircleUnitKm) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleCircleUnitKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleCircleUnitM Completed
+type GeosearchstoreCircleCircleUnitM Incomplete
 
 func (c GeosearchstoreCircleCircleUnitM) Bybox(width float64) GeosearchstoreCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -3145,10 +3145,10 @@ func (c GeosearchstoreCircleCircleUnitM) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleCircleUnitM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCircleCircleUnitMi Completed
+type GeosearchstoreCircleCircleUnitMi Incomplete
 
 func (c GeosearchstoreCircleCircleUnitMi) Bybox(width float64) GeosearchstoreCircleBoxBybox {
 	c.cs.s = append(c.cs.s, "BYBOX", strconv.FormatFloat(width, 'f', -1, 64))
@@ -3177,10 +3177,10 @@ func (c GeosearchstoreCircleCircleUnitMi) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCircleCircleUnitMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCountAny Completed
+type GeosearchstoreCountAny Incomplete
 
 func (c GeosearchstoreCountAny) Storedist() GeosearchstoreStoredist {
 	c.cs.s = append(c.cs.s, "STOREDIST")
@@ -3189,10 +3189,10 @@ func (c GeosearchstoreCountAny) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCountAny) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreCountCount Completed
+type GeosearchstoreCountCount Incomplete
 
 func (c GeosearchstoreCountCount) Any() GeosearchstoreCountAny {
 	c.cs.s = append(c.cs.s, "ANY")
@@ -3206,10 +3206,10 @@ func (c GeosearchstoreCountCount) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreDestination Completed
+type GeosearchstoreDestination Incomplete
 
 func (c GeosearchstoreDestination) Source(source string) GeosearchstoreSource {
 	if c.ks&NoSlot == NoSlot {
@@ -3221,7 +3221,7 @@ func (c GeosearchstoreDestination) Source(source string) GeosearchstoreSource {
 	return (GeosearchstoreSource)(c)
 }
 
-type GeosearchstoreFrommemberFromlonlat Completed
+type GeosearchstoreFrommemberFromlonlat Incomplete
 
 func (c GeosearchstoreFrommemberFromlonlat) Byradius(radius float64) GeosearchstoreCircleCircleByradius {
 	c.cs.s = append(c.cs.s, "BYRADIUS", strconv.FormatFloat(radius, 'f', -1, 64))
@@ -3233,7 +3233,7 @@ func (c GeosearchstoreFrommemberFromlonlat) Bybox(width float64) GeosearchstoreC
 	return (GeosearchstoreCircleBoxBybox)(c)
 }
 
-type GeosearchstoreFrommemberFrommember Completed
+type GeosearchstoreFrommemberFrommember Incomplete
 
 func (c GeosearchstoreFrommemberFrommember) Fromlonlat(longitude float64, latitude float64) GeosearchstoreFrommemberFromlonlat {
 	c.cs.s = append(c.cs.s, "FROMLONLAT", strconv.FormatFloat(longitude, 'f', -1, 64), strconv.FormatFloat(latitude, 'f', -1, 64))
@@ -3250,7 +3250,7 @@ func (c GeosearchstoreFrommemberFrommember) Bybox(width float64) GeosearchstoreC
 	return (GeosearchstoreCircleBoxBybox)(c)
 }
 
-type GeosearchstoreOrderAsc Completed
+type GeosearchstoreOrderAsc Incomplete
 
 func (c GeosearchstoreOrderAsc) Count(count int64) GeosearchstoreCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -3264,10 +3264,10 @@ func (c GeosearchstoreOrderAsc) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreOrderDesc Completed
+type GeosearchstoreOrderDesc Incomplete
 
 func (c GeosearchstoreOrderDesc) Count(count int64) GeosearchstoreCountCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -3281,10 +3281,10 @@ func (c GeosearchstoreOrderDesc) Storedist() GeosearchstoreStoredist {
 
 func (c GeosearchstoreOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GeosearchstoreSource Completed
+type GeosearchstoreSource Incomplete
 
 func (c GeosearchstoreSource) Frommember(member string) GeosearchstoreFrommemberFrommember {
 	c.cs.s = append(c.cs.s, "FROMMEMBER", member)
@@ -3296,9 +3296,9 @@ func (c GeosearchstoreSource) Fromlonlat(longitude float64, latitude float64) Ge
 	return (GeosearchstoreFrommemberFromlonlat)(c)
 }
 
-type GeosearchstoreStoredist Completed
+type GeosearchstoreStoredist Incomplete
 
 func (c GeosearchstoreStoredist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_graph.go
+++ b/internal/cmds/gen_graph.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type GraphConfigGet Completed
+type GraphConfigGet Incomplete
 
 func (b Builder) GraphConfigGet() (c GraphConfigGet) {
-	c = GraphConfigGet{cs: get(), ks: b.ks, cf: readonly}
+	c = GraphConfigGet{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GRAPH.CONFIG", "GET")
 	return c
 }
@@ -17,14 +17,14 @@ func (c GraphConfigGet) Name(name string) GraphConfigGetName {
 	return (GraphConfigGetName)(c)
 }
 
-type GraphConfigGetName Completed
+type GraphConfigGetName Incomplete
 
 func (c GraphConfigGetName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphConfigSet Completed
+type GraphConfigSet Incomplete
 
 func (b Builder) GraphConfigSet() (c GraphConfigSet) {
 	c = GraphConfigSet{cs: get(), ks: b.ks}
@@ -37,21 +37,21 @@ func (c GraphConfigSet) Name(name string) GraphConfigSetName {
 	return (GraphConfigSetName)(c)
 }
 
-type GraphConfigSetName Completed
+type GraphConfigSetName Incomplete
 
 func (c GraphConfigSetName) Value(value string) GraphConfigSetValue {
 	c.cs.s = append(c.cs.s, value)
 	return (GraphConfigSetValue)(c)
 }
 
-type GraphConfigSetValue Completed
+type GraphConfigSetValue Incomplete
 
 func (c GraphConfigSetValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphConstraintCreate Completed
+type GraphConstraintCreate Incomplete
 
 func (b Builder) GraphConstraintCreate() (c GraphConstraintCreate) {
 	c = GraphConstraintCreate{cs: get(), ks: b.ks}
@@ -61,10 +61,10 @@ func (b Builder) GraphConstraintCreate() (c GraphConstraintCreate) {
 
 func (c GraphConstraintCreate) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphConstraintDrop Completed
+type GraphConstraintDrop Incomplete
 
 func (b Builder) GraphConstraintDrop() (c GraphConstraintDrop) {
 	c = GraphConstraintDrop{cs: get(), ks: b.ks}
@@ -74,10 +74,10 @@ func (b Builder) GraphConstraintDrop() (c GraphConstraintDrop) {
 
 func (c GraphConstraintDrop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphDelete Completed
+type GraphDelete Incomplete
 
 func (b Builder) GraphDelete() (c GraphDelete) {
 	c = GraphDelete{cs: get(), ks: b.ks}
@@ -95,17 +95,17 @@ func (c GraphDelete) Graph(graph string) GraphDeleteGraph {
 	return (GraphDeleteGraph)(c)
 }
 
-type GraphDeleteGraph Completed
+type GraphDeleteGraph Incomplete
 
 func (c GraphDeleteGraph) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphExplain Completed
+type GraphExplain Incomplete
 
 func (b Builder) GraphExplain() (c GraphExplain) {
-	c = GraphExplain{cs: get(), ks: b.ks, cf: readonly}
+	c = GraphExplain{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GRAPH.EXPLAIN")
 	return c
 }
@@ -120,34 +120,34 @@ func (c GraphExplain) Graph(graph string) GraphExplainGraph {
 	return (GraphExplainGraph)(c)
 }
 
-type GraphExplainGraph Completed
+type GraphExplainGraph Incomplete
 
 func (c GraphExplainGraph) Query(query string) GraphExplainQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (GraphExplainQuery)(c)
 }
 
-type GraphExplainQuery Completed
+type GraphExplainQuery Incomplete
 
 func (c GraphExplainQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphList Completed
+type GraphList Incomplete
 
 func (b Builder) GraphList() (c GraphList) {
-	c = GraphList{cs: get(), ks: b.ks, cf: readonly}
+	c = GraphList{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GRAPH.LIST")
 	return c
 }
 
 func (c GraphList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphProfile Completed
+type GraphProfile Incomplete
 
 func (b Builder) GraphProfile() (c GraphProfile) {
 	c = GraphProfile{cs: get(), ks: b.ks}
@@ -165,14 +165,14 @@ func (c GraphProfile) Graph(graph string) GraphProfileGraph {
 	return (GraphProfileGraph)(c)
 }
 
-type GraphProfileGraph Completed
+type GraphProfileGraph Incomplete
 
 func (c GraphProfileGraph) Query(query string) GraphProfileQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (GraphProfileQuery)(c)
 }
 
-type GraphProfileQuery Completed
+type GraphProfileQuery Incomplete
 
 func (c GraphProfileQuery) Timeout(timeout int64) GraphProfileTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT", strconv.FormatInt(timeout, 10))
@@ -181,17 +181,17 @@ func (c GraphProfileQuery) Timeout(timeout int64) GraphProfileTimeout {
 
 func (c GraphProfileQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphProfileTimeout Completed
+type GraphProfileTimeout Incomplete
 
 func (c GraphProfileTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphQuery Completed
+type GraphQuery Incomplete
 
 func (b Builder) GraphQuery() (c GraphQuery) {
 	c = GraphQuery{cs: get(), ks: b.ks}
@@ -209,14 +209,14 @@ func (c GraphQuery) Graph(graph string) GraphQueryGraph {
 	return (GraphQueryGraph)(c)
 }
 
-type GraphQueryGraph Completed
+type GraphQueryGraph Incomplete
 
 func (c GraphQueryGraph) Query(query string) GraphQueryQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (GraphQueryQuery)(c)
 }
 
-type GraphQueryQuery Completed
+type GraphQueryQuery Incomplete
 
 func (c GraphQueryQuery) Timeout(timeout int64) GraphQueryTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT", strconv.FormatInt(timeout, 10))
@@ -225,20 +225,20 @@ func (c GraphQueryQuery) Timeout(timeout int64) GraphQueryTimeout {
 
 func (c GraphQueryQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphQueryTimeout Completed
+type GraphQueryTimeout Incomplete
 
 func (c GraphQueryTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphRoQuery Completed
+type GraphRoQuery Incomplete
 
 func (b Builder) GraphRoQuery() (c GraphRoQuery) {
-	c = GraphRoQuery{cs: get(), ks: b.ks, cf: readonly}
+	c = GraphRoQuery{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GRAPH.RO_QUERY")
 	return c
 }
@@ -253,14 +253,14 @@ func (c GraphRoQuery) Graph(graph string) GraphRoQueryGraph {
 	return (GraphRoQueryGraph)(c)
 }
 
-type GraphRoQueryGraph Completed
+type GraphRoQueryGraph Incomplete
 
 func (c GraphRoQueryGraph) Query(query string) GraphRoQueryQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (GraphRoQueryQuery)(c)
 }
 
-type GraphRoQueryQuery Completed
+type GraphRoQueryQuery Incomplete
 
 func (c GraphRoQueryQuery) Timeout(timeout int64) GraphRoQueryTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT", strconv.FormatInt(timeout, 10))
@@ -269,30 +269,30 @@ func (c GraphRoQueryQuery) Timeout(timeout int64) GraphRoQueryTimeout {
 
 func (c GraphRoQueryQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GraphRoQueryQuery) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphRoQueryTimeout Completed
+type GraphRoQueryTimeout Incomplete
 
 func (c GraphRoQueryTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GraphRoQueryTimeout) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GraphSlowlog Completed
+type GraphSlowlog Incomplete
 
 func (b Builder) GraphSlowlog() (c GraphSlowlog) {
-	c = GraphSlowlog{cs: get(), ks: b.ks, cf: readonly}
+	c = GraphSlowlog{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GRAPH.SLOWLOG")
 	return c
 }
@@ -307,9 +307,9 @@ func (c GraphSlowlog) Graph(graph string) GraphSlowlogGraph {
 	return (GraphSlowlogGraph)(c)
 }
 
-type GraphSlowlogGraph Completed
+type GraphSlowlogGraph Incomplete
 
 func (c GraphSlowlogGraph) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_hash.go
+++ b/internal/cmds/gen_hash.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Hdel Completed
+type Hdel Incomplete
 
 func (b Builder) Hdel() (c Hdel) {
 	c = Hdel{cs: get(), ks: b.ks}
@@ -22,7 +22,7 @@ func (c Hdel) Key(key string) HdelKey {
 	return (HdelKey)(c)
 }
 
-type HdelField Completed
+type HdelField Incomplete
 
 func (c HdelField) Field(field ...string) HdelField {
 	c.cs.s = append(c.cs.s, field...)
@@ -31,20 +31,20 @@ func (c HdelField) Field(field ...string) HdelField {
 
 func (c HdelField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HdelKey Completed
+type HdelKey Incomplete
 
 func (c HdelKey) Field(field ...string) HdelField {
 	c.cs.s = append(c.cs.s, field...)
 	return (HdelField)(c)
 }
 
-type Hexists Completed
+type Hexists Incomplete
 
 func (b Builder) Hexists() (c Hexists) {
-	c = Hexists{cs: get(), ks: b.ks, cf: readonly}
+	c = Hexists{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HEXISTS")
 	return c
 }
@@ -59,29 +59,29 @@ func (c Hexists) Key(key string) HexistsKey {
 	return (HexistsKey)(c)
 }
 
-type HexistsField Completed
+type HexistsField Incomplete
 
 func (c HexistsField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HexistsField) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HexistsKey Completed
+type HexistsKey Incomplete
 
 func (c HexistsKey) Field(field string) HexistsField {
 	c.cs.s = append(c.cs.s, field)
 	return (HexistsField)(c)
 }
 
-type Hget Completed
+type Hget Incomplete
 
 func (b Builder) Hget() (c Hget) {
-	c = Hget{cs: get(), ks: b.ks, cf: readonly}
+	c = Hget{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HGET")
 	return c
 }
@@ -96,29 +96,29 @@ func (c Hget) Key(key string) HgetKey {
 	return (HgetKey)(c)
 }
 
-type HgetField Completed
+type HgetField Incomplete
 
 func (c HgetField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HgetField) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HgetKey Completed
+type HgetKey Incomplete
 
 func (c HgetKey) Field(field string) HgetField {
 	c.cs.s = append(c.cs.s, field)
 	return (HgetField)(c)
 }
 
-type Hgetall Completed
+type Hgetall Incomplete
 
 func (b Builder) Hgetall() (c Hgetall) {
-	c = Hgetall{cs: get(), ks: b.ks, cf: readonly}
+	c = Hgetall{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HGETALL")
 	return c
 }
@@ -133,19 +133,19 @@ func (c Hgetall) Key(key string) HgetallKey {
 	return (HgetallKey)(c)
 }
 
-type HgetallKey Completed
+type HgetallKey Incomplete
 
 func (c HgetallKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HgetallKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hincrby Completed
+type Hincrby Incomplete
 
 func (b Builder) Hincrby() (c Hincrby) {
 	c = Hincrby{cs: get(), ks: b.ks}
@@ -163,28 +163,28 @@ func (c Hincrby) Key(key string) HincrbyKey {
 	return (HincrbyKey)(c)
 }
 
-type HincrbyField Completed
+type HincrbyField Incomplete
 
 func (c HincrbyField) Increment(increment int64) HincrbyIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(increment, 10))
 	return (HincrbyIncrement)(c)
 }
 
-type HincrbyIncrement Completed
+type HincrbyIncrement Incomplete
 
 func (c HincrbyIncrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HincrbyKey Completed
+type HincrbyKey Incomplete
 
 func (c HincrbyKey) Field(field string) HincrbyField {
 	c.cs.s = append(c.cs.s, field)
 	return (HincrbyField)(c)
 }
 
-type Hincrbyfloat Completed
+type Hincrbyfloat Incomplete
 
 func (b Builder) Hincrbyfloat() (c Hincrbyfloat) {
 	c = Hincrbyfloat{cs: get(), ks: b.ks}
@@ -202,31 +202,31 @@ func (c Hincrbyfloat) Key(key string) HincrbyfloatKey {
 	return (HincrbyfloatKey)(c)
 }
 
-type HincrbyfloatField Completed
+type HincrbyfloatField Incomplete
 
 func (c HincrbyfloatField) Increment(increment float64) HincrbyfloatIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(increment, 'f', -1, 64))
 	return (HincrbyfloatIncrement)(c)
 }
 
-type HincrbyfloatIncrement Completed
+type HincrbyfloatIncrement Incomplete
 
 func (c HincrbyfloatIncrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HincrbyfloatKey Completed
+type HincrbyfloatKey Incomplete
 
 func (c HincrbyfloatKey) Field(field string) HincrbyfloatField {
 	c.cs.s = append(c.cs.s, field)
 	return (HincrbyfloatField)(c)
 }
 
-type Hkeys Completed
+type Hkeys Incomplete
 
 func (b Builder) Hkeys() (c Hkeys) {
-	c = Hkeys{cs: get(), ks: b.ks, cf: readonly}
+	c = Hkeys{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HKEYS")
 	return c
 }
@@ -241,22 +241,22 @@ func (c Hkeys) Key(key string) HkeysKey {
 	return (HkeysKey)(c)
 }
 
-type HkeysKey Completed
+type HkeysKey Incomplete
 
 func (c HkeysKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HkeysKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hlen Completed
+type Hlen Incomplete
 
 func (b Builder) Hlen() (c Hlen) {
-	c = Hlen{cs: get(), ks: b.ks, cf: readonly}
+	c = Hlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HLEN")
 	return c
 }
@@ -271,22 +271,22 @@ func (c Hlen) Key(key string) HlenKey {
 	return (HlenKey)(c)
 }
 
-type HlenKey Completed
+type HlenKey Incomplete
 
 func (c HlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HlenKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hmget Completed
+type Hmget Incomplete
 
 func (b Builder) Hmget() (c Hmget) {
-	c = Hmget{cs: get(), ks: b.ks, cf: readonly}
+	c = Hmget{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HMGET")
 	return c
 }
@@ -301,7 +301,7 @@ func (c Hmget) Key(key string) HmgetKey {
 	return (HmgetKey)(c)
 }
 
-type HmgetField Completed
+type HmgetField Incomplete
 
 func (c HmgetField) Field(field ...string) HmgetField {
 	c.cs.s = append(c.cs.s, field...)
@@ -310,22 +310,22 @@ func (c HmgetField) Field(field ...string) HmgetField {
 
 func (c HmgetField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HmgetField) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HmgetKey Completed
+type HmgetKey Incomplete
 
 func (c HmgetKey) Field(field ...string) HmgetField {
 	c.cs.s = append(c.cs.s, field...)
 	return (HmgetField)(c)
 }
 
-type Hmset Completed
+type Hmset Incomplete
 
 func (b Builder) Hmset() (c Hmset) {
 	c = Hmset{cs: get(), ks: b.ks}
@@ -343,7 +343,7 @@ func (c Hmset) Key(key string) HmsetKey {
 	return (HmsetKey)(c)
 }
 
-type HmsetFieldValue Completed
+type HmsetFieldValue Incomplete
 
 func (c HmsetFieldValue) FieldValue(field string, value string) HmsetFieldValue {
 	c.cs.s = append(c.cs.s, field, value)
@@ -352,19 +352,19 @@ func (c HmsetFieldValue) FieldValue(field string, value string) HmsetFieldValue 
 
 func (c HmsetFieldValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HmsetKey Completed
+type HmsetKey Incomplete
 
 func (c HmsetKey) FieldValue() HmsetFieldValue {
 	return (HmsetFieldValue)(c)
 }
 
-type Hrandfield Completed
+type Hrandfield Incomplete
 
 func (b Builder) Hrandfield() (c Hrandfield) {
-	c = Hrandfield{cs: get(), ks: b.ks, cf: readonly}
+	c = Hrandfield{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HRANDFIELD")
 	return c
 }
@@ -379,7 +379,7 @@ func (c Hrandfield) Key(key string) HrandfieldKey {
 	return (HrandfieldKey)(c)
 }
 
-type HrandfieldKey Completed
+type HrandfieldKey Incomplete
 
 func (c HrandfieldKey) Count(count int64) HrandfieldOptionsCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -388,10 +388,10 @@ func (c HrandfieldKey) Count(count int64) HrandfieldOptionsCount {
 
 func (c HrandfieldKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HrandfieldOptionsCount Completed
+type HrandfieldOptionsCount Incomplete
 
 func (c HrandfieldOptionsCount) Withvalues() HrandfieldOptionsWithvalues {
 	c.cs.s = append(c.cs.s, "WITHVALUES")
@@ -400,20 +400,20 @@ func (c HrandfieldOptionsCount) Withvalues() HrandfieldOptionsWithvalues {
 
 func (c HrandfieldOptionsCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HrandfieldOptionsWithvalues Completed
+type HrandfieldOptionsWithvalues Incomplete
 
 func (c HrandfieldOptionsWithvalues) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hscan Completed
+type Hscan Incomplete
 
 func (b Builder) Hscan() (c Hscan) {
-	c = Hscan{cs: get(), ks: b.ks, cf: readonly}
+	c = Hscan{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HSCAN")
 	return c
 }
@@ -428,14 +428,14 @@ func (c Hscan) Key(key string) HscanKey {
 	return (HscanKey)(c)
 }
 
-type HscanCount Completed
+type HscanCount Incomplete
 
 func (c HscanCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HscanCursor Completed
+type HscanCursor Incomplete
 
 func (c HscanCursor) Match(pattern string) HscanMatch {
 	c.cs.s = append(c.cs.s, "MATCH", pattern)
@@ -449,17 +449,17 @@ func (c HscanCursor) Count(count int64) HscanCount {
 
 func (c HscanCursor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HscanKey Completed
+type HscanKey Incomplete
 
 func (c HscanKey) Cursor(cursor uint64) HscanCursor {
 	c.cs.s = append(c.cs.s, strconv.FormatUint(cursor, 10))
 	return (HscanCursor)(c)
 }
 
-type HscanMatch Completed
+type HscanMatch Incomplete
 
 func (c HscanMatch) Count(count int64) HscanCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -468,10 +468,10 @@ func (c HscanMatch) Count(count int64) HscanCount {
 
 func (c HscanMatch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hset Completed
+type Hset Incomplete
 
 func (b Builder) Hset() (c Hset) {
 	c = Hset{cs: get(), ks: b.ks}
@@ -489,7 +489,7 @@ func (c Hset) Key(key string) HsetKey {
 	return (HsetKey)(c)
 }
 
-type HsetFieldValue Completed
+type HsetFieldValue Incomplete
 
 func (c HsetFieldValue) FieldValue(field string, value string) HsetFieldValue {
 	c.cs.s = append(c.cs.s, field, value)
@@ -498,16 +498,16 @@ func (c HsetFieldValue) FieldValue(field string, value string) HsetFieldValue {
 
 func (c HsetFieldValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HsetKey Completed
+type HsetKey Incomplete
 
 func (c HsetKey) FieldValue() HsetFieldValue {
 	return (HsetFieldValue)(c)
 }
 
-type Hsetnx Completed
+type Hsetnx Incomplete
 
 func (b Builder) Hsetnx() (c Hsetnx) {
 	c = Hsetnx{cs: get(), ks: b.ks}
@@ -525,31 +525,31 @@ func (c Hsetnx) Key(key string) HsetnxKey {
 	return (HsetnxKey)(c)
 }
 
-type HsetnxField Completed
+type HsetnxField Incomplete
 
 func (c HsetnxField) Value(value string) HsetnxValue {
 	c.cs.s = append(c.cs.s, value)
 	return (HsetnxValue)(c)
 }
 
-type HsetnxKey Completed
+type HsetnxKey Incomplete
 
 func (c HsetnxKey) Field(field string) HsetnxField {
 	c.cs.s = append(c.cs.s, field)
 	return (HsetnxField)(c)
 }
 
-type HsetnxValue Completed
+type HsetnxValue Incomplete
 
 func (c HsetnxValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Hstrlen Completed
+type Hstrlen Incomplete
 
 func (b Builder) Hstrlen() (c Hstrlen) {
-	c = Hstrlen{cs: get(), ks: b.ks, cf: readonly}
+	c = Hstrlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HSTRLEN")
 	return c
 }
@@ -564,29 +564,29 @@ func (c Hstrlen) Key(key string) HstrlenKey {
 	return (HstrlenKey)(c)
 }
 
-type HstrlenField Completed
+type HstrlenField Incomplete
 
 func (c HstrlenField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HstrlenField) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type HstrlenKey Completed
+type HstrlenKey Incomplete
 
 func (c HstrlenKey) Field(field string) HstrlenField {
 	c.cs.s = append(c.cs.s, field)
 	return (HstrlenField)(c)
 }
 
-type Hvals Completed
+type Hvals Incomplete
 
 func (b Builder) Hvals() (c Hvals) {
-	c = Hvals{cs: get(), ks: b.ks, cf: readonly}
+	c = Hvals{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "HVALS")
 	return c
 }
@@ -601,14 +601,14 @@ func (c Hvals) Key(key string) HvalsKey {
 	return (HvalsKey)(c)
 }
 
-type HvalsKey Completed
+type HvalsKey Incomplete
 
 func (c HvalsKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c HvalsKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_hyperloglog.go
+++ b/internal/cmds/gen_hyperloglog.go
@@ -2,7 +2,7 @@
 
 package cmds
 
-type Pfadd Completed
+type Pfadd Incomplete
 
 func (b Builder) Pfadd() (c Pfadd) {
 	c = Pfadd{cs: get(), ks: b.ks}
@@ -20,7 +20,7 @@ func (c Pfadd) Key(key string) PfaddKey {
 	return (PfaddKey)(c)
 }
 
-type PfaddElement Completed
+type PfaddElement Incomplete
 
 func (c PfaddElement) Element(element ...string) PfaddElement {
 	c.cs.s = append(c.cs.s, element...)
@@ -29,10 +29,10 @@ func (c PfaddElement) Element(element ...string) PfaddElement {
 
 func (c PfaddElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PfaddKey Completed
+type PfaddKey Incomplete
 
 func (c PfaddKey) Element(element ...string) PfaddElement {
 	c.cs.s = append(c.cs.s, element...)
@@ -41,13 +41,13 @@ func (c PfaddKey) Element(element ...string) PfaddElement {
 
 func (c PfaddKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Pfcount Completed
+type Pfcount Incomplete
 
 func (b Builder) Pfcount() (c Pfcount) {
-	c = Pfcount{cs: get(), ks: b.ks, cf: readonly}
+	c = Pfcount{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PFCOUNT")
 	return c
 }
@@ -67,7 +67,7 @@ func (c Pfcount) Key(key ...string) PfcountKey {
 	return (PfcountKey)(c)
 }
 
-type PfcountKey Completed
+type PfcountKey Incomplete
 
 func (c PfcountKey) Key(key ...string) PfcountKey {
 	if c.ks&NoSlot == NoSlot {
@@ -86,10 +86,10 @@ func (c PfcountKey) Key(key ...string) PfcountKey {
 
 func (c PfcountKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Pfmerge Completed
+type Pfmerge Incomplete
 
 func (b Builder) Pfmerge() (c Pfmerge) {
 	c = Pfmerge{cs: get(), ks: b.ks}
@@ -107,7 +107,7 @@ func (c Pfmerge) Destkey(destkey string) PfmergeDestkey {
 	return (PfmergeDestkey)(c)
 }
 
-type PfmergeDestkey Completed
+type PfmergeDestkey Incomplete
 
 func (c PfmergeDestkey) Sourcekey(sourcekey ...string) PfmergeSourcekey {
 	if c.ks&NoSlot == NoSlot {
@@ -126,10 +126,10 @@ func (c PfmergeDestkey) Sourcekey(sourcekey ...string) PfmergeSourcekey {
 
 func (c PfmergeDestkey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PfmergeSourcekey Completed
+type PfmergeSourcekey Incomplete
 
 func (c PfmergeSourcekey) Sourcekey(sourcekey ...string) PfmergeSourcekey {
 	if c.ks&NoSlot == NoSlot {
@@ -148,5 +148,5 @@ func (c PfmergeSourcekey) Sourcekey(sourcekey ...string) PfmergeSourcekey {
 
 func (c PfmergeSourcekey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_inference.go
+++ b/internal/cmds/gen_inference.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type AiModelexecute Completed
+type AiModelexecute Incomplete
 
 func (b Builder) AiModelexecute() (c AiModelexecute) {
-	c = AiModelexecute{cs: get(), ks: b.ks, cf: readonly}
+	c = AiModelexecute{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "AI.MODELEXECUTE")
 	return c
 }
@@ -22,7 +22,7 @@ func (c AiModelexecute) Key(key string) AiModelexecuteKey {
 	return (AiModelexecuteKey)(c)
 }
 
-type AiModelexecuteInputsInput Completed
+type AiModelexecuteInputsInput Incomplete
 
 func (c AiModelexecuteInputsInput) Input(input ...string) AiModelexecuteInputsInput {
 	c.cs.s = append(c.cs.s, input...)
@@ -34,21 +34,21 @@ func (c AiModelexecuteInputsInput) Outputs(outputCount int64) AiModelexecuteOutp
 	return (AiModelexecuteOutputsOutputs)(c)
 }
 
-type AiModelexecuteInputsInputs Completed
+type AiModelexecuteInputsInputs Incomplete
 
 func (c AiModelexecuteInputsInputs) Input(input ...string) AiModelexecuteInputsInput {
 	c.cs.s = append(c.cs.s, input...)
 	return (AiModelexecuteInputsInput)(c)
 }
 
-type AiModelexecuteKey Completed
+type AiModelexecuteKey Incomplete
 
 func (c AiModelexecuteKey) Inputs(inputCount int64) AiModelexecuteInputsInputs {
 	c.cs.s = append(c.cs.s, "INPUTS", strconv.FormatInt(inputCount, 10))
 	return (AiModelexecuteInputsInputs)(c)
 }
 
-type AiModelexecuteOutputsOutput Completed
+type AiModelexecuteOutputsOutput Incomplete
 
 func (c AiModelexecuteOutputsOutput) Output(output ...string) AiModelexecuteOutputsOutput {
 	c.cs.s = append(c.cs.s, output...)
@@ -62,34 +62,34 @@ func (c AiModelexecuteOutputsOutput) Timeout(timeout int64) AiModelexecuteTimeou
 
 func (c AiModelexecuteOutputsOutput) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiModelexecuteOutputsOutput) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelexecuteOutputsOutputs Completed
+type AiModelexecuteOutputsOutputs Incomplete
 
 func (c AiModelexecuteOutputsOutputs) Output(output ...string) AiModelexecuteOutputsOutput {
 	c.cs.s = append(c.cs.s, output...)
 	return (AiModelexecuteOutputsOutput)(c)
 }
 
-type AiModelexecuteTimeout Completed
+type AiModelexecuteTimeout Incomplete
 
 func (c AiModelexecuteTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiModelexecuteTimeout) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptexecute Completed
+type AiScriptexecute Incomplete
 
 func (b Builder) AiScriptexecute() (c AiScriptexecute) {
 	c = AiScriptexecute{cs: get(), ks: b.ks}
@@ -107,7 +107,7 @@ func (c AiScriptexecute) Key(key string) AiScriptexecuteKey {
 	return (AiScriptexecuteKey)(c)
 }
 
-type AiScriptexecuteArgsArg Completed
+type AiScriptexecuteArgsArg Incomplete
 
 func (c AiScriptexecuteArgsArg) Arg(arg ...string) AiScriptexecuteArgsArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -126,17 +126,17 @@ func (c AiScriptexecuteArgsArg) Timeout(timeout int64) AiScriptexecuteTimeout {
 
 func (c AiScriptexecuteArgsArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptexecuteArgsArgs Completed
+type AiScriptexecuteArgsArgs Incomplete
 
 func (c AiScriptexecuteArgsArgs) Arg(arg ...string) AiScriptexecuteArgsArg {
 	c.cs.s = append(c.cs.s, arg...)
 	return (AiScriptexecuteArgsArg)(c)
 }
 
-type AiScriptexecuteFunction Completed
+type AiScriptexecuteFunction Incomplete
 
 func (c AiScriptexecuteFunction) Keys(keyCount int64) AiScriptexecuteKeysKeys {
 	c.cs.s = append(c.cs.s, "KEYS", strconv.FormatInt(keyCount, 10))
@@ -165,10 +165,10 @@ func (c AiScriptexecuteFunction) Timeout(timeout int64) AiScriptexecuteTimeout {
 
 func (c AiScriptexecuteFunction) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptexecuteInputsInput Completed
+type AiScriptexecuteInputsInput Incomplete
 
 func (c AiScriptexecuteInputsInput) Input(input ...string) AiScriptexecuteInputsInput {
 	c.cs.s = append(c.cs.s, input...)
@@ -192,24 +192,24 @@ func (c AiScriptexecuteInputsInput) Timeout(timeout int64) AiScriptexecuteTimeou
 
 func (c AiScriptexecuteInputsInput) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptexecuteInputsInputs Completed
+type AiScriptexecuteInputsInputs Incomplete
 
 func (c AiScriptexecuteInputsInputs) Input(input ...string) AiScriptexecuteInputsInput {
 	c.cs.s = append(c.cs.s, input...)
 	return (AiScriptexecuteInputsInput)(c)
 }
 
-type AiScriptexecuteKey Completed
+type AiScriptexecuteKey Incomplete
 
 func (c AiScriptexecuteKey) Function(function string) AiScriptexecuteFunction {
 	c.cs.s = append(c.cs.s, function)
 	return (AiScriptexecuteFunction)(c)
 }
 
-type AiScriptexecuteKeysKey Completed
+type AiScriptexecuteKeysKey Incomplete
 
 func (c AiScriptexecuteKeysKey) Key(key ...string) AiScriptexecuteKeysKey {
 	c.cs.s = append(c.cs.s, key...)
@@ -238,17 +238,17 @@ func (c AiScriptexecuteKeysKey) Timeout(timeout int64) AiScriptexecuteTimeout {
 
 func (c AiScriptexecuteKeysKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptexecuteKeysKeys Completed
+type AiScriptexecuteKeysKeys Incomplete
 
 func (c AiScriptexecuteKeysKeys) Key(key ...string) AiScriptexecuteKeysKey {
 	c.cs.s = append(c.cs.s, key...)
 	return (AiScriptexecuteKeysKey)(c)
 }
 
-type AiScriptexecuteOutputsOutput Completed
+type AiScriptexecuteOutputsOutput Incomplete
 
 func (c AiScriptexecuteOutputsOutput) Output(output ...string) AiScriptexecuteOutputsOutput {
 	c.cs.s = append(c.cs.s, output...)
@@ -262,19 +262,19 @@ func (c AiScriptexecuteOutputsOutput) Timeout(timeout int64) AiScriptexecuteTime
 
 func (c AiScriptexecuteOutputsOutput) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptexecuteOutputsOutputs Completed
+type AiScriptexecuteOutputsOutputs Incomplete
 
 func (c AiScriptexecuteOutputsOutputs) Output(output ...string) AiScriptexecuteOutputsOutput {
 	c.cs.s = append(c.cs.s, output...)
 	return (AiScriptexecuteOutputsOutput)(c)
 }
 
-type AiScriptexecuteTimeout Completed
+type AiScriptexecuteTimeout Incomplete
 
 func (c AiScriptexecuteTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_json.go
+++ b/internal/cmds/gen_json.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type JsonArrappend Completed
+type JsonArrappend Incomplete
 
 func (b Builder) JsonArrappend() (c JsonArrappend) {
 	c = JsonArrappend{cs: get(), ks: b.ks}
@@ -22,7 +22,7 @@ func (c JsonArrappend) Key(key string) JsonArrappendKey {
 	return (JsonArrappendKey)(c)
 }
 
-type JsonArrappendKey Completed
+type JsonArrappendKey Incomplete
 
 func (c JsonArrappendKey) Path(path string) JsonArrappendPath {
 	c.cs.s = append(c.cs.s, path)
@@ -34,14 +34,14 @@ func (c JsonArrappendKey) Value(value ...string) JsonArrappendValue {
 	return (JsonArrappendValue)(c)
 }
 
-type JsonArrappendPath Completed
+type JsonArrappendPath Incomplete
 
 func (c JsonArrappendPath) Value(value ...string) JsonArrappendValue {
 	c.cs.s = append(c.cs.s, value...)
 	return (JsonArrappendValue)(c)
 }
 
-type JsonArrappendValue Completed
+type JsonArrappendValue Incomplete
 
 func (c JsonArrappendValue) Value(value ...string) JsonArrappendValue {
 	c.cs.s = append(c.cs.s, value...)
@@ -50,13 +50,13 @@ func (c JsonArrappendValue) Value(value ...string) JsonArrappendValue {
 
 func (c JsonArrappendValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrindex Completed
+type JsonArrindex Incomplete
 
 func (b Builder) JsonArrindex() (c JsonArrindex) {
-	c = JsonArrindex{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonArrindex{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.ARRINDEX")
 	return c
 }
@@ -71,21 +71,21 @@ func (c JsonArrindex) Key(key string) JsonArrindexKey {
 	return (JsonArrindexKey)(c)
 }
 
-type JsonArrindexKey Completed
+type JsonArrindexKey Incomplete
 
 func (c JsonArrindexKey) Path(path string) JsonArrindexPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonArrindexPath)(c)
 }
 
-type JsonArrindexPath Completed
+type JsonArrindexPath Incomplete
 
 func (c JsonArrindexPath) Value(value string) JsonArrindexValue {
 	c.cs.s = append(c.cs.s, value)
 	return (JsonArrindexValue)(c)
 }
 
-type JsonArrindexStartStart Completed
+type JsonArrindexStartStart Incomplete
 
 func (c JsonArrindexStartStart) Stop(stop int64) JsonArrindexStartStop {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(stop, 10))
@@ -94,27 +94,27 @@ func (c JsonArrindexStartStart) Stop(stop int64) JsonArrindexStartStop {
 
 func (c JsonArrindexStartStart) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonArrindexStartStart) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrindexStartStop Completed
+type JsonArrindexStartStop Incomplete
 
 func (c JsonArrindexStartStop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonArrindexStartStop) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrindexValue Completed
+type JsonArrindexValue Incomplete
 
 func (c JsonArrindexValue) Start(start int64) JsonArrindexStartStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
@@ -123,15 +123,15 @@ func (c JsonArrindexValue) Start(start int64) JsonArrindexStartStart {
 
 func (c JsonArrindexValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonArrindexValue) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrinsert Completed
+type JsonArrinsert Incomplete
 
 func (b Builder) JsonArrinsert() (c JsonArrinsert) {
 	c = JsonArrinsert{cs: get(), ks: b.ks}
@@ -149,28 +149,28 @@ func (c JsonArrinsert) Key(key string) JsonArrinsertKey {
 	return (JsonArrinsertKey)(c)
 }
 
-type JsonArrinsertIndex Completed
+type JsonArrinsertIndex Incomplete
 
 func (c JsonArrinsertIndex) Value(value ...string) JsonArrinsertValue {
 	c.cs.s = append(c.cs.s, value...)
 	return (JsonArrinsertValue)(c)
 }
 
-type JsonArrinsertKey Completed
+type JsonArrinsertKey Incomplete
 
 func (c JsonArrinsertKey) Path(path string) JsonArrinsertPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonArrinsertPath)(c)
 }
 
-type JsonArrinsertPath Completed
+type JsonArrinsertPath Incomplete
 
 func (c JsonArrinsertPath) Index(index int64) JsonArrinsertIndex {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(index, 10))
 	return (JsonArrinsertIndex)(c)
 }
 
-type JsonArrinsertValue Completed
+type JsonArrinsertValue Incomplete
 
 func (c JsonArrinsertValue) Value(value ...string) JsonArrinsertValue {
 	c.cs.s = append(c.cs.s, value...)
@@ -179,13 +179,13 @@ func (c JsonArrinsertValue) Value(value ...string) JsonArrinsertValue {
 
 func (c JsonArrinsertValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrlen Completed
+type JsonArrlen Incomplete
 
 func (b Builder) JsonArrlen() (c JsonArrlen) {
-	c = JsonArrlen{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonArrlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.ARRLEN")
 	return c
 }
@@ -200,7 +200,7 @@ func (c JsonArrlen) Key(key string) JsonArrlenKey {
 	return (JsonArrlenKey)(c)
 }
 
-type JsonArrlenKey Completed
+type JsonArrlenKey Incomplete
 
 func (c JsonArrlenKey) Path(path string) JsonArrlenPath {
 	c.cs.s = append(c.cs.s, path)
@@ -209,27 +209,27 @@ func (c JsonArrlenKey) Path(path string) JsonArrlenPath {
 
 func (c JsonArrlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonArrlenKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrlenPath Completed
+type JsonArrlenPath Incomplete
 
 func (c JsonArrlenPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonArrlenPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrpop Completed
+type JsonArrpop Incomplete
 
 func (b Builder) JsonArrpop() (c JsonArrpop) {
 	c = JsonArrpop{cs: get(), ks: b.ks}
@@ -247,7 +247,7 @@ func (c JsonArrpop) Key(key string) JsonArrpopKey {
 	return (JsonArrpopKey)(c)
 }
 
-type JsonArrpopKey Completed
+type JsonArrpopKey Incomplete
 
 func (c JsonArrpopKey) Path(path string) JsonArrpopPathPath {
 	c.cs.s = append(c.cs.s, path)
@@ -256,17 +256,17 @@ func (c JsonArrpopKey) Path(path string) JsonArrpopPathPath {
 
 func (c JsonArrpopKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrpopPathIndex Completed
+type JsonArrpopPathIndex Incomplete
 
 func (c JsonArrpopPathIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrpopPathPath Completed
+type JsonArrpopPathPath Incomplete
 
 func (c JsonArrpopPathPath) Index(index int64) JsonArrpopPathIndex {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(index, 10))
@@ -275,10 +275,10 @@ func (c JsonArrpopPathPath) Index(index int64) JsonArrpopPathIndex {
 
 func (c JsonArrpopPathPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonArrtrim Completed
+type JsonArrtrim Incomplete
 
 func (b Builder) JsonArrtrim() (c JsonArrtrim) {
 	c = JsonArrtrim{cs: get(), ks: b.ks}
@@ -296,35 +296,35 @@ func (c JsonArrtrim) Key(key string) JsonArrtrimKey {
 	return (JsonArrtrimKey)(c)
 }
 
-type JsonArrtrimKey Completed
+type JsonArrtrimKey Incomplete
 
 func (c JsonArrtrimKey) Path(path string) JsonArrtrimPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonArrtrimPath)(c)
 }
 
-type JsonArrtrimPath Completed
+type JsonArrtrimPath Incomplete
 
 func (c JsonArrtrimPath) Start(start int64) JsonArrtrimStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
 	return (JsonArrtrimStart)(c)
 }
 
-type JsonArrtrimStart Completed
+type JsonArrtrimStart Incomplete
 
 func (c JsonArrtrimStart) Stop(stop int64) JsonArrtrimStop {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(stop, 10))
 	return (JsonArrtrimStop)(c)
 }
 
-type JsonArrtrimStop Completed
+type JsonArrtrimStop Incomplete
 
 func (c JsonArrtrimStop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonClear Completed
+type JsonClear Incomplete
 
 func (b Builder) JsonClear() (c JsonClear) {
 	c = JsonClear{cs: get(), ks: b.ks}
@@ -342,7 +342,7 @@ func (c JsonClear) Key(key string) JsonClearKey {
 	return (JsonClearKey)(c)
 }
 
-type JsonClearKey Completed
+type JsonClearKey Incomplete
 
 func (c JsonClearKey) Path(path string) JsonClearPath {
 	c.cs.s = append(c.cs.s, path)
@@ -351,17 +351,17 @@ func (c JsonClearKey) Path(path string) JsonClearPath {
 
 func (c JsonClearKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonClearPath Completed
+type JsonClearPath Incomplete
 
 func (c JsonClearPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonDebugHelp Completed
+type JsonDebugHelp Incomplete
 
 func (b Builder) JsonDebugHelp() (c JsonDebugHelp) {
 	c = JsonDebugHelp{cs: get(), ks: b.ks}
@@ -371,10 +371,10 @@ func (b Builder) JsonDebugHelp() (c JsonDebugHelp) {
 
 func (c JsonDebugHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonDebugMemory Completed
+type JsonDebugMemory Incomplete
 
 func (b Builder) JsonDebugMemory() (c JsonDebugMemory) {
 	c = JsonDebugMemory{cs: get(), ks: b.ks}
@@ -392,7 +392,7 @@ func (c JsonDebugMemory) Key(key string) JsonDebugMemoryKey {
 	return (JsonDebugMemoryKey)(c)
 }
 
-type JsonDebugMemoryKey Completed
+type JsonDebugMemoryKey Incomplete
 
 func (c JsonDebugMemoryKey) Path(path string) JsonDebugMemoryPath {
 	c.cs.s = append(c.cs.s, path)
@@ -401,17 +401,17 @@ func (c JsonDebugMemoryKey) Path(path string) JsonDebugMemoryPath {
 
 func (c JsonDebugMemoryKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonDebugMemoryPath Completed
+type JsonDebugMemoryPath Incomplete
 
 func (c JsonDebugMemoryPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonDel Completed
+type JsonDel Incomplete
 
 func (b Builder) JsonDel() (c JsonDel) {
 	c = JsonDel{cs: get(), ks: b.ks}
@@ -429,7 +429,7 @@ func (c JsonDel) Key(key string) JsonDelKey {
 	return (JsonDelKey)(c)
 }
 
-type JsonDelKey Completed
+type JsonDelKey Incomplete
 
 func (c JsonDelKey) Path(path string) JsonDelPath {
 	c.cs.s = append(c.cs.s, path)
@@ -438,17 +438,17 @@ func (c JsonDelKey) Path(path string) JsonDelPath {
 
 func (c JsonDelKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonDelPath Completed
+type JsonDelPath Incomplete
 
 func (c JsonDelPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonForget Completed
+type JsonForget Incomplete
 
 func (b Builder) JsonForget() (c JsonForget) {
 	c = JsonForget{cs: get(), ks: b.ks}
@@ -466,7 +466,7 @@ func (c JsonForget) Key(key string) JsonForgetKey {
 	return (JsonForgetKey)(c)
 }
 
-type JsonForgetKey Completed
+type JsonForgetKey Incomplete
 
 func (c JsonForgetKey) Path(path string) JsonForgetPath {
 	c.cs.s = append(c.cs.s, path)
@@ -475,20 +475,20 @@ func (c JsonForgetKey) Path(path string) JsonForgetPath {
 
 func (c JsonForgetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonForgetPath Completed
+type JsonForgetPath Incomplete
 
 func (c JsonForgetPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonGet Completed
+type JsonGet Incomplete
 
 func (b Builder) JsonGet() (c JsonGet) {
-	c = JsonGet{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonGet{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.GET")
 	return c
 }
@@ -503,7 +503,7 @@ func (c JsonGet) Key(key string) JsonGetKey {
 	return (JsonGetKey)(c)
 }
 
-type JsonGetIndent Completed
+type JsonGetIndent Incomplete
 
 func (c JsonGetIndent) Newline(newline string) JsonGetNewline {
 	c.cs.s = append(c.cs.s, "NEWLINE", newline)
@@ -522,15 +522,15 @@ func (c JsonGetIndent) Path(path ...string) JsonGetPath {
 
 func (c JsonGetIndent) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonGetIndent) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonGetKey Completed
+type JsonGetKey Incomplete
 
 func (c JsonGetKey) Indent(indent string) JsonGetIndent {
 	c.cs.s = append(c.cs.s, "INDENT", indent)
@@ -554,15 +554,15 @@ func (c JsonGetKey) Path(path ...string) JsonGetPath {
 
 func (c JsonGetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonGetKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonGetNewline Completed
+type JsonGetNewline Incomplete
 
 func (c JsonGetNewline) Space(space string) JsonGetSpace {
 	c.cs.s = append(c.cs.s, "SPACE", space)
@@ -576,15 +576,15 @@ func (c JsonGetNewline) Path(path ...string) JsonGetPath {
 
 func (c JsonGetNewline) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonGetNewline) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonGetPath Completed
+type JsonGetPath Incomplete
 
 func (c JsonGetPath) Path(path ...string) JsonGetPath {
 	c.cs.s = append(c.cs.s, path...)
@@ -593,15 +593,15 @@ func (c JsonGetPath) Path(path ...string) JsonGetPath {
 
 func (c JsonGetPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonGetPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonGetSpace Completed
+type JsonGetSpace Incomplete
 
 func (c JsonGetSpace) Path(path ...string) JsonGetPath {
 	c.cs.s = append(c.cs.s, path...)
@@ -610,15 +610,15 @@ func (c JsonGetSpace) Path(path ...string) JsonGetPath {
 
 func (c JsonGetSpace) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonGetSpace) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonMerge Completed
+type JsonMerge Incomplete
 
 func (b Builder) JsonMerge() (c JsonMerge) {
 	c = JsonMerge{cs: get(), ks: b.ks}
@@ -636,31 +636,31 @@ func (c JsonMerge) Key(key string) JsonMergeKey {
 	return (JsonMergeKey)(c)
 }
 
-type JsonMergeKey Completed
+type JsonMergeKey Incomplete
 
 func (c JsonMergeKey) Path(path string) JsonMergePath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonMergePath)(c)
 }
 
-type JsonMergePath Completed
+type JsonMergePath Incomplete
 
 func (c JsonMergePath) Value(value string) JsonMergeValue {
 	c.cs.s = append(c.cs.s, value)
 	return (JsonMergeValue)(c)
 }
 
-type JsonMergeValue Completed
+type JsonMergeValue Incomplete
 
 func (c JsonMergeValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonMget Completed
+type JsonMget Incomplete
 
 func (b Builder) JsonMget() (c JsonMget) {
-	c = JsonMget{cs: get(), ks: b.ks, cf: mtGetTag}
+	c = JsonMget{cs: get(), ks: b.ks, cf: int16(mtGetTag)}
 	c.cs.s = append(c.cs.s, "JSON.MGET")
 	return c
 }
@@ -680,7 +680,7 @@ func (c JsonMget) Key(key ...string) JsonMgetKey {
 	return (JsonMgetKey)(c)
 }
 
-type JsonMgetKey Completed
+type JsonMgetKey Incomplete
 
 func (c JsonMgetKey) Key(key ...string) JsonMgetKey {
 	if c.ks&NoSlot == NoSlot {
@@ -702,19 +702,19 @@ func (c JsonMgetKey) Path(path string) JsonMgetPath {
 	return (JsonMgetPath)(c)
 }
 
-type JsonMgetPath Completed
+type JsonMgetPath Incomplete
 
 func (c JsonMgetPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonMgetPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonMset Completed
+type JsonMset Incomplete
 
 func (b Builder) JsonMset() (c JsonMset) {
 	c = JsonMset{cs: get(), ks: b.ks}
@@ -732,21 +732,21 @@ func (c JsonMset) Key(key string) JsonMsetTripletKey {
 	return (JsonMsetTripletKey)(c)
 }
 
-type JsonMsetTripletKey Completed
+type JsonMsetTripletKey Incomplete
 
 func (c JsonMsetTripletKey) Path(path string) JsonMsetTripletPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonMsetTripletPath)(c)
 }
 
-type JsonMsetTripletPath Completed
+type JsonMsetTripletPath Incomplete
 
 func (c JsonMsetTripletPath) Value(value string) JsonMsetTripletValue {
 	c.cs.s = append(c.cs.s, value)
 	return (JsonMsetTripletValue)(c)
 }
 
-type JsonMsetTripletValue Completed
+type JsonMsetTripletValue Incomplete
 
 func (c JsonMsetTripletValue) Key(key string) JsonMsetTripletKey {
 	if c.ks&NoSlot == NoSlot {
@@ -760,10 +760,10 @@ func (c JsonMsetTripletValue) Key(key string) JsonMsetTripletKey {
 
 func (c JsonMsetTripletValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonNumincrby Completed
+type JsonNumincrby Incomplete
 
 func (b Builder) JsonNumincrby() (c JsonNumincrby) {
 	c = JsonNumincrby{cs: get(), ks: b.ks}
@@ -781,28 +781,28 @@ func (c JsonNumincrby) Key(key string) JsonNumincrbyKey {
 	return (JsonNumincrbyKey)(c)
 }
 
-type JsonNumincrbyKey Completed
+type JsonNumincrbyKey Incomplete
 
 func (c JsonNumincrbyKey) Path(path string) JsonNumincrbyPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonNumincrbyPath)(c)
 }
 
-type JsonNumincrbyPath Completed
+type JsonNumincrbyPath Incomplete
 
 func (c JsonNumincrbyPath) Value(value float64) JsonNumincrbyValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
 	return (JsonNumincrbyValue)(c)
 }
 
-type JsonNumincrbyValue Completed
+type JsonNumincrbyValue Incomplete
 
 func (c JsonNumincrbyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonNummultby Completed
+type JsonNummultby Incomplete
 
 func (b Builder) JsonNummultby() (c JsonNummultby) {
 	c = JsonNummultby{cs: get(), ks: b.ks}
@@ -820,31 +820,31 @@ func (c JsonNummultby) Key(key string) JsonNummultbyKey {
 	return (JsonNummultbyKey)(c)
 }
 
-type JsonNummultbyKey Completed
+type JsonNummultbyKey Incomplete
 
 func (c JsonNummultbyKey) Path(path string) JsonNummultbyPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonNummultbyPath)(c)
 }
 
-type JsonNummultbyPath Completed
+type JsonNummultbyPath Incomplete
 
 func (c JsonNummultbyPath) Value(value float64) JsonNummultbyValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
 	return (JsonNummultbyValue)(c)
 }
 
-type JsonNummultbyValue Completed
+type JsonNummultbyValue Incomplete
 
 func (c JsonNummultbyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonObjkeys Completed
+type JsonObjkeys Incomplete
 
 func (b Builder) JsonObjkeys() (c JsonObjkeys) {
-	c = JsonObjkeys{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonObjkeys{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.OBJKEYS")
 	return c
 }
@@ -859,7 +859,7 @@ func (c JsonObjkeys) Key(key string) JsonObjkeysKey {
 	return (JsonObjkeysKey)(c)
 }
 
-type JsonObjkeysKey Completed
+type JsonObjkeysKey Incomplete
 
 func (c JsonObjkeysKey) Path(path string) JsonObjkeysPath {
 	c.cs.s = append(c.cs.s, path)
@@ -868,30 +868,30 @@ func (c JsonObjkeysKey) Path(path string) JsonObjkeysPath {
 
 func (c JsonObjkeysKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonObjkeysKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonObjkeysPath Completed
+type JsonObjkeysPath Incomplete
 
 func (c JsonObjkeysPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonObjkeysPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonObjlen Completed
+type JsonObjlen Incomplete
 
 func (b Builder) JsonObjlen() (c JsonObjlen) {
-	c = JsonObjlen{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonObjlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.OBJLEN")
 	return c
 }
@@ -906,7 +906,7 @@ func (c JsonObjlen) Key(key string) JsonObjlenKey {
 	return (JsonObjlenKey)(c)
 }
 
-type JsonObjlenKey Completed
+type JsonObjlenKey Incomplete
 
 func (c JsonObjlenKey) Path(path string) JsonObjlenPath {
 	c.cs.s = append(c.cs.s, path)
@@ -915,30 +915,30 @@ func (c JsonObjlenKey) Path(path string) JsonObjlenPath {
 
 func (c JsonObjlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonObjlenKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonObjlenPath Completed
+type JsonObjlenPath Incomplete
 
 func (c JsonObjlenPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonObjlenPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonResp Completed
+type JsonResp Incomplete
 
 func (b Builder) JsonResp() (c JsonResp) {
-	c = JsonResp{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonResp{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.RESP")
 	return c
 }
@@ -953,7 +953,7 @@ func (c JsonResp) Key(key string) JsonRespKey {
 	return (JsonRespKey)(c)
 }
 
-type JsonRespKey Completed
+type JsonRespKey Incomplete
 
 func (c JsonRespKey) Path(path string) JsonRespPath {
 	c.cs.s = append(c.cs.s, path)
@@ -962,27 +962,27 @@ func (c JsonRespKey) Path(path string) JsonRespPath {
 
 func (c JsonRespKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonRespKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonRespPath Completed
+type JsonRespPath Incomplete
 
 func (c JsonRespPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonRespPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonSet Completed
+type JsonSet Incomplete
 
 func (b Builder) JsonSet() (c JsonSet) {
 	c = JsonSet{cs: get(), ks: b.ks}
@@ -1000,35 +1000,35 @@ func (c JsonSet) Key(key string) JsonSetKey {
 	return (JsonSetKey)(c)
 }
 
-type JsonSetConditionNx Completed
+type JsonSetConditionNx Incomplete
 
 func (c JsonSetConditionNx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonSetConditionXx Completed
+type JsonSetConditionXx Incomplete
 
 func (c JsonSetConditionXx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonSetKey Completed
+type JsonSetKey Incomplete
 
 func (c JsonSetKey) Path(path string) JsonSetPath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonSetPath)(c)
 }
 
-type JsonSetPath Completed
+type JsonSetPath Incomplete
 
 func (c JsonSetPath) Value(value string) JsonSetValue {
 	c.cs.s = append(c.cs.s, value)
 	return (JsonSetValue)(c)
 }
 
-type JsonSetValue Completed
+type JsonSetValue Incomplete
 
 func (c JsonSetValue) Nx() JsonSetConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -1042,10 +1042,10 @@ func (c JsonSetValue) Xx() JsonSetConditionXx {
 
 func (c JsonSetValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonStrappend Completed
+type JsonStrappend Incomplete
 
 func (b Builder) JsonStrappend() (c JsonStrappend) {
 	c = JsonStrappend{cs: get(), ks: b.ks}
@@ -1063,7 +1063,7 @@ func (c JsonStrappend) Key(key string) JsonStrappendKey {
 	return (JsonStrappendKey)(c)
 }
 
-type JsonStrappendKey Completed
+type JsonStrappendKey Incomplete
 
 func (c JsonStrappendKey) Path(path string) JsonStrappendPath {
 	c.cs.s = append(c.cs.s, path)
@@ -1075,24 +1075,24 @@ func (c JsonStrappendKey) Value(value string) JsonStrappendValue {
 	return (JsonStrappendValue)(c)
 }
 
-type JsonStrappendPath Completed
+type JsonStrappendPath Incomplete
 
 func (c JsonStrappendPath) Value(value string) JsonStrappendValue {
 	c.cs.s = append(c.cs.s, value)
 	return (JsonStrappendValue)(c)
 }
 
-type JsonStrappendValue Completed
+type JsonStrappendValue Incomplete
 
 func (c JsonStrappendValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonStrlen Completed
+type JsonStrlen Incomplete
 
 func (b Builder) JsonStrlen() (c JsonStrlen) {
-	c = JsonStrlen{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonStrlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.STRLEN")
 	return c
 }
@@ -1107,7 +1107,7 @@ func (c JsonStrlen) Key(key string) JsonStrlenKey {
 	return (JsonStrlenKey)(c)
 }
 
-type JsonStrlenKey Completed
+type JsonStrlenKey Incomplete
 
 func (c JsonStrlenKey) Path(path string) JsonStrlenPath {
 	c.cs.s = append(c.cs.s, path)
@@ -1116,27 +1116,27 @@ func (c JsonStrlenKey) Path(path string) JsonStrlenPath {
 
 func (c JsonStrlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonStrlenKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonStrlenPath Completed
+type JsonStrlenPath Incomplete
 
 func (c JsonStrlenPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonStrlenPath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonToggle Completed
+type JsonToggle Incomplete
 
 func (b Builder) JsonToggle() (c JsonToggle) {
 	c = JsonToggle{cs: get(), ks: b.ks}
@@ -1154,24 +1154,24 @@ func (c JsonToggle) Key(key string) JsonToggleKey {
 	return (JsonToggleKey)(c)
 }
 
-type JsonToggleKey Completed
+type JsonToggleKey Incomplete
 
 func (c JsonToggleKey) Path(path string) JsonTogglePath {
 	c.cs.s = append(c.cs.s, path)
 	return (JsonTogglePath)(c)
 }
 
-type JsonTogglePath Completed
+type JsonTogglePath Incomplete
 
 func (c JsonTogglePath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonType Completed
+type JsonType Incomplete
 
 func (b Builder) JsonType() (c JsonType) {
-	c = JsonType{cs: get(), ks: b.ks, cf: readonly}
+	c = JsonType{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "JSON.TYPE")
 	return c
 }
@@ -1186,7 +1186,7 @@ func (c JsonType) Key(key string) JsonTypeKey {
 	return (JsonTypeKey)(c)
 }
 
-type JsonTypeKey Completed
+type JsonTypeKey Incomplete
 
 func (c JsonTypeKey) Path(path string) JsonTypePath {
 	c.cs.s = append(c.cs.s, path)
@@ -1195,22 +1195,22 @@ func (c JsonTypeKey) Path(path string) JsonTypePath {
 
 func (c JsonTypeKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonTypeKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type JsonTypePath Completed
+type JsonTypePath Incomplete
 
 func (c JsonTypePath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c JsonTypePath) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_list.go
+++ b/internal/cmds/gen_list.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type Blmove Completed
+type Blmove Incomplete
 
 func (b Builder) Blmove() (c Blmove) {
-	c = Blmove{cs: get(), ks: b.ks, cf: blockTag}
+	c = Blmove{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BLMOVE")
 	return c
 }
@@ -22,7 +22,7 @@ func (c Blmove) Source(source string) BlmoveSource {
 	return (BlmoveSource)(c)
 }
 
-type BlmoveDestination Completed
+type BlmoveDestination Incomplete
 
 func (c BlmoveDestination) Left() BlmoveWherefromLeft {
 	c.cs.s = append(c.cs.s, "LEFT")
@@ -34,7 +34,7 @@ func (c BlmoveDestination) Right() BlmoveWherefromRight {
 	return (BlmoveWherefromRight)(c)
 }
 
-type BlmoveSource Completed
+type BlmoveSource Incomplete
 
 func (c BlmoveSource) Destination(destination string) BlmoveDestination {
 	if c.ks&NoSlot == NoSlot {
@@ -46,14 +46,14 @@ func (c BlmoveSource) Destination(destination string) BlmoveDestination {
 	return (BlmoveDestination)(c)
 }
 
-type BlmoveTimeout Completed
+type BlmoveTimeout Incomplete
 
 func (c BlmoveTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BlmoveWherefromLeft Completed
+type BlmoveWherefromLeft Incomplete
 
 func (c BlmoveWherefromLeft) Left() BlmoveWheretoLeft {
 	c.cs.s = append(c.cs.s, "LEFT")
@@ -65,7 +65,7 @@ func (c BlmoveWherefromLeft) Right() BlmoveWheretoRight {
 	return (BlmoveWheretoRight)(c)
 }
 
-type BlmoveWherefromRight Completed
+type BlmoveWherefromRight Incomplete
 
 func (c BlmoveWherefromRight) Left() BlmoveWheretoLeft {
 	c.cs.s = append(c.cs.s, "LEFT")
@@ -77,24 +77,24 @@ func (c BlmoveWherefromRight) Right() BlmoveWheretoRight {
 	return (BlmoveWheretoRight)(c)
 }
 
-type BlmoveWheretoLeft Completed
+type BlmoveWheretoLeft Incomplete
 
 func (c BlmoveWheretoLeft) Timeout(timeout float64) BlmoveTimeout {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(timeout, 'f', -1, 64))
 	return (BlmoveTimeout)(c)
 }
 
-type BlmoveWheretoRight Completed
+type BlmoveWheretoRight Incomplete
 
 func (c BlmoveWheretoRight) Timeout(timeout float64) BlmoveTimeout {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(timeout, 'f', -1, 64))
 	return (BlmoveTimeout)(c)
 }
 
-type Blmpop Completed
+type Blmpop Incomplete
 
 func (b Builder) Blmpop() (c Blmpop) {
-	c = Blmpop{cs: get(), ks: b.ks, cf: blockTag}
+	c = Blmpop{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BLMPOP")
 	return c
 }
@@ -104,14 +104,14 @@ func (c Blmpop) Timeout(timeout float64) BlmpopTimeout {
 	return (BlmpopTimeout)(c)
 }
 
-type BlmpopCount Completed
+type BlmpopCount Incomplete
 
 func (c BlmpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BlmpopKey Completed
+type BlmpopKey Incomplete
 
 func (c BlmpopKey) Key(key ...string) BlmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -138,7 +138,7 @@ func (c BlmpopKey) Right() BlmpopWhereRight {
 	return (BlmpopWhereRight)(c)
 }
 
-type BlmpopNumkeys Completed
+type BlmpopNumkeys Incomplete
 
 func (c BlmpopNumkeys) Key(key ...string) BlmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -155,14 +155,14 @@ func (c BlmpopNumkeys) Key(key ...string) BlmpopKey {
 	return (BlmpopKey)(c)
 }
 
-type BlmpopTimeout Completed
+type BlmpopTimeout Incomplete
 
 func (c BlmpopTimeout) Numkeys(numkeys int64) BlmpopNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (BlmpopNumkeys)(c)
 }
 
-type BlmpopWhereLeft Completed
+type BlmpopWhereLeft Incomplete
 
 func (c BlmpopWhereLeft) Count(count int64) BlmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -171,10 +171,10 @@ func (c BlmpopWhereLeft) Count(count int64) BlmpopCount {
 
 func (c BlmpopWhereLeft) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BlmpopWhereRight Completed
+type BlmpopWhereRight Incomplete
 
 func (c BlmpopWhereRight) Count(count int64) BlmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -183,13 +183,13 @@ func (c BlmpopWhereRight) Count(count int64) BlmpopCount {
 
 func (c BlmpopWhereRight) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Blpop Completed
+type Blpop Incomplete
 
 func (b Builder) Blpop() (c Blpop) {
-	c = Blpop{cs: get(), ks: b.ks, cf: blockTag}
+	c = Blpop{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BLPOP")
 	return c
 }
@@ -209,7 +209,7 @@ func (c Blpop) Key(key ...string) BlpopKey {
 	return (BlpopKey)(c)
 }
 
-type BlpopKey Completed
+type BlpopKey Incomplete
 
 func (c BlpopKey) Key(key ...string) BlpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -231,17 +231,17 @@ func (c BlpopKey) Timeout(timeout float64) BlpopTimeout {
 	return (BlpopTimeout)(c)
 }
 
-type BlpopTimeout Completed
+type BlpopTimeout Incomplete
 
 func (c BlpopTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Brpop Completed
+type Brpop Incomplete
 
 func (b Builder) Brpop() (c Brpop) {
-	c = Brpop{cs: get(), ks: b.ks, cf: blockTag}
+	c = Brpop{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BRPOP")
 	return c
 }
@@ -261,7 +261,7 @@ func (c Brpop) Key(key ...string) BrpopKey {
 	return (BrpopKey)(c)
 }
 
-type BrpopKey Completed
+type BrpopKey Incomplete
 
 func (c BrpopKey) Key(key ...string) BrpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -283,17 +283,17 @@ func (c BrpopKey) Timeout(timeout float64) BrpopTimeout {
 	return (BrpopTimeout)(c)
 }
 
-type BrpopTimeout Completed
+type BrpopTimeout Incomplete
 
 func (c BrpopTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Brpoplpush Completed
+type Brpoplpush Incomplete
 
 func (b Builder) Brpoplpush() (c Brpoplpush) {
-	c = Brpoplpush{cs: get(), ks: b.ks, cf: blockTag}
+	c = Brpoplpush{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BRPOPLPUSH")
 	return c
 }
@@ -308,14 +308,14 @@ func (c Brpoplpush) Source(source string) BrpoplpushSource {
 	return (BrpoplpushSource)(c)
 }
 
-type BrpoplpushDestination Completed
+type BrpoplpushDestination Incomplete
 
 func (c BrpoplpushDestination) Timeout(timeout float64) BrpoplpushTimeout {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(timeout, 'f', -1, 64))
 	return (BrpoplpushTimeout)(c)
 }
 
-type BrpoplpushSource Completed
+type BrpoplpushSource Incomplete
 
 func (c BrpoplpushSource) Destination(destination string) BrpoplpushDestination {
 	if c.ks&NoSlot == NoSlot {
@@ -327,17 +327,17 @@ func (c BrpoplpushSource) Destination(destination string) BrpoplpushDestination 
 	return (BrpoplpushDestination)(c)
 }
 
-type BrpoplpushTimeout Completed
+type BrpoplpushTimeout Incomplete
 
 func (c BrpoplpushTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lindex Completed
+type Lindex Incomplete
 
 func (b Builder) Lindex() (c Lindex) {
-	c = Lindex{cs: get(), ks: b.ks, cf: readonly}
+	c = Lindex{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "LINDEX")
 	return c
 }
@@ -352,26 +352,26 @@ func (c Lindex) Key(key string) LindexKey {
 	return (LindexKey)(c)
 }
 
-type LindexIndex Completed
+type LindexIndex Incomplete
 
 func (c LindexIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LindexIndex) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LindexKey Completed
+type LindexKey Incomplete
 
 func (c LindexKey) Index(index int64) LindexIndex {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(index, 10))
 	return (LindexIndex)(c)
 }
 
-type Linsert Completed
+type Linsert Incomplete
 
 func (b Builder) Linsert() (c Linsert) {
 	c = Linsert{cs: get(), ks: b.ks}
@@ -389,14 +389,14 @@ func (c Linsert) Key(key string) LinsertKey {
 	return (LinsertKey)(c)
 }
 
-type LinsertElement Completed
+type LinsertElement Incomplete
 
 func (c LinsertElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LinsertKey Completed
+type LinsertKey Incomplete
 
 func (c LinsertKey) Before() LinsertWhereBefore {
 	c.cs.s = append(c.cs.s, "BEFORE")
@@ -408,31 +408,31 @@ func (c LinsertKey) After() LinsertWhereAfter {
 	return (LinsertWhereAfter)(c)
 }
 
-type LinsertPivot Completed
+type LinsertPivot Incomplete
 
 func (c LinsertPivot) Element(element string) LinsertElement {
 	c.cs.s = append(c.cs.s, element)
 	return (LinsertElement)(c)
 }
 
-type LinsertWhereAfter Completed
+type LinsertWhereAfter Incomplete
 
 func (c LinsertWhereAfter) Pivot(pivot string) LinsertPivot {
 	c.cs.s = append(c.cs.s, pivot)
 	return (LinsertPivot)(c)
 }
 
-type LinsertWhereBefore Completed
+type LinsertWhereBefore Incomplete
 
 func (c LinsertWhereBefore) Pivot(pivot string) LinsertPivot {
 	c.cs.s = append(c.cs.s, pivot)
 	return (LinsertPivot)(c)
 }
 
-type Llen Completed
+type Llen Incomplete
 
 func (b Builder) Llen() (c Llen) {
-	c = Llen{cs: get(), ks: b.ks, cf: readonly}
+	c = Llen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "LLEN")
 	return c
 }
@@ -447,19 +447,19 @@ func (c Llen) Key(key string) LlenKey {
 	return (LlenKey)(c)
 }
 
-type LlenKey Completed
+type LlenKey Incomplete
 
 func (c LlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LlenKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lmove Completed
+type Lmove Incomplete
 
 func (b Builder) Lmove() (c Lmove) {
 	c = Lmove{cs: get(), ks: b.ks}
@@ -477,7 +477,7 @@ func (c Lmove) Source(source string) LmoveSource {
 	return (LmoveSource)(c)
 }
 
-type LmoveDestination Completed
+type LmoveDestination Incomplete
 
 func (c LmoveDestination) Left() LmoveWherefromLeft {
 	c.cs.s = append(c.cs.s, "LEFT")
@@ -489,7 +489,7 @@ func (c LmoveDestination) Right() LmoveWherefromRight {
 	return (LmoveWherefromRight)(c)
 }
 
-type LmoveSource Completed
+type LmoveSource Incomplete
 
 func (c LmoveSource) Destination(destination string) LmoveDestination {
 	if c.ks&NoSlot == NoSlot {
@@ -501,7 +501,7 @@ func (c LmoveSource) Destination(destination string) LmoveDestination {
 	return (LmoveDestination)(c)
 }
 
-type LmoveWherefromLeft Completed
+type LmoveWherefromLeft Incomplete
 
 func (c LmoveWherefromLeft) Left() LmoveWheretoLeft {
 	c.cs.s = append(c.cs.s, "LEFT")
@@ -513,7 +513,7 @@ func (c LmoveWherefromLeft) Right() LmoveWheretoRight {
 	return (LmoveWheretoRight)(c)
 }
 
-type LmoveWherefromRight Completed
+type LmoveWherefromRight Incomplete
 
 func (c LmoveWherefromRight) Left() LmoveWheretoLeft {
 	c.cs.s = append(c.cs.s, "LEFT")
@@ -525,21 +525,21 @@ func (c LmoveWherefromRight) Right() LmoveWheretoRight {
 	return (LmoveWheretoRight)(c)
 }
 
-type LmoveWheretoLeft Completed
+type LmoveWheretoLeft Incomplete
 
 func (c LmoveWheretoLeft) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LmoveWheretoRight Completed
+type LmoveWheretoRight Incomplete
 
 func (c LmoveWheretoRight) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lmpop Completed
+type Lmpop Incomplete
 
 func (b Builder) Lmpop() (c Lmpop) {
 	c = Lmpop{cs: get(), ks: b.ks}
@@ -552,14 +552,14 @@ func (c Lmpop) Numkeys(numkeys int64) LmpopNumkeys {
 	return (LmpopNumkeys)(c)
 }
 
-type LmpopCount Completed
+type LmpopCount Incomplete
 
 func (c LmpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LmpopKey Completed
+type LmpopKey Incomplete
 
 func (c LmpopKey) Key(key ...string) LmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -586,7 +586,7 @@ func (c LmpopKey) Right() LmpopWhereRight {
 	return (LmpopWhereRight)(c)
 }
 
-type LmpopNumkeys Completed
+type LmpopNumkeys Incomplete
 
 func (c LmpopNumkeys) Key(key ...string) LmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -603,7 +603,7 @@ func (c LmpopNumkeys) Key(key ...string) LmpopKey {
 	return (LmpopKey)(c)
 }
 
-type LmpopWhereLeft Completed
+type LmpopWhereLeft Incomplete
 
 func (c LmpopWhereLeft) Count(count int64) LmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -612,10 +612,10 @@ func (c LmpopWhereLeft) Count(count int64) LmpopCount {
 
 func (c LmpopWhereLeft) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LmpopWhereRight Completed
+type LmpopWhereRight Incomplete
 
 func (c LmpopWhereRight) Count(count int64) LmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -624,10 +624,10 @@ func (c LmpopWhereRight) Count(count int64) LmpopCount {
 
 func (c LmpopWhereRight) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lpop Completed
+type Lpop Incomplete
 
 func (b Builder) Lpop() (c Lpop) {
 	c = Lpop{cs: get(), ks: b.ks}
@@ -645,14 +645,14 @@ func (c Lpop) Key(key string) LpopKey {
 	return (LpopKey)(c)
 }
 
-type LpopCount Completed
+type LpopCount Incomplete
 
 func (c LpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LpopKey Completed
+type LpopKey Incomplete
 
 func (c LpopKey) Count(count int64) LpopCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -661,13 +661,13 @@ func (c LpopKey) Count(count int64) LpopCount {
 
 func (c LpopKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lpos Completed
+type Lpos Incomplete
 
 func (b Builder) Lpos() (c Lpos) {
-	c = Lpos{cs: get(), ks: b.ks, cf: readonly}
+	c = Lpos{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "LPOS")
 	return c
 }
@@ -682,7 +682,7 @@ func (c Lpos) Key(key string) LposKey {
 	return (LposKey)(c)
 }
 
-type LposCount Completed
+type LposCount Incomplete
 
 func (c LposCount) Maxlen(len int64) LposMaxlen {
 	c.cs.s = append(c.cs.s, "MAXLEN", strconv.FormatInt(len, 10))
@@ -691,15 +691,15 @@ func (c LposCount) Maxlen(len int64) LposMaxlen {
 
 func (c LposCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LposCount) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LposElement Completed
+type LposElement Incomplete
 
 func (c LposElement) Rank(rank int64) LposRank {
 	c.cs.s = append(c.cs.s, "RANK", strconv.FormatInt(rank, 10))
@@ -718,34 +718,34 @@ func (c LposElement) Maxlen(len int64) LposMaxlen {
 
 func (c LposElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LposElement) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LposKey Completed
+type LposKey Incomplete
 
 func (c LposKey) Element(element string) LposElement {
 	c.cs.s = append(c.cs.s, element)
 	return (LposElement)(c)
 }
 
-type LposMaxlen Completed
+type LposMaxlen Incomplete
 
 func (c LposMaxlen) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LposMaxlen) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LposRank Completed
+type LposRank Incomplete
 
 func (c LposRank) Count(numMatches int64) LposCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(numMatches, 10))
@@ -759,15 +759,15 @@ func (c LposRank) Maxlen(len int64) LposMaxlen {
 
 func (c LposRank) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LposRank) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lpush Completed
+type Lpush Incomplete
 
 func (b Builder) Lpush() (c Lpush) {
 	c = Lpush{cs: get(), ks: b.ks}
@@ -785,7 +785,7 @@ func (c Lpush) Key(key string) LpushKey {
 	return (LpushKey)(c)
 }
 
-type LpushElement Completed
+type LpushElement Incomplete
 
 func (c LpushElement) Element(element ...string) LpushElement {
 	c.cs.s = append(c.cs.s, element...)
@@ -794,17 +794,17 @@ func (c LpushElement) Element(element ...string) LpushElement {
 
 func (c LpushElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LpushKey Completed
+type LpushKey Incomplete
 
 func (c LpushKey) Element(element ...string) LpushElement {
 	c.cs.s = append(c.cs.s, element...)
 	return (LpushElement)(c)
 }
 
-type Lpushx Completed
+type Lpushx Incomplete
 
 func (b Builder) Lpushx() (c Lpushx) {
 	c = Lpushx{cs: get(), ks: b.ks}
@@ -822,7 +822,7 @@ func (c Lpushx) Key(key string) LpushxKey {
 	return (LpushxKey)(c)
 }
 
-type LpushxElement Completed
+type LpushxElement Incomplete
 
 func (c LpushxElement) Element(element ...string) LpushxElement {
 	c.cs.s = append(c.cs.s, element...)
@@ -831,20 +831,20 @@ func (c LpushxElement) Element(element ...string) LpushxElement {
 
 func (c LpushxElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LpushxKey Completed
+type LpushxKey Incomplete
 
 func (c LpushxKey) Element(element ...string) LpushxElement {
 	c.cs.s = append(c.cs.s, element...)
 	return (LpushxElement)(c)
 }
 
-type Lrange Completed
+type Lrange Incomplete
 
 func (b Builder) Lrange() (c Lrange) {
-	c = Lrange{cs: get(), ks: b.ks, cf: readonly}
+	c = Lrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "LRANGE")
 	return c
 }
@@ -859,33 +859,33 @@ func (c Lrange) Key(key string) LrangeKey {
 	return (LrangeKey)(c)
 }
 
-type LrangeKey Completed
+type LrangeKey Incomplete
 
 func (c LrangeKey) Start(start int64) LrangeStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
 	return (LrangeStart)(c)
 }
 
-type LrangeStart Completed
+type LrangeStart Incomplete
 
 func (c LrangeStart) Stop(stop int64) LrangeStop {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(stop, 10))
 	return (LrangeStop)(c)
 }
 
-type LrangeStop Completed
+type LrangeStop Incomplete
 
 func (c LrangeStop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c LrangeStop) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lrem Completed
+type Lrem Incomplete
 
 func (b Builder) Lrem() (c Lrem) {
 	c = Lrem{cs: get(), ks: b.ks}
@@ -903,28 +903,28 @@ func (c Lrem) Key(key string) LremKey {
 	return (LremKey)(c)
 }
 
-type LremCount Completed
+type LremCount Incomplete
 
 func (c LremCount) Element(element string) LremElement {
 	c.cs.s = append(c.cs.s, element)
 	return (LremElement)(c)
 }
 
-type LremElement Completed
+type LremElement Incomplete
 
 func (c LremElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LremKey Completed
+type LremKey Incomplete
 
 func (c LremKey) Count(count int64) LremCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
 	return (LremCount)(c)
 }
 
-type Lset Completed
+type Lset Incomplete
 
 func (b Builder) Lset() (c Lset) {
 	c = Lset{cs: get(), ks: b.ks}
@@ -942,28 +942,28 @@ func (c Lset) Key(key string) LsetKey {
 	return (LsetKey)(c)
 }
 
-type LsetElement Completed
+type LsetElement Incomplete
 
 func (c LsetElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LsetIndex Completed
+type LsetIndex Incomplete
 
 func (c LsetIndex) Element(element string) LsetElement {
 	c.cs.s = append(c.cs.s, element)
 	return (LsetElement)(c)
 }
 
-type LsetKey Completed
+type LsetKey Incomplete
 
 func (c LsetKey) Index(index int64) LsetIndex {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(index, 10))
 	return (LsetIndex)(c)
 }
 
-type Ltrim Completed
+type Ltrim Incomplete
 
 func (b Builder) Ltrim() (c Ltrim) {
 	c = Ltrim{cs: get(), ks: b.ks}
@@ -981,28 +981,28 @@ func (c Ltrim) Key(key string) LtrimKey {
 	return (LtrimKey)(c)
 }
 
-type LtrimKey Completed
+type LtrimKey Incomplete
 
 func (c LtrimKey) Start(start int64) LtrimStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
 	return (LtrimStart)(c)
 }
 
-type LtrimStart Completed
+type LtrimStart Incomplete
 
 func (c LtrimStart) Stop(stop int64) LtrimStop {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(stop, 10))
 	return (LtrimStop)(c)
 }
 
-type LtrimStop Completed
+type LtrimStop Incomplete
 
 func (c LtrimStop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Rpop Completed
+type Rpop Incomplete
 
 func (b Builder) Rpop() (c Rpop) {
 	c = Rpop{cs: get(), ks: b.ks}
@@ -1020,14 +1020,14 @@ func (c Rpop) Key(key string) RpopKey {
 	return (RpopKey)(c)
 }
 
-type RpopCount Completed
+type RpopCount Incomplete
 
 func (c RpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RpopKey Completed
+type RpopKey Incomplete
 
 func (c RpopKey) Count(count int64) RpopCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -1036,10 +1036,10 @@ func (c RpopKey) Count(count int64) RpopCount {
 
 func (c RpopKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Rpoplpush Completed
+type Rpoplpush Incomplete
 
 func (b Builder) Rpoplpush() (c Rpoplpush) {
 	c = Rpoplpush{cs: get(), ks: b.ks}
@@ -1057,14 +1057,14 @@ func (c Rpoplpush) Source(source string) RpoplpushSource {
 	return (RpoplpushSource)(c)
 }
 
-type RpoplpushDestination Completed
+type RpoplpushDestination Incomplete
 
 func (c RpoplpushDestination) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RpoplpushSource Completed
+type RpoplpushSource Incomplete
 
 func (c RpoplpushSource) Destination(destination string) RpoplpushDestination {
 	if c.ks&NoSlot == NoSlot {
@@ -1076,7 +1076,7 @@ func (c RpoplpushSource) Destination(destination string) RpoplpushDestination {
 	return (RpoplpushDestination)(c)
 }
 
-type Rpush Completed
+type Rpush Incomplete
 
 func (b Builder) Rpush() (c Rpush) {
 	c = Rpush{cs: get(), ks: b.ks}
@@ -1094,7 +1094,7 @@ func (c Rpush) Key(key string) RpushKey {
 	return (RpushKey)(c)
 }
 
-type RpushElement Completed
+type RpushElement Incomplete
 
 func (c RpushElement) Element(element ...string) RpushElement {
 	c.cs.s = append(c.cs.s, element...)
@@ -1103,17 +1103,17 @@ func (c RpushElement) Element(element ...string) RpushElement {
 
 func (c RpushElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RpushKey Completed
+type RpushKey Incomplete
 
 func (c RpushKey) Element(element ...string) RpushElement {
 	c.cs.s = append(c.cs.s, element...)
 	return (RpushElement)(c)
 }
 
-type Rpushx Completed
+type Rpushx Incomplete
 
 func (b Builder) Rpushx() (c Rpushx) {
 	c = Rpushx{cs: get(), ks: b.ks}
@@ -1131,7 +1131,7 @@ func (c Rpushx) Key(key string) RpushxKey {
 	return (RpushxKey)(c)
 }
 
-type RpushxElement Completed
+type RpushxElement Incomplete
 
 func (c RpushxElement) Element(element ...string) RpushxElement {
 	c.cs.s = append(c.cs.s, element...)
@@ -1140,10 +1140,10 @@ func (c RpushxElement) Element(element ...string) RpushxElement {
 
 func (c RpushxElement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type RpushxKey Completed
+type RpushxKey Incomplete
 
 func (c RpushxKey) Element(element ...string) RpushxElement {
 	c.cs.s = append(c.cs.s, element...)

--- a/internal/cmds/gen_model.go
+++ b/internal/cmds/gen_model.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type AiModeldel Completed
+type AiModeldel Incomplete
 
 func (b Builder) AiModeldel() (c AiModeldel) {
 	c = AiModeldel{cs: get(), ks: b.ks}
@@ -22,17 +22,17 @@ func (c AiModeldel) Key(key string) AiModeldelKey {
 	return (AiModeldelKey)(c)
 }
 
-type AiModeldelKey Completed
+type AiModeldelKey Incomplete
 
 func (c AiModeldelKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelget Completed
+type AiModelget Incomplete
 
 func (b Builder) AiModelget() (c AiModelget) {
-	c = AiModelget{cs: get(), ks: b.ks, cf: readonly}
+	c = AiModelget{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "AI.MODELGET")
 	return c
 }
@@ -47,19 +47,19 @@ func (c AiModelget) Key(key string) AiModelgetKey {
 	return (AiModelgetKey)(c)
 }
 
-type AiModelgetBlob Completed
+type AiModelgetBlob Incomplete
 
 func (c AiModelgetBlob) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiModelgetBlob) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelgetKey Completed
+type AiModelgetKey Incomplete
 
 func (c AiModelgetKey) Meta() AiModelgetMeta {
 	c.cs.s = append(c.cs.s, "META")
@@ -73,15 +73,15 @@ func (c AiModelgetKey) Blob() AiModelgetBlob {
 
 func (c AiModelgetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiModelgetKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelgetMeta Completed
+type AiModelgetMeta Incomplete
 
 func (c AiModelgetMeta) Blob() AiModelgetBlob {
 	c.cs.s = append(c.cs.s, "BLOB")
@@ -90,15 +90,15 @@ func (c AiModelgetMeta) Blob() AiModelgetBlob {
 
 func (c AiModelgetMeta) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiModelgetMeta) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstore Completed
+type AiModelstore Incomplete
 
 func (b Builder) AiModelstore() (c AiModelstore) {
 	c = AiModelstore{cs: get(), ks: b.ks}
@@ -116,7 +116,7 @@ func (c AiModelstore) Key(key string) AiModelstoreKey {
 	return (AiModelstoreKey)(c)
 }
 
-type AiModelstoreBackendOnnx Completed
+type AiModelstoreBackendOnnx Incomplete
 
 func (c AiModelstoreBackendOnnx) Cpu() AiModelstoreDeviceCpu {
 	c.cs.s = append(c.cs.s, "CPU")
@@ -128,7 +128,7 @@ func (c AiModelstoreBackendOnnx) Gpu() AiModelstoreDeviceGpu {
 	return (AiModelstoreDeviceGpu)(c)
 }
 
-type AiModelstoreBackendTf Completed
+type AiModelstoreBackendTf Incomplete
 
 func (c AiModelstoreBackendTf) Cpu() AiModelstoreDeviceCpu {
 	c.cs.s = append(c.cs.s, "CPU")
@@ -140,7 +140,7 @@ func (c AiModelstoreBackendTf) Gpu() AiModelstoreDeviceGpu {
 	return (AiModelstoreDeviceGpu)(c)
 }
 
-type AiModelstoreBackendTorch Completed
+type AiModelstoreBackendTorch Incomplete
 
 func (c AiModelstoreBackendTorch) Cpu() AiModelstoreDeviceCpu {
 	c.cs.s = append(c.cs.s, "CPU")
@@ -152,7 +152,7 @@ func (c AiModelstoreBackendTorch) Gpu() AiModelstoreDeviceGpu {
 	return (AiModelstoreDeviceGpu)(c)
 }
 
-type AiModelstoreBatchsize Completed
+type AiModelstoreBatchsize Incomplete
 
 func (c AiModelstoreBatchsize) Minbatchsize(minbatchsize int64) AiModelstoreMinbatchsize {
 	c.cs.s = append(c.cs.s, "MINBATCHSIZE", strconv.FormatInt(minbatchsize, 10))
@@ -181,17 +181,17 @@ func (c AiModelstoreBatchsize) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreBatchsize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreBlob Completed
+type AiModelstoreBlob Incomplete
 
 func (c AiModelstoreBlob) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreDeviceCpu Completed
+type AiModelstoreDeviceCpu Incomplete
 
 func (c AiModelstoreDeviceCpu) Tag(tag string) AiModelstoreTag {
 	c.cs.s = append(c.cs.s, "TAG", tag)
@@ -230,10 +230,10 @@ func (c AiModelstoreDeviceCpu) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreDeviceCpu) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreDeviceGpu Completed
+type AiModelstoreDeviceGpu Incomplete
 
 func (c AiModelstoreDeviceGpu) Tag(tag string) AiModelstoreTag {
 	c.cs.s = append(c.cs.s, "TAG", tag)
@@ -272,10 +272,10 @@ func (c AiModelstoreDeviceGpu) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreDeviceGpu) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreInputsInput Completed
+type AiModelstoreInputsInput Incomplete
 
 func (c AiModelstoreInputsInput) Input(input ...string) AiModelstoreInputsInput {
 	c.cs.s = append(c.cs.s, input...)
@@ -294,17 +294,17 @@ func (c AiModelstoreInputsInput) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreInputsInput) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreInputsInputs Completed
+type AiModelstoreInputsInputs Incomplete
 
 func (c AiModelstoreInputsInputs) Input(input ...string) AiModelstoreInputsInput {
 	c.cs.s = append(c.cs.s, input...)
 	return (AiModelstoreInputsInput)(c)
 }
 
-type AiModelstoreKey Completed
+type AiModelstoreKey Incomplete
 
 func (c AiModelstoreKey) Tf() AiModelstoreBackendTf {
 	c.cs.s = append(c.cs.s, "TF")
@@ -321,7 +321,7 @@ func (c AiModelstoreKey) Onnx() AiModelstoreBackendOnnx {
 	return (AiModelstoreBackendOnnx)(c)
 }
 
-type AiModelstoreMinbatchsize Completed
+type AiModelstoreMinbatchsize Incomplete
 
 func (c AiModelstoreMinbatchsize) Minbatchtimeout(minbatchtimeout int64) AiModelstoreMinbatchtimeout {
 	c.cs.s = append(c.cs.s, "MINBATCHTIMEOUT", strconv.FormatInt(minbatchtimeout, 10))
@@ -345,10 +345,10 @@ func (c AiModelstoreMinbatchsize) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreMinbatchsize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreMinbatchtimeout Completed
+type AiModelstoreMinbatchtimeout Incomplete
 
 func (c AiModelstoreMinbatchtimeout) Inputs(inputCount int64) AiModelstoreInputsInputs {
 	c.cs.s = append(c.cs.s, "INPUTS", strconv.FormatInt(inputCount, 10))
@@ -367,10 +367,10 @@ func (c AiModelstoreMinbatchtimeout) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreMinbatchtimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreOutputsOutput Completed
+type AiModelstoreOutputsOutput Incomplete
 
 func (c AiModelstoreOutputsOutput) Output(output ...string) AiModelstoreOutputsOutput {
 	c.cs.s = append(c.cs.s, output...)
@@ -384,17 +384,17 @@ func (c AiModelstoreOutputsOutput) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreOutputsOutput) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiModelstoreOutputsOutputs Completed
+type AiModelstoreOutputsOutputs Incomplete
 
 func (c AiModelstoreOutputsOutputs) Output(output ...string) AiModelstoreOutputsOutput {
 	c.cs.s = append(c.cs.s, output...)
 	return (AiModelstoreOutputsOutput)(c)
 }
 
-type AiModelstoreTag Completed
+type AiModelstoreTag Incomplete
 
 func (c AiModelstoreTag) Batchsize(batchsize int64) AiModelstoreBatchsize {
 	c.cs.s = append(c.cs.s, "BATCHSIZE", strconv.FormatInt(batchsize, 10))
@@ -428,5 +428,5 @@ func (c AiModelstoreTag) Blob(blob string) AiModelstoreBlob {
 
 func (c AiModelstoreTag) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_pubsub.go
+++ b/internal/cmds/gen_pubsub.go
@@ -2,10 +2,10 @@
 
 package cmds
 
-type Psubscribe Completed
+type Psubscribe Incomplete
 
 func (b Builder) Psubscribe() (c Psubscribe) {
-	c = Psubscribe{cs: get(), ks: b.ks, cf: noRetTag}
+	c = Psubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
 	c.cs.s = append(c.cs.s, "PSUBSCRIBE")
 	return c
 }
@@ -15,7 +15,7 @@ func (c Psubscribe) Pattern(pattern ...string) PsubscribePattern {
 	return (PsubscribePattern)(c)
 }
 
-type PsubscribePattern Completed
+type PsubscribePattern Incomplete
 
 func (c PsubscribePattern) Pattern(pattern ...string) PsubscribePattern {
 	c.cs.s = append(c.cs.s, pattern...)
@@ -24,10 +24,10 @@ func (c PsubscribePattern) Pattern(pattern ...string) PsubscribePattern {
 
 func (c PsubscribePattern) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Publish Completed
+type Publish Incomplete
 
 func (b Builder) Publish() (c Publish) {
 	c = Publish{cs: get(), ks: b.ks}
@@ -40,24 +40,24 @@ func (c Publish) Channel(channel string) PublishChannel {
 	return (PublishChannel)(c)
 }
 
-type PublishChannel Completed
+type PublishChannel Incomplete
 
 func (c PublishChannel) Message(message string) PublishMessage {
 	c.cs.s = append(c.cs.s, message)
 	return (PublishMessage)(c)
 }
 
-type PublishMessage Completed
+type PublishMessage Incomplete
 
 func (c PublishMessage) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubChannels Completed
+type PubsubChannels Incomplete
 
 func (b Builder) PubsubChannels() (c PubsubChannels) {
-	c = PubsubChannels{cs: get(), ks: b.ks, cf: readonly}
+	c = PubsubChannels{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PUBSUB", "CHANNELS")
 	return c
 }
@@ -69,46 +69,46 @@ func (c PubsubChannels) Pattern(pattern string) PubsubChannelsPattern {
 
 func (c PubsubChannels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubChannelsPattern Completed
+type PubsubChannelsPattern Incomplete
 
 func (c PubsubChannelsPattern) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubHelp Completed
+type PubsubHelp Incomplete
 
 func (b Builder) PubsubHelp() (c PubsubHelp) {
-	c = PubsubHelp{cs: get(), ks: b.ks, cf: readonly}
+	c = PubsubHelp{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PUBSUB", "HELP")
 	return c
 }
 
 func (c PubsubHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubNumpat Completed
+type PubsubNumpat Incomplete
 
 func (b Builder) PubsubNumpat() (c PubsubNumpat) {
-	c = PubsubNumpat{cs: get(), ks: b.ks, cf: readonly}
+	c = PubsubNumpat{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PUBSUB", "NUMPAT")
 	return c
 }
 
 func (c PubsubNumpat) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubNumsub Completed
+type PubsubNumsub Incomplete
 
 func (b Builder) PubsubNumsub() (c PubsubNumsub) {
-	c = PubsubNumsub{cs: get(), ks: b.ks, cf: readonly}
+	c = PubsubNumsub{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "PUBSUB", "NUMSUB")
 	return c
 }
@@ -120,10 +120,10 @@ func (c PubsubNumsub) Channel(channel ...string) PubsubNumsubChannel {
 
 func (c PubsubNumsub) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubNumsubChannel Completed
+type PubsubNumsubChannel Incomplete
 
 func (c PubsubNumsubChannel) Channel(channel ...string) PubsubNumsubChannel {
 	c.cs.s = append(c.cs.s, channel...)
@@ -132,10 +132,10 @@ func (c PubsubNumsubChannel) Channel(channel ...string) PubsubNumsubChannel {
 
 func (c PubsubNumsubChannel) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubShardchannels Completed
+type PubsubShardchannels Incomplete
 
 func (b Builder) PubsubShardchannels() (c PubsubShardchannels) {
 	c = PubsubShardchannels{cs: get(), ks: b.ks}
@@ -150,17 +150,17 @@ func (c PubsubShardchannels) Pattern(pattern string) PubsubShardchannelsPattern 
 
 func (c PubsubShardchannels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubShardchannelsPattern Completed
+type PubsubShardchannelsPattern Incomplete
 
 func (c PubsubShardchannelsPattern) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubShardnumsub Completed
+type PubsubShardnumsub Incomplete
 
 func (b Builder) PubsubShardnumsub() (c PubsubShardnumsub) {
 	c = PubsubShardnumsub{cs: get(), ks: b.ks}
@@ -175,10 +175,10 @@ func (c PubsubShardnumsub) Channel(channel ...string) PubsubShardnumsubChannel {
 
 func (c PubsubShardnumsub) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PubsubShardnumsubChannel Completed
+type PubsubShardnumsubChannel Incomplete
 
 func (c PubsubShardnumsubChannel) Channel(channel ...string) PubsubShardnumsubChannel {
 	c.cs.s = append(c.cs.s, channel...)
@@ -187,13 +187,13 @@ func (c PubsubShardnumsubChannel) Channel(channel ...string) PubsubShardnumsubCh
 
 func (c PubsubShardnumsubChannel) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Punsubscribe Completed
+type Punsubscribe Incomplete
 
 func (b Builder) Punsubscribe() (c Punsubscribe) {
-	c = Punsubscribe{cs: get(), ks: b.ks, cf: noRetTag}
+	c = Punsubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
 	c.cs.s = append(c.cs.s, "PUNSUBSCRIBE")
 	return c
 }
@@ -205,10 +205,10 @@ func (c Punsubscribe) Pattern(pattern ...string) PunsubscribePattern {
 
 func (c Punsubscribe) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PunsubscribePattern Completed
+type PunsubscribePattern Incomplete
 
 func (c PunsubscribePattern) Pattern(pattern ...string) PunsubscribePattern {
 	c.cs.s = append(c.cs.s, pattern...)
@@ -217,10 +217,10 @@ func (c PunsubscribePattern) Pattern(pattern ...string) PunsubscribePattern {
 
 func (c PunsubscribePattern) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Spublish Completed
+type Spublish Incomplete
 
 func (b Builder) Spublish() (c Spublish) {
 	c = Spublish{cs: get(), ks: b.ks}
@@ -238,24 +238,24 @@ func (c Spublish) Channel(channel string) SpublishChannel {
 	return (SpublishChannel)(c)
 }
 
-type SpublishChannel Completed
+type SpublishChannel Incomplete
 
 func (c SpublishChannel) Message(message string) SpublishMessage {
 	c.cs.s = append(c.cs.s, message)
 	return (SpublishMessage)(c)
 }
 
-type SpublishMessage Completed
+type SpublishMessage Incomplete
 
 func (c SpublishMessage) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Ssubscribe Completed
+type Ssubscribe Incomplete
 
 func (b Builder) Ssubscribe() (c Ssubscribe) {
-	c = Ssubscribe{cs: get(), ks: b.ks, cf: noRetTag}
+	c = Ssubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
 	c.cs.s = append(c.cs.s, "SSUBSCRIBE")
 	return c
 }
@@ -275,7 +275,7 @@ func (c Ssubscribe) Channel(channel ...string) SsubscribeChannel {
 	return (SsubscribeChannel)(c)
 }
 
-type SsubscribeChannel Completed
+type SsubscribeChannel Incomplete
 
 func (c SsubscribeChannel) Channel(channel ...string) SsubscribeChannel {
 	if c.ks&NoSlot == NoSlot {
@@ -294,13 +294,13 @@ func (c SsubscribeChannel) Channel(channel ...string) SsubscribeChannel {
 
 func (c SsubscribeChannel) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Subscribe Completed
+type Subscribe Incomplete
 
 func (b Builder) Subscribe() (c Subscribe) {
-	c = Subscribe{cs: get(), ks: b.ks, cf: noRetTag}
+	c = Subscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
 	c.cs.s = append(c.cs.s, "SUBSCRIBE")
 	return c
 }
@@ -310,7 +310,7 @@ func (c Subscribe) Channel(channel ...string) SubscribeChannel {
 	return (SubscribeChannel)(c)
 }
 
-type SubscribeChannel Completed
+type SubscribeChannel Incomplete
 
 func (c SubscribeChannel) Channel(channel ...string) SubscribeChannel {
 	c.cs.s = append(c.cs.s, channel...)
@@ -319,13 +319,13 @@ func (c SubscribeChannel) Channel(channel ...string) SubscribeChannel {
 
 func (c SubscribeChannel) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sunsubscribe Completed
+type Sunsubscribe Incomplete
 
 func (b Builder) Sunsubscribe() (c Sunsubscribe) {
-	c = Sunsubscribe{cs: get(), ks: b.ks, cf: noRetTag}
+	c = Sunsubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
 	c.cs.s = append(c.cs.s, "SUNSUBSCRIBE")
 	return c
 }
@@ -347,10 +347,10 @@ func (c Sunsubscribe) Channel(channel ...string) SunsubscribeChannel {
 
 func (c Sunsubscribe) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SunsubscribeChannel Completed
+type SunsubscribeChannel Incomplete
 
 func (c SunsubscribeChannel) Channel(channel ...string) SunsubscribeChannel {
 	if c.ks&NoSlot == NoSlot {
@@ -369,13 +369,13 @@ func (c SunsubscribeChannel) Channel(channel ...string) SunsubscribeChannel {
 
 func (c SunsubscribeChannel) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Unsubscribe Completed
+type Unsubscribe Incomplete
 
 func (b Builder) Unsubscribe() (c Unsubscribe) {
-	c = Unsubscribe{cs: get(), ks: b.ks, cf: noRetTag}
+	c = Unsubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
 	c.cs.s = append(c.cs.s, "UNSUBSCRIBE")
 	return c
 }
@@ -387,10 +387,10 @@ func (c Unsubscribe) Channel(channel ...string) UnsubscribeChannel {
 
 func (c Unsubscribe) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type UnsubscribeChannel Completed
+type UnsubscribeChannel Incomplete
 
 func (c UnsubscribeChannel) Channel(channel ...string) UnsubscribeChannel {
 	c.cs.s = append(c.cs.s, channel...)
@@ -399,5 +399,5 @@ func (c UnsubscribeChannel) Channel(channel ...string) UnsubscribeChannel {
 
 func (c UnsubscribeChannel) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_script.go
+++ b/internal/cmds/gen_script.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type AiScriptdel Completed
+type AiScriptdel Incomplete
 
 func (b Builder) AiScriptdel() (c AiScriptdel) {
 	c = AiScriptdel{cs: get(), ks: b.ks}
@@ -22,17 +22,17 @@ func (c AiScriptdel) Key(key string) AiScriptdelKey {
 	return (AiScriptdelKey)(c)
 }
 
-type AiScriptdelKey Completed
+type AiScriptdelKey Incomplete
 
 func (c AiScriptdelKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptget Completed
+type AiScriptget Incomplete
 
 func (b Builder) AiScriptget() (c AiScriptget) {
-	c = AiScriptget{cs: get(), ks: b.ks, cf: readonly}
+	c = AiScriptget{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "AI.SCRIPTGET")
 	return c
 }
@@ -47,7 +47,7 @@ func (c AiScriptget) Key(key string) AiScriptgetKey {
 	return (AiScriptgetKey)(c)
 }
 
-type AiScriptgetKey Completed
+type AiScriptgetKey Incomplete
 
 func (c AiScriptgetKey) Meta() AiScriptgetMeta {
 	c.cs.s = append(c.cs.s, "META")
@@ -61,15 +61,15 @@ func (c AiScriptgetKey) Source() AiScriptgetSource {
 
 func (c AiScriptgetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiScriptgetKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptgetMeta Completed
+type AiScriptgetMeta Incomplete
 
 func (c AiScriptgetMeta) Source() AiScriptgetSource {
 	c.cs.s = append(c.cs.s, "SOURCE")
@@ -78,27 +78,27 @@ func (c AiScriptgetMeta) Source() AiScriptgetSource {
 
 func (c AiScriptgetMeta) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiScriptgetMeta) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptgetSource Completed
+type AiScriptgetSource Incomplete
 
 func (c AiScriptgetSource) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiScriptgetSource) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptstore Completed
+type AiScriptstore Incomplete
 
 func (b Builder) AiScriptstore() (c AiScriptstore) {
 	c = AiScriptstore{cs: get(), ks: b.ks}
@@ -116,7 +116,7 @@ func (c AiScriptstore) Key(key string) AiScriptstoreKey {
 	return (AiScriptstoreKey)(c)
 }
 
-type AiScriptstoreDeviceCpu Completed
+type AiScriptstoreDeviceCpu Incomplete
 
 func (c AiScriptstoreDeviceCpu) Tag(tag string) AiScriptstoreTag {
 	c.cs.s = append(c.cs.s, "TAG", tag)
@@ -128,7 +128,7 @@ func (c AiScriptstoreDeviceCpu) EntryPoints(entryPointCount int64) AiScriptstore
 	return (AiScriptstoreEntryPointsEntryPoints)(c)
 }
 
-type AiScriptstoreDeviceGpu Completed
+type AiScriptstoreDeviceGpu Incomplete
 
 func (c AiScriptstoreDeviceGpu) Tag(tag string) AiScriptstoreTag {
 	c.cs.s = append(c.cs.s, "TAG", tag)
@@ -140,7 +140,7 @@ func (c AiScriptstoreDeviceGpu) EntryPoints(entryPointCount int64) AiScriptstore
 	return (AiScriptstoreEntryPointsEntryPoints)(c)
 }
 
-type AiScriptstoreEntryPointsEntryPoint Completed
+type AiScriptstoreEntryPointsEntryPoint Incomplete
 
 func (c AiScriptstoreEntryPointsEntryPoint) EntryPoint(entryPoint ...string) AiScriptstoreEntryPointsEntryPoint {
 	c.cs.s = append(c.cs.s, entryPoint...)
@@ -149,17 +149,17 @@ func (c AiScriptstoreEntryPointsEntryPoint) EntryPoint(entryPoint ...string) AiS
 
 func (c AiScriptstoreEntryPointsEntryPoint) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiScriptstoreEntryPointsEntryPoints Completed
+type AiScriptstoreEntryPointsEntryPoints Incomplete
 
 func (c AiScriptstoreEntryPointsEntryPoints) EntryPoint(entryPoint ...string) AiScriptstoreEntryPointsEntryPoint {
 	c.cs.s = append(c.cs.s, entryPoint...)
 	return (AiScriptstoreEntryPointsEntryPoint)(c)
 }
 
-type AiScriptstoreKey Completed
+type AiScriptstoreKey Incomplete
 
 func (c AiScriptstoreKey) Cpu() AiScriptstoreDeviceCpu {
 	c.cs.s = append(c.cs.s, "CPU")
@@ -171,7 +171,7 @@ func (c AiScriptstoreKey) Gpu() AiScriptstoreDeviceGpu {
 	return (AiScriptstoreDeviceGpu)(c)
 }
 
-type AiScriptstoreTag Completed
+type AiScriptstoreTag Incomplete
 
 func (c AiScriptstoreTag) EntryPoints(entryPointCount int64) AiScriptstoreEntryPointsEntryPoints {
 	c.cs.s = append(c.cs.s, "ENTRY_POINTS", strconv.FormatInt(entryPointCount, 10))

--- a/internal/cmds/gen_scripting.go
+++ b/internal/cmds/gen_scripting.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Eval Completed
+type Eval Incomplete
 
 func (b Builder) Eval() (c Eval) {
 	c = Eval{cs: get(), ks: b.ks}
@@ -17,7 +17,7 @@ func (c Eval) Script(script string) EvalScript {
 	return (EvalScript)(c)
 }
 
-type EvalArg Completed
+type EvalArg Incomplete
 
 func (c EvalArg) Arg(arg ...string) EvalArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -26,10 +26,10 @@ func (c EvalArg) Arg(arg ...string) EvalArg {
 
 func (c EvalArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalKey Completed
+type EvalKey Incomplete
 
 func (c EvalKey) Key(key ...string) EvalKey {
 	if c.ks&NoSlot == NoSlot {
@@ -53,10 +53,10 @@ func (c EvalKey) Arg(arg ...string) EvalArg {
 
 func (c EvalKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalNumkeys Completed
+type EvalNumkeys Incomplete
 
 func (c EvalNumkeys) Key(key ...string) EvalKey {
 	if c.ks&NoSlot == NoSlot {
@@ -80,13 +80,13 @@ func (c EvalNumkeys) Arg(arg ...string) EvalArg {
 
 func (c EvalNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalRo Completed
+type EvalRo Incomplete
 
 func (b Builder) EvalRo() (c EvalRo) {
-	c = EvalRo{cs: get(), ks: b.ks, cf: scrRoTag}
+	c = EvalRo{cs: get(), ks: b.ks, cf: int16(scrRoTag)}
 	c.cs.s = append(c.cs.s, "EVAL_RO")
 	return c
 }
@@ -96,7 +96,7 @@ func (c EvalRo) Script(script string) EvalRoScript {
 	return (EvalRoScript)(c)
 }
 
-type EvalRoArg Completed
+type EvalRoArg Incomplete
 
 func (c EvalRoArg) Arg(arg ...string) EvalRoArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -105,15 +105,15 @@ func (c EvalRoArg) Arg(arg ...string) EvalRoArg {
 
 func (c EvalRoArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c EvalRoArg) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalRoKey Completed
+type EvalRoKey Incomplete
 
 func (c EvalRoKey) Key(key ...string) EvalRoKey {
 	if c.ks&NoSlot == NoSlot {
@@ -137,15 +137,15 @@ func (c EvalRoKey) Arg(arg ...string) EvalRoArg {
 
 func (c EvalRoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c EvalRoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalRoNumkeys Completed
+type EvalRoNumkeys Incomplete
 
 func (c EvalRoNumkeys) Key(key ...string) EvalRoKey {
 	if c.ks&NoSlot == NoSlot {
@@ -169,29 +169,29 @@ func (c EvalRoNumkeys) Arg(arg ...string) EvalRoArg {
 
 func (c EvalRoNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c EvalRoNumkeys) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalRoScript Completed
+type EvalRoScript Incomplete
 
 func (c EvalRoScript) Numkeys(numkeys int64) EvalRoNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (EvalRoNumkeys)(c)
 }
 
-type EvalScript Completed
+type EvalScript Incomplete
 
 func (c EvalScript) Numkeys(numkeys int64) EvalNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (EvalNumkeys)(c)
 }
 
-type Evalsha Completed
+type Evalsha Incomplete
 
 func (b Builder) Evalsha() (c Evalsha) {
 	c = Evalsha{cs: get(), ks: b.ks}
@@ -204,7 +204,7 @@ func (c Evalsha) Sha1(sha1 string) EvalshaSha1 {
 	return (EvalshaSha1)(c)
 }
 
-type EvalshaArg Completed
+type EvalshaArg Incomplete
 
 func (c EvalshaArg) Arg(arg ...string) EvalshaArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -213,10 +213,10 @@ func (c EvalshaArg) Arg(arg ...string) EvalshaArg {
 
 func (c EvalshaArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalshaKey Completed
+type EvalshaKey Incomplete
 
 func (c EvalshaKey) Key(key ...string) EvalshaKey {
 	if c.ks&NoSlot == NoSlot {
@@ -240,10 +240,10 @@ func (c EvalshaKey) Arg(arg ...string) EvalshaArg {
 
 func (c EvalshaKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalshaNumkeys Completed
+type EvalshaNumkeys Incomplete
 
 func (c EvalshaNumkeys) Key(key ...string) EvalshaKey {
 	if c.ks&NoSlot == NoSlot {
@@ -267,13 +267,13 @@ func (c EvalshaNumkeys) Arg(arg ...string) EvalshaArg {
 
 func (c EvalshaNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalshaRo Completed
+type EvalshaRo Incomplete
 
 func (b Builder) EvalshaRo() (c EvalshaRo) {
-	c = EvalshaRo{cs: get(), ks: b.ks, cf: scrRoTag}
+	c = EvalshaRo{cs: get(), ks: b.ks, cf: int16(scrRoTag)}
 	c.cs.s = append(c.cs.s, "EVALSHA_RO")
 	return c
 }
@@ -283,7 +283,7 @@ func (c EvalshaRo) Sha1(sha1 string) EvalshaRoSha1 {
 	return (EvalshaRoSha1)(c)
 }
 
-type EvalshaRoArg Completed
+type EvalshaRoArg Incomplete
 
 func (c EvalshaRoArg) Arg(arg ...string) EvalshaRoArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -292,15 +292,15 @@ func (c EvalshaRoArg) Arg(arg ...string) EvalshaRoArg {
 
 func (c EvalshaRoArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c EvalshaRoArg) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalshaRoKey Completed
+type EvalshaRoKey Incomplete
 
 func (c EvalshaRoKey) Key(key ...string) EvalshaRoKey {
 	if c.ks&NoSlot == NoSlot {
@@ -324,15 +324,15 @@ func (c EvalshaRoKey) Arg(arg ...string) EvalshaRoArg {
 
 func (c EvalshaRoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c EvalshaRoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalshaRoNumkeys Completed
+type EvalshaRoNumkeys Incomplete
 
 func (c EvalshaRoNumkeys) Key(key ...string) EvalshaRoKey {
 	if c.ks&NoSlot == NoSlot {
@@ -356,29 +356,29 @@ func (c EvalshaRoNumkeys) Arg(arg ...string) EvalshaRoArg {
 
 func (c EvalshaRoNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c EvalshaRoNumkeys) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type EvalshaRoSha1 Completed
+type EvalshaRoSha1 Incomplete
 
 func (c EvalshaRoSha1) Numkeys(numkeys int64) EvalshaRoNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (EvalshaRoNumkeys)(c)
 }
 
-type EvalshaSha1 Completed
+type EvalshaSha1 Incomplete
 
 func (c EvalshaSha1) Numkeys(numkeys int64) EvalshaNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (EvalshaNumkeys)(c)
 }
 
-type Fcall Completed
+type Fcall Incomplete
 
 func (b Builder) Fcall() (c Fcall) {
 	c = Fcall{cs: get(), ks: b.ks}
@@ -391,7 +391,7 @@ func (c Fcall) Function(function string) FcallFunction {
 	return (FcallFunction)(c)
 }
 
-type FcallArg Completed
+type FcallArg Incomplete
 
 func (c FcallArg) Arg(arg ...string) FcallArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -400,17 +400,17 @@ func (c FcallArg) Arg(arg ...string) FcallArg {
 
 func (c FcallArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FcallFunction Completed
+type FcallFunction Incomplete
 
 func (c FcallFunction) Numkeys(numkeys int64) FcallNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (FcallNumkeys)(c)
 }
 
-type FcallKey Completed
+type FcallKey Incomplete
 
 func (c FcallKey) Key(key ...string) FcallKey {
 	if c.ks&NoSlot == NoSlot {
@@ -434,10 +434,10 @@ func (c FcallKey) Arg(arg ...string) FcallArg {
 
 func (c FcallKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FcallNumkeys Completed
+type FcallNumkeys Incomplete
 
 func (c FcallNumkeys) Key(key ...string) FcallKey {
 	if c.ks&NoSlot == NoSlot {
@@ -461,13 +461,13 @@ func (c FcallNumkeys) Arg(arg ...string) FcallArg {
 
 func (c FcallNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FcallRo Completed
+type FcallRo Incomplete
 
 func (b Builder) FcallRo() (c FcallRo) {
-	c = FcallRo{cs: get(), ks: b.ks, cf: scrRoTag}
+	c = FcallRo{cs: get(), ks: b.ks, cf: int16(scrRoTag)}
 	c.cs.s = append(c.cs.s, "FCALL_RO")
 	return c
 }
@@ -477,7 +477,7 @@ func (c FcallRo) Function(function string) FcallRoFunction {
 	return (FcallRoFunction)(c)
 }
 
-type FcallRoArg Completed
+type FcallRoArg Incomplete
 
 func (c FcallRoArg) Arg(arg ...string) FcallRoArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -486,22 +486,22 @@ func (c FcallRoArg) Arg(arg ...string) FcallRoArg {
 
 func (c FcallRoArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c FcallRoArg) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FcallRoFunction Completed
+type FcallRoFunction Incomplete
 
 func (c FcallRoFunction) Numkeys(numkeys int64) FcallRoNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (FcallRoNumkeys)(c)
 }
 
-type FcallRoKey Completed
+type FcallRoKey Incomplete
 
 func (c FcallRoKey) Key(key ...string) FcallRoKey {
 	if c.ks&NoSlot == NoSlot {
@@ -525,15 +525,15 @@ func (c FcallRoKey) Arg(arg ...string) FcallRoArg {
 
 func (c FcallRoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c FcallRoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FcallRoNumkeys Completed
+type FcallRoNumkeys Incomplete
 
 func (c FcallRoNumkeys) Key(key ...string) FcallRoKey {
 	if c.ks&NoSlot == NoSlot {
@@ -557,15 +557,15 @@ func (c FcallRoNumkeys) Arg(arg ...string) FcallRoArg {
 
 func (c FcallRoNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c FcallRoNumkeys) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionDelete Completed
+type FunctionDelete Incomplete
 
 func (b Builder) FunctionDelete() (c FunctionDelete) {
 	c = FunctionDelete{cs: get(), ks: b.ks}
@@ -578,14 +578,14 @@ func (c FunctionDelete) LibraryName(libraryName string) FunctionDeleteLibraryNam
 	return (FunctionDeleteLibraryName)(c)
 }
 
-type FunctionDeleteLibraryName Completed
+type FunctionDeleteLibraryName Incomplete
 
 func (c FunctionDeleteLibraryName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionDump Completed
+type FunctionDump Incomplete
 
 func (b Builder) FunctionDump() (c FunctionDump) {
 	c = FunctionDump{cs: get(), ks: b.ks}
@@ -595,10 +595,10 @@ func (b Builder) FunctionDump() (c FunctionDump) {
 
 func (c FunctionDump) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionFlush Completed
+type FunctionFlush Incomplete
 
 func (b Builder) FunctionFlush() (c FunctionFlush) {
 	c = FunctionFlush{cs: get(), ks: b.ks}
@@ -618,24 +618,24 @@ func (c FunctionFlush) Sync() FunctionFlushAsyncSync {
 
 func (c FunctionFlush) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionFlushAsync Completed
+type FunctionFlushAsync Incomplete
 
 func (c FunctionFlushAsync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionFlushAsyncSync Completed
+type FunctionFlushAsyncSync Incomplete
 
 func (c FunctionFlushAsyncSync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionHelp Completed
+type FunctionHelp Incomplete
 
 func (b Builder) FunctionHelp() (c FunctionHelp) {
 	c = FunctionHelp{cs: get(), ks: b.ks}
@@ -645,10 +645,10 @@ func (b Builder) FunctionHelp() (c FunctionHelp) {
 
 func (c FunctionHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionKill Completed
+type FunctionKill Incomplete
 
 func (b Builder) FunctionKill() (c FunctionKill) {
 	c = FunctionKill{cs: get(), ks: b.ks}
@@ -658,10 +658,10 @@ func (b Builder) FunctionKill() (c FunctionKill) {
 
 func (c FunctionKill) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionList Completed
+type FunctionList Incomplete
 
 func (b Builder) FunctionList() (c FunctionList) {
 	c = FunctionList{cs: get(), ks: b.ks}
@@ -681,10 +681,10 @@ func (c FunctionList) Withcode() FunctionListWithcode {
 
 func (c FunctionList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionListLibraryname Completed
+type FunctionListLibraryname Incomplete
 
 func (c FunctionListLibraryname) Withcode() FunctionListWithcode {
 	c.cs.s = append(c.cs.s, "WITHCODE")
@@ -693,17 +693,17 @@ func (c FunctionListLibraryname) Withcode() FunctionListWithcode {
 
 func (c FunctionListLibraryname) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionListWithcode Completed
+type FunctionListWithcode Incomplete
 
 func (c FunctionListWithcode) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionLoad Completed
+type FunctionLoad Incomplete
 
 func (b Builder) FunctionLoad() (c FunctionLoad) {
 	c = FunctionLoad{cs: get(), ks: b.ks}
@@ -721,21 +721,21 @@ func (c FunctionLoad) FunctionCode(functionCode string) FunctionLoadFunctionCode
 	return (FunctionLoadFunctionCode)(c)
 }
 
-type FunctionLoadFunctionCode Completed
+type FunctionLoadFunctionCode Incomplete
 
 func (c FunctionLoadFunctionCode) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionLoadReplace Completed
+type FunctionLoadReplace Incomplete
 
 func (c FunctionLoadReplace) FunctionCode(functionCode string) FunctionLoadFunctionCode {
 	c.cs.s = append(c.cs.s, functionCode)
 	return (FunctionLoadFunctionCode)(c)
 }
 
-type FunctionRestore Completed
+type FunctionRestore Incomplete
 
 func (b Builder) FunctionRestore() (c FunctionRestore) {
 	c = FunctionRestore{cs: get(), ks: b.ks}
@@ -748,28 +748,28 @@ func (c FunctionRestore) SerializedValue(serializedValue string) FunctionRestore
 	return (FunctionRestoreSerializedValue)(c)
 }
 
-type FunctionRestorePolicyAppend Completed
+type FunctionRestorePolicyAppend Incomplete
 
 func (c FunctionRestorePolicyAppend) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionRestorePolicyFlush Completed
+type FunctionRestorePolicyFlush Incomplete
 
 func (c FunctionRestorePolicyFlush) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionRestorePolicyReplace Completed
+type FunctionRestorePolicyReplace Incomplete
 
 func (c FunctionRestorePolicyReplace) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionRestoreSerializedValue Completed
+type FunctionRestoreSerializedValue Incomplete
 
 func (c FunctionRestoreSerializedValue) Flush() FunctionRestorePolicyFlush {
 	c.cs.s = append(c.cs.s, "FLUSH")
@@ -788,10 +788,10 @@ func (c FunctionRestoreSerializedValue) Replace() FunctionRestorePolicyReplace {
 
 func (c FunctionRestoreSerializedValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FunctionStats Completed
+type FunctionStats Incomplete
 
 func (b Builder) FunctionStats() (c FunctionStats) {
 	c = FunctionStats{cs: get(), ks: b.ks}
@@ -801,10 +801,10 @@ func (b Builder) FunctionStats() (c FunctionStats) {
 
 func (c FunctionStats) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptDebug Completed
+type ScriptDebug Incomplete
 
 func (b Builder) ScriptDebug() (c ScriptDebug) {
 	c = ScriptDebug{cs: get(), ks: b.ks}
@@ -827,28 +827,28 @@ func (c ScriptDebug) No() ScriptDebugModeNo {
 	return (ScriptDebugModeNo)(c)
 }
 
-type ScriptDebugModeNo Completed
+type ScriptDebugModeNo Incomplete
 
 func (c ScriptDebugModeNo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptDebugModeSync Completed
+type ScriptDebugModeSync Incomplete
 
 func (c ScriptDebugModeSync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptDebugModeYes Completed
+type ScriptDebugModeYes Incomplete
 
 func (c ScriptDebugModeYes) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptExists Completed
+type ScriptExists Incomplete
 
 func (b Builder) ScriptExists() (c ScriptExists) {
 	c = ScriptExists{cs: get(), ks: b.ks}
@@ -861,7 +861,7 @@ func (c ScriptExists) Sha1(sha1 ...string) ScriptExistsSha1 {
 	return (ScriptExistsSha1)(c)
 }
 
-type ScriptExistsSha1 Completed
+type ScriptExistsSha1 Incomplete
 
 func (c ScriptExistsSha1) Sha1(sha1 ...string) ScriptExistsSha1 {
 	c.cs.s = append(c.cs.s, sha1...)
@@ -870,10 +870,10 @@ func (c ScriptExistsSha1) Sha1(sha1 ...string) ScriptExistsSha1 {
 
 func (c ScriptExistsSha1) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptFlush Completed
+type ScriptFlush Incomplete
 
 func (b Builder) ScriptFlush() (c ScriptFlush) {
 	c = ScriptFlush{cs: get(), ks: b.ks}
@@ -893,24 +893,24 @@ func (c ScriptFlush) Sync() ScriptFlushAsyncSync {
 
 func (c ScriptFlush) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptFlushAsync Completed
+type ScriptFlushAsync Incomplete
 
 func (c ScriptFlushAsync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptFlushAsyncSync Completed
+type ScriptFlushAsyncSync Incomplete
 
 func (c ScriptFlushAsyncSync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptKill Completed
+type ScriptKill Incomplete
 
 func (b Builder) ScriptKill() (c ScriptKill) {
 	c = ScriptKill{cs: get(), ks: b.ks}
@@ -920,10 +920,10 @@ func (b Builder) ScriptKill() (c ScriptKill) {
 
 func (c ScriptKill) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ScriptLoad Completed
+type ScriptLoad Incomplete
 
 func (b Builder) ScriptLoad() (c ScriptLoad) {
 	c = ScriptLoad{cs: get(), ks: b.ks}
@@ -936,9 +936,9 @@ func (c ScriptLoad) Script(script string) ScriptLoadScript {
 	return (ScriptLoadScript)(c)
 }
 
-type ScriptLoadScript Completed
+type ScriptLoadScript Incomplete
 
 func (c ScriptLoadScript) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_search.go
+++ b/internal/cmds/gen_search.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type FtAggregate Completed
+type FtAggregate Incomplete
 
 func (b Builder) FtAggregate() (c FtAggregate) {
-	c = FtAggregate{cs: get(), ks: b.ks, cf: readonly}
+	c = FtAggregate{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "FT.AGGREGATE")
 	return c
 }
@@ -17,7 +17,7 @@ func (c FtAggregate) Index(index string) FtAggregateIndex {
 	return (FtAggregateIndex)(c)
 }
 
-type FtAggregateCursorCount Completed
+type FtAggregateCursorCount Incomplete
 
 func (c FtAggregateCursorCount) Maxidle(idleTime int64) FtAggregateCursorMaxidle {
 	c.cs.s = append(c.cs.s, "MAXIDLE", strconv.FormatInt(idleTime, 10))
@@ -36,10 +36,10 @@ func (c FtAggregateCursorCount) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateCursorCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateCursorMaxidle Completed
+type FtAggregateCursorMaxidle Incomplete
 
 func (c FtAggregateCursorMaxidle) Params() FtAggregateParamsParams {
 	c.cs.s = append(c.cs.s, "PARAMS")
@@ -53,10 +53,10 @@ func (c FtAggregateCursorMaxidle) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateCursorMaxidle) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateCursorWithcursor Completed
+type FtAggregateCursorWithcursor Incomplete
 
 func (c FtAggregateCursorWithcursor) Count(readSize int64) FtAggregateCursorCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(readSize, 10))
@@ -80,31 +80,31 @@ func (c FtAggregateCursorWithcursor) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateCursorWithcursor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateDialect Completed
+type FtAggregateDialect Incomplete
 
 func (c FtAggregateDialect) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateIndex Completed
+type FtAggregateIndex Incomplete
 
 func (c FtAggregateIndex) Query(query string) FtAggregateQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (FtAggregateQuery)(c)
 }
 
-type FtAggregateOpApplyApply Completed
+type FtAggregateOpApplyApply Incomplete
 
 func (c FtAggregateOpApplyApply) As(name string) FtAggregateOpApplyAs {
 	c.cs.s = append(c.cs.s, "AS", name)
 	return (FtAggregateOpApplyAs)(c)
 }
 
-type FtAggregateOpApplyAs Completed
+type FtAggregateOpApplyAs Incomplete
 
 func (c FtAggregateOpApplyAs) Apply(expression string) FtAggregateOpApplyApply {
 	c.cs.s = append(c.cs.s, "APPLY", expression)
@@ -158,10 +158,10 @@ func (c FtAggregateOpApplyAs) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpApplyAs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpFilter Completed
+type FtAggregateOpFilter Incomplete
 
 func (c FtAggregateOpFilter) LoadAll() FtAggregateOpLoadallLoadAll {
 	c.cs.s = append(c.cs.s, "LOAD", "*")
@@ -215,10 +215,10 @@ func (c FtAggregateOpFilter) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpFilter) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyGroupby Completed
+type FtAggregateOpGroupbyGroupby Incomplete
 
 func (c FtAggregateOpGroupbyGroupby) Property(property ...string) FtAggregateOpGroupbyProperty {
 	c.cs.s = append(c.cs.s, property...)
@@ -282,10 +282,10 @@ func (c FtAggregateOpGroupbyGroupby) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpGroupbyGroupby) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyProperty Completed
+type FtAggregateOpGroupbyProperty Incomplete
 
 func (c FtAggregateOpGroupbyProperty) Property(property ...string) FtAggregateOpGroupbyProperty {
 	c.cs.s = append(c.cs.s, property...)
@@ -349,10 +349,10 @@ func (c FtAggregateOpGroupbyProperty) Dialect(dialect int64) FtAggregateDialect 
 
 func (c FtAggregateOpGroupbyProperty) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceArg Completed
+type FtAggregateOpGroupbyReduceArg Incomplete
 
 func (c FtAggregateOpGroupbyReduceArg) Arg(arg ...string) FtAggregateOpGroupbyReduceArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -436,10 +436,10 @@ func (c FtAggregateOpGroupbyReduceArg) Dialect(dialect int64) FtAggregateDialect
 
 func (c FtAggregateOpGroupbyReduceArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceAs Completed
+type FtAggregateOpGroupbyReduceAs Incomplete
 
 func (c FtAggregateOpGroupbyReduceAs) By(by string) FtAggregateOpGroupbyReduceBy {
 	c.cs.s = append(c.cs.s, "BY", by)
@@ -513,10 +513,10 @@ func (c FtAggregateOpGroupbyReduceAs) Dialect(dialect int64) FtAggregateDialect 
 
 func (c FtAggregateOpGroupbyReduceAs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceBy Completed
+type FtAggregateOpGroupbyReduceBy Incomplete
 
 func (c FtAggregateOpGroupbyReduceBy) Asc() FtAggregateOpGroupbyReduceOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -585,10 +585,10 @@ func (c FtAggregateOpGroupbyReduceBy) Dialect(dialect int64) FtAggregateDialect 
 
 func (c FtAggregateOpGroupbyReduceBy) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceNargs Completed
+type FtAggregateOpGroupbyReduceNargs Incomplete
 
 func (c FtAggregateOpGroupbyReduceNargs) Arg(arg ...string) FtAggregateOpGroupbyReduceArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -672,10 +672,10 @@ func (c FtAggregateOpGroupbyReduceNargs) Dialect(dialect int64) FtAggregateDiale
 
 func (c FtAggregateOpGroupbyReduceNargs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceOrderAsc Completed
+type FtAggregateOpGroupbyReduceOrderAsc Incomplete
 
 func (c FtAggregateOpGroupbyReduceOrderAsc) Reduce(function string) FtAggregateOpGroupbyReduceReduce {
 	c.cs.s = append(c.cs.s, "REDUCE", function)
@@ -734,10 +734,10 @@ func (c FtAggregateOpGroupbyReduceOrderAsc) Dialect(dialect int64) FtAggregateDi
 
 func (c FtAggregateOpGroupbyReduceOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceOrderDesc Completed
+type FtAggregateOpGroupbyReduceOrderDesc Incomplete
 
 func (c FtAggregateOpGroupbyReduceOrderDesc) Reduce(function string) FtAggregateOpGroupbyReduceReduce {
 	c.cs.s = append(c.cs.s, "REDUCE", function)
@@ -796,24 +796,24 @@ func (c FtAggregateOpGroupbyReduceOrderDesc) Dialect(dialect int64) FtAggregateD
 
 func (c FtAggregateOpGroupbyReduceOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpGroupbyReduceReduce Completed
+type FtAggregateOpGroupbyReduceReduce Incomplete
 
 func (c FtAggregateOpGroupbyReduceReduce) Nargs(nargs int64) FtAggregateOpGroupbyReduceNargs {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(nargs, 10))
 	return (FtAggregateOpGroupbyReduceNargs)(c)
 }
 
-type FtAggregateOpLimitLimit Completed
+type FtAggregateOpLimitLimit Incomplete
 
 func (c FtAggregateOpLimitLimit) OffsetNum(offset int64, num int64) FtAggregateOpLimitOffsetNum {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(offset, 10), strconv.FormatInt(num, 10))
 	return (FtAggregateOpLimitOffsetNum)(c)
 }
 
-type FtAggregateOpLimitOffsetNum Completed
+type FtAggregateOpLimitOffsetNum Incomplete
 
 func (c FtAggregateOpLimitOffsetNum) Filter(filter string) FtAggregateOpFilter {
 	c.cs.s = append(c.cs.s, "FILTER", filter)
@@ -867,10 +867,10 @@ func (c FtAggregateOpLimitOffsetNum) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpLimitOffsetNum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpLoadField Completed
+type FtAggregateOpLoadField Incomplete
 
 func (c FtAggregateOpLoadField) Field(field ...string) FtAggregateOpLoadField {
 	c.cs.s = append(c.cs.s, field...)
@@ -929,17 +929,17 @@ func (c FtAggregateOpLoadField) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpLoadField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpLoadLoad Completed
+type FtAggregateOpLoadLoad Incomplete
 
 func (c FtAggregateOpLoadLoad) Field(field ...string) FtAggregateOpLoadField {
 	c.cs.s = append(c.cs.s, field...)
 	return (FtAggregateOpLoadField)(c)
 }
 
-type FtAggregateOpLoadallLoadAll Completed
+type FtAggregateOpLoadallLoadAll Incomplete
 
 func (c FtAggregateOpLoadallLoadAll) Load(count int64) FtAggregateOpLoadLoad {
 	c.cs.s = append(c.cs.s, "LOAD", strconv.FormatInt(count, 10))
@@ -993,10 +993,10 @@ func (c FtAggregateOpLoadallLoadAll) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpLoadallLoadAll) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpSortbyFieldsOrderAsc Completed
+type FtAggregateOpSortbyFieldsOrderAsc Incomplete
 
 func (c FtAggregateOpSortbyFieldsOrderAsc) Property(property string) FtAggregateOpSortbyFieldsProperty {
 	c.cs.s = append(c.cs.s, property)
@@ -1060,10 +1060,10 @@ func (c FtAggregateOpSortbyFieldsOrderAsc) Dialect(dialect int64) FtAggregateDia
 
 func (c FtAggregateOpSortbyFieldsOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpSortbyFieldsOrderDesc Completed
+type FtAggregateOpSortbyFieldsOrderDesc Incomplete
 
 func (c FtAggregateOpSortbyFieldsOrderDesc) Property(property string) FtAggregateOpSortbyFieldsProperty {
 	c.cs.s = append(c.cs.s, property)
@@ -1127,10 +1127,10 @@ func (c FtAggregateOpSortbyFieldsOrderDesc) Dialect(dialect int64) FtAggregateDi
 
 func (c FtAggregateOpSortbyFieldsOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpSortbyFieldsProperty Completed
+type FtAggregateOpSortbyFieldsProperty Incomplete
 
 func (c FtAggregateOpSortbyFieldsProperty) Asc() FtAggregateOpSortbyFieldsOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -1204,10 +1204,10 @@ func (c FtAggregateOpSortbyFieldsProperty) Dialect(dialect int64) FtAggregateDia
 
 func (c FtAggregateOpSortbyFieldsProperty) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpSortbyMax Completed
+type FtAggregateOpSortbyMax Incomplete
 
 func (c FtAggregateOpSortbyMax) Apply(expression string) FtAggregateOpApplyApply {
 	c.cs.s = append(c.cs.s, "APPLY", expression)
@@ -1261,10 +1261,10 @@ func (c FtAggregateOpSortbyMax) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpSortbyMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateOpSortbySortby Completed
+type FtAggregateOpSortbySortby Incomplete
 
 func (c FtAggregateOpSortbySortby) Property(property string) FtAggregateOpSortbyFieldsProperty {
 	c.cs.s = append(c.cs.s, property)
@@ -1328,10 +1328,10 @@ func (c FtAggregateOpSortbySortby) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateOpSortbySortby) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateParamsNameValue Completed
+type FtAggregateParamsNameValue Incomplete
 
 func (c FtAggregateParamsNameValue) NameValue(name string, value string) FtAggregateParamsNameValue {
 	c.cs.s = append(c.cs.s, name, value)
@@ -1345,23 +1345,23 @@ func (c FtAggregateParamsNameValue) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateParamsNameValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateParamsNargs Completed
+type FtAggregateParamsNargs Incomplete
 
 func (c FtAggregateParamsNargs) NameValue() FtAggregateParamsNameValue {
 	return (FtAggregateParamsNameValue)(c)
 }
 
-type FtAggregateParamsParams Completed
+type FtAggregateParamsParams Incomplete
 
 func (c FtAggregateParamsParams) Nargs(nargs int64) FtAggregateParamsNargs {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(nargs, 10))
 	return (FtAggregateParamsNargs)(c)
 }
 
-type FtAggregateQuery Completed
+type FtAggregateQuery Incomplete
 
 func (c FtAggregateQuery) Verbatim() FtAggregateVerbatim {
 	c.cs.s = append(c.cs.s, "VERBATIM")
@@ -1425,10 +1425,10 @@ func (c FtAggregateQuery) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateTimeout Completed
+type FtAggregateTimeout Incomplete
 
 func (c FtAggregateTimeout) LoadAll() FtAggregateOpLoadallLoadAll {
 	c.cs.s = append(c.cs.s, "LOAD", "*")
@@ -1482,10 +1482,10 @@ func (c FtAggregateTimeout) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAggregateVerbatim Completed
+type FtAggregateVerbatim Incomplete
 
 func (c FtAggregateVerbatim) Timeout(timeout int64) FtAggregateTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT", strconv.FormatInt(timeout, 10))
@@ -1544,10 +1544,10 @@ func (c FtAggregateVerbatim) Dialect(dialect int64) FtAggregateDialect {
 
 func (c FtAggregateVerbatim) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAliasadd Completed
+type FtAliasadd Incomplete
 
 func (b Builder) FtAliasadd() (c FtAliasadd) {
 	c = FtAliasadd{cs: get(), ks: b.ks}
@@ -1560,21 +1560,21 @@ func (c FtAliasadd) Alias(alias string) FtAliasaddAlias {
 	return (FtAliasaddAlias)(c)
 }
 
-type FtAliasaddAlias Completed
+type FtAliasaddAlias Incomplete
 
 func (c FtAliasaddAlias) Index(index string) FtAliasaddIndex {
 	c.cs.s = append(c.cs.s, index)
 	return (FtAliasaddIndex)(c)
 }
 
-type FtAliasaddIndex Completed
+type FtAliasaddIndex Incomplete
 
 func (c FtAliasaddIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAliasdel Completed
+type FtAliasdel Incomplete
 
 func (b Builder) FtAliasdel() (c FtAliasdel) {
 	c = FtAliasdel{cs: get(), ks: b.ks}
@@ -1587,14 +1587,14 @@ func (c FtAliasdel) Alias(alias string) FtAliasdelAlias {
 	return (FtAliasdelAlias)(c)
 }
 
-type FtAliasdelAlias Completed
+type FtAliasdelAlias Incomplete
 
 func (c FtAliasdelAlias) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAliasupdate Completed
+type FtAliasupdate Incomplete
 
 func (b Builder) FtAliasupdate() (c FtAliasupdate) {
 	c = FtAliasupdate{cs: get(), ks: b.ks}
@@ -1607,21 +1607,21 @@ func (c FtAliasupdate) Alias(alias string) FtAliasupdateAlias {
 	return (FtAliasupdateAlias)(c)
 }
 
-type FtAliasupdateAlias Completed
+type FtAliasupdateAlias Incomplete
 
 func (c FtAliasupdateAlias) Index(index string) FtAliasupdateIndex {
 	c.cs.s = append(c.cs.s, index)
 	return (FtAliasupdateIndex)(c)
 }
 
-type FtAliasupdateIndex Completed
+type FtAliasupdateIndex Incomplete
 
 func (c FtAliasupdateIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAlter Completed
+type FtAlter Incomplete
 
 func (b Builder) FtAlter() (c FtAlter) {
 	c = FtAlter{cs: get(), ks: b.ks}
@@ -1634,21 +1634,21 @@ func (c FtAlter) Index(index string) FtAlterIndex {
 	return (FtAlterIndex)(c)
 }
 
-type FtAlterAdd Completed
+type FtAlterAdd Incomplete
 
 func (c FtAlterAdd) Field(field string) FtAlterField {
 	c.cs.s = append(c.cs.s, field)
 	return (FtAlterField)(c)
 }
 
-type FtAlterField Completed
+type FtAlterField Incomplete
 
 func (c FtAlterField) Options(options string) FtAlterOptions {
 	c.cs.s = append(c.cs.s, options)
 	return (FtAlterOptions)(c)
 }
 
-type FtAlterIndex Completed
+type FtAlterIndex Incomplete
 
 func (c FtAlterIndex) Skipinitialscan() FtAlterSkipinitialscan {
 	c.cs.s = append(c.cs.s, "SKIPINITIALSCAN")
@@ -1660,28 +1660,28 @@ func (c FtAlterIndex) Schema() FtAlterSchema {
 	return (FtAlterSchema)(c)
 }
 
-type FtAlterOptions Completed
+type FtAlterOptions Incomplete
 
 func (c FtAlterOptions) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtAlterSchema Completed
+type FtAlterSchema Incomplete
 
 func (c FtAlterSchema) Add() FtAlterAdd {
 	c.cs.s = append(c.cs.s, "ADD")
 	return (FtAlterAdd)(c)
 }
 
-type FtAlterSkipinitialscan Completed
+type FtAlterSkipinitialscan Incomplete
 
 func (c FtAlterSkipinitialscan) Schema() FtAlterSchema {
 	c.cs.s = append(c.cs.s, "SCHEMA")
 	return (FtAlterSchema)(c)
 }
 
-type FtConfigGet Completed
+type FtConfigGet Incomplete
 
 func (b Builder) FtConfigGet() (c FtConfigGet) {
 	c = FtConfigGet{cs: get(), ks: b.ks}
@@ -1694,14 +1694,14 @@ func (c FtConfigGet) Option(option string) FtConfigGetOption {
 	return (FtConfigGetOption)(c)
 }
 
-type FtConfigGetOption Completed
+type FtConfigGetOption Incomplete
 
 func (c FtConfigGetOption) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtConfigHelp Completed
+type FtConfigHelp Incomplete
 
 func (b Builder) FtConfigHelp() (c FtConfigHelp) {
 	c = FtConfigHelp{cs: get(), ks: b.ks}
@@ -1714,14 +1714,14 @@ func (c FtConfigHelp) Option(option string) FtConfigHelpOption {
 	return (FtConfigHelpOption)(c)
 }
 
-type FtConfigHelpOption Completed
+type FtConfigHelpOption Incomplete
 
 func (c FtConfigHelpOption) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtConfigSet Completed
+type FtConfigSet Incomplete
 
 func (b Builder) FtConfigSet() (c FtConfigSet) {
 	c = FtConfigSet{cs: get(), ks: b.ks}
@@ -1734,21 +1734,21 @@ func (c FtConfigSet) Option(option string) FtConfigSetOption {
 	return (FtConfigSetOption)(c)
 }
 
-type FtConfigSetOption Completed
+type FtConfigSetOption Incomplete
 
 func (c FtConfigSetOption) Value(value string) FtConfigSetValue {
 	c.cs.s = append(c.cs.s, value)
 	return (FtConfigSetValue)(c)
 }
 
-type FtConfigSetValue Completed
+type FtConfigSetValue Incomplete
 
 func (c FtConfigSetValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreate Completed
+type FtCreate Incomplete
 
 func (b Builder) FtCreate() (c FtCreate) {
 	c = FtCreate{cs: get(), ks: b.ks}
@@ -1761,7 +1761,7 @@ func (c FtCreate) Index(index string) FtCreateIndex {
 	return (FtCreateIndex)(c)
 }
 
-type FtCreateFieldAs Completed
+type FtCreateFieldAs Incomplete
 
 func (c FtCreateFieldAs) Text() FtCreateFieldFieldTypeText {
 	c.cs.s = append(c.cs.s, "TEXT")
@@ -1789,7 +1789,7 @@ func (c FtCreateFieldAs) Vector(algo string, nargs int64, args ...string) FtCrea
 	return (FtCreateFieldFieldTypeVector)(c)
 }
 
-type FtCreateFieldFieldName Completed
+type FtCreateFieldFieldName Incomplete
 
 func (c FtCreateFieldFieldName) As(alias string) FtCreateFieldAs {
 	c.cs.s = append(c.cs.s, "AS", alias)
@@ -1822,7 +1822,7 @@ func (c FtCreateFieldFieldName) Vector(algo string, nargs int64, args ...string)
 	return (FtCreateFieldFieldTypeVector)(c)
 }
 
-type FtCreateFieldFieldTypeGeo Completed
+type FtCreateFieldFieldTypeGeo Incomplete
 
 func (c FtCreateFieldFieldTypeGeo) Withsuffixtrie() FtCreateFieldOptionWithsuffixtrie {
 	c.cs.s = append(c.cs.s, "WITHSUFFIXTRIE")
@@ -1871,10 +1871,10 @@ func (c FtCreateFieldFieldTypeGeo) FieldName(fieldName string) FtCreateFieldFiel
 
 func (c FtCreateFieldFieldTypeGeo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldFieldTypeNumeric Completed
+type FtCreateFieldFieldTypeNumeric Incomplete
 
 func (c FtCreateFieldFieldTypeNumeric) Withsuffixtrie() FtCreateFieldOptionWithsuffixtrie {
 	c.cs.s = append(c.cs.s, "WITHSUFFIXTRIE")
@@ -1923,10 +1923,10 @@ func (c FtCreateFieldFieldTypeNumeric) FieldName(fieldName string) FtCreateField
 
 func (c FtCreateFieldFieldTypeNumeric) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldFieldTypeTag Completed
+type FtCreateFieldFieldTypeTag Incomplete
 
 func (c FtCreateFieldFieldTypeTag) Withsuffixtrie() FtCreateFieldOptionWithsuffixtrie {
 	c.cs.s = append(c.cs.s, "WITHSUFFIXTRIE")
@@ -1975,10 +1975,10 @@ func (c FtCreateFieldFieldTypeTag) FieldName(fieldName string) FtCreateFieldFiel
 
 func (c FtCreateFieldFieldTypeTag) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldFieldTypeText Completed
+type FtCreateFieldFieldTypeText Incomplete
 
 func (c FtCreateFieldFieldTypeText) Withsuffixtrie() FtCreateFieldOptionWithsuffixtrie {
 	c.cs.s = append(c.cs.s, "WITHSUFFIXTRIE")
@@ -2027,10 +2027,10 @@ func (c FtCreateFieldFieldTypeText) FieldName(fieldName string) FtCreateFieldFie
 
 func (c FtCreateFieldFieldTypeText) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldFieldTypeVector Completed
+type FtCreateFieldFieldTypeVector Incomplete
 
 func (c FtCreateFieldFieldTypeVector) Withsuffixtrie() FtCreateFieldOptionWithsuffixtrie {
 	c.cs.s = append(c.cs.s, "WITHSUFFIXTRIE")
@@ -2079,10 +2079,10 @@ func (c FtCreateFieldFieldTypeVector) FieldName(fieldName string) FtCreateFieldF
 
 func (c FtCreateFieldFieldTypeVector) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionCasesensitive Completed
+type FtCreateFieldOptionCasesensitive Incomplete
 
 func (c FtCreateFieldOptionCasesensitive) Withsuffixtrie() FtCreateFieldOptionWithsuffixtrie {
 	c.cs.s = append(c.cs.s, "WITHSUFFIXTRIE")
@@ -2131,10 +2131,10 @@ func (c FtCreateFieldOptionCasesensitive) FieldName(fieldName string) FtCreateFi
 
 func (c FtCreateFieldOptionCasesensitive) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionNoindex Completed
+type FtCreateFieldOptionNoindex Incomplete
 
 func (c FtCreateFieldOptionNoindex) Nostem() FtCreateFieldOptionNostem {
 	c.cs.s = append(c.cs.s, "NOSTEM")
@@ -2183,10 +2183,10 @@ func (c FtCreateFieldOptionNoindex) FieldName(fieldName string) FtCreateFieldFie
 
 func (c FtCreateFieldOptionNoindex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionNostem Completed
+type FtCreateFieldOptionNostem Incomplete
 
 func (c FtCreateFieldOptionNostem) Phonetic(phonetic string) FtCreateFieldOptionPhonetic {
 	c.cs.s = append(c.cs.s, "PHONETIC", phonetic)
@@ -2235,10 +2235,10 @@ func (c FtCreateFieldOptionNostem) FieldName(fieldName string) FtCreateFieldFiel
 
 func (c FtCreateFieldOptionNostem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionPhonetic Completed
+type FtCreateFieldOptionPhonetic Incomplete
 
 func (c FtCreateFieldOptionPhonetic) Weight(weight float64) FtCreateFieldOptionWeight {
 	c.cs.s = append(c.cs.s, "WEIGHT", strconv.FormatFloat(weight, 'f', -1, 64))
@@ -2287,10 +2287,10 @@ func (c FtCreateFieldOptionPhonetic) FieldName(fieldName string) FtCreateFieldFi
 
 func (c FtCreateFieldOptionPhonetic) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionSeparator Completed
+type FtCreateFieldOptionSeparator Incomplete
 
 func (c FtCreateFieldOptionSeparator) Casesensitive() FtCreateFieldOptionCasesensitive {
 	c.cs.s = append(c.cs.s, "CASESENSITIVE")
@@ -2339,10 +2339,10 @@ func (c FtCreateFieldOptionSeparator) FieldName(fieldName string) FtCreateFieldF
 
 func (c FtCreateFieldOptionSeparator) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionSortableSortable Completed
+type FtCreateFieldOptionSortableSortable Incomplete
 
 func (c FtCreateFieldOptionSortableSortable) Unf() FtCreateFieldOptionSortableUnf {
 	c.cs.s = append(c.cs.s, "UNF")
@@ -2396,10 +2396,10 @@ func (c FtCreateFieldOptionSortableSortable) FieldName(fieldName string) FtCreat
 
 func (c FtCreateFieldOptionSortableSortable) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionSortableUnf Completed
+type FtCreateFieldOptionSortableUnf Incomplete
 
 func (c FtCreateFieldOptionSortableUnf) Noindex() FtCreateFieldOptionNoindex {
 	c.cs.s = append(c.cs.s, "NOINDEX")
@@ -2448,10 +2448,10 @@ func (c FtCreateFieldOptionSortableUnf) FieldName(fieldName string) FtCreateFiel
 
 func (c FtCreateFieldOptionSortableUnf) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionWeight Completed
+type FtCreateFieldOptionWeight Incomplete
 
 func (c FtCreateFieldOptionWeight) Separator(separator string) FtCreateFieldOptionSeparator {
 	c.cs.s = append(c.cs.s, "SEPARATOR", separator)
@@ -2500,10 +2500,10 @@ func (c FtCreateFieldOptionWeight) FieldName(fieldName string) FtCreateFieldFiel
 
 func (c FtCreateFieldOptionWeight) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFieldOptionWithsuffixtrie Completed
+type FtCreateFieldOptionWithsuffixtrie Incomplete
 
 func (c FtCreateFieldOptionWithsuffixtrie) Sortable() FtCreateFieldOptionSortableSortable {
 	c.cs.s = append(c.cs.s, "SORTABLE")
@@ -2552,10 +2552,10 @@ func (c FtCreateFieldOptionWithsuffixtrie) FieldName(fieldName string) FtCreateF
 
 func (c FtCreateFieldOptionWithsuffixtrie) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCreateFilter Completed
+type FtCreateFilter Incomplete
 
 func (c FtCreateFilter) Language(defaultLang string) FtCreateLanguage {
 	c.cs.s = append(c.cs.s, "LANGUAGE", defaultLang)
@@ -2627,7 +2627,7 @@ func (c FtCreateFilter) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateIndex Completed
+type FtCreateIndex Incomplete
 
 func (c FtCreateIndex) OnHash() FtCreateOnHash {
 	c.cs.s = append(c.cs.s, "ON", "HASH")
@@ -2719,7 +2719,7 @@ func (c FtCreateIndex) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateLanguage Completed
+type FtCreateLanguage Incomplete
 
 func (c FtCreateLanguage) LanguageField(langAttribute string) FtCreateLanguageField {
 	c.cs.s = append(c.cs.s, "LANGUAGE_FIELD", langAttribute)
@@ -2786,7 +2786,7 @@ func (c FtCreateLanguage) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateLanguageField Completed
+type FtCreateLanguageField Incomplete
 
 func (c FtCreateLanguageField) Score(defaultScore float64) FtCreateScore {
 	c.cs.s = append(c.cs.s, "SCORE", strconv.FormatFloat(defaultScore, 'f', -1, 64))
@@ -2848,7 +2848,7 @@ func (c FtCreateLanguageField) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateMaxtextfields Completed
+type FtCreateMaxtextfields Incomplete
 
 func (c FtCreateMaxtextfields) Temporary(seconds float64) FtCreateTemporary {
 	c.cs.s = append(c.cs.s, "TEMPORARY", strconv.FormatFloat(seconds, 'f', -1, 64))
@@ -2890,7 +2890,7 @@ func (c FtCreateMaxtextfields) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateNofields Completed
+type FtCreateNofields Incomplete
 
 func (c FtCreateNofields) Nofreqs() FtCreateNofreqs {
 	c.cs.s = append(c.cs.s, "NOFREQS")
@@ -2912,7 +2912,7 @@ func (c FtCreateNofields) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateNofreqs Completed
+type FtCreateNofreqs Incomplete
 
 func (c FtCreateNofreqs) Stopwords(count int64) FtCreateStopwordsStopwords {
 	c.cs.s = append(c.cs.s, "STOPWORDS", strconv.FormatInt(count, 10))
@@ -2929,7 +2929,7 @@ func (c FtCreateNofreqs) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateNohl Completed
+type FtCreateNohl Incomplete
 
 func (c FtCreateNohl) Nofields() FtCreateNofields {
 	c.cs.s = append(c.cs.s, "NOFIELDS")
@@ -2956,7 +2956,7 @@ func (c FtCreateNohl) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateNooffsets Completed
+type FtCreateNooffsets Incomplete
 
 func (c FtCreateNooffsets) Nohl() FtCreateNohl {
 	c.cs.s = append(c.cs.s, "NOHL")
@@ -2988,7 +2988,7 @@ func (c FtCreateNooffsets) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateOnHash Completed
+type FtCreateOnHash Incomplete
 
 func (c FtCreateOnHash) Prefix(count int64) FtCreatePrefixCount {
 	c.cs.s = append(c.cs.s, "PREFIX", strconv.FormatInt(count, 10))
@@ -3070,7 +3070,7 @@ func (c FtCreateOnHash) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateOnJson Completed
+type FtCreateOnJson Incomplete
 
 func (c FtCreateOnJson) Prefix(count int64) FtCreatePrefixCount {
 	c.cs.s = append(c.cs.s, "PREFIX", strconv.FormatInt(count, 10))
@@ -3152,7 +3152,7 @@ func (c FtCreateOnJson) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreatePayloadField Completed
+type FtCreatePayloadField Incomplete
 
 func (c FtCreatePayloadField) Maxtextfields() FtCreateMaxtextfields {
 	c.cs.s = append(c.cs.s, "MAXTEXTFIELDS")
@@ -3199,14 +3199,14 @@ func (c FtCreatePayloadField) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreatePrefixCount Completed
+type FtCreatePrefixCount Incomplete
 
 func (c FtCreatePrefixCount) Prefix(prefix ...string) FtCreatePrefixPrefix {
 	c.cs.s = append(c.cs.s, prefix...)
 	return (FtCreatePrefixPrefix)(c)
 }
 
-type FtCreatePrefixPrefix Completed
+type FtCreatePrefixPrefix Incomplete
 
 func (c FtCreatePrefixPrefix) Prefix(prefix ...string) FtCreatePrefixPrefix {
 	c.cs.s = append(c.cs.s, prefix...)
@@ -3288,14 +3288,14 @@ func (c FtCreatePrefixPrefix) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateSchema Completed
+type FtCreateSchema Incomplete
 
 func (c FtCreateSchema) FieldName(fieldName string) FtCreateFieldFieldName {
 	c.cs.s = append(c.cs.s, fieldName)
 	return (FtCreateFieldFieldName)(c)
 }
 
-type FtCreateScore Completed
+type FtCreateScore Incomplete
 
 func (c FtCreateScore) ScoreField(scoreAttribute string) FtCreateScoreField {
 	c.cs.s = append(c.cs.s, "SCORE_FIELD", scoreAttribute)
@@ -3352,7 +3352,7 @@ func (c FtCreateScore) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateScoreField Completed
+type FtCreateScoreField Incomplete
 
 func (c FtCreateScoreField) PayloadField(payloadAttribute string) FtCreatePayloadField {
 	c.cs.s = append(c.cs.s, "PAYLOAD_FIELD", payloadAttribute)
@@ -3404,14 +3404,14 @@ func (c FtCreateScoreField) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateSkipinitialscan Completed
+type FtCreateSkipinitialscan Incomplete
 
 func (c FtCreateSkipinitialscan) Schema() FtCreateSchema {
 	c.cs.s = append(c.cs.s, "SCHEMA")
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateStopwordsStopword Completed
+type FtCreateStopwordsStopword Incomplete
 
 func (c FtCreateStopwordsStopword) Stopword(stopword ...string) FtCreateStopwordsStopword {
 	c.cs.s = append(c.cs.s, stopword...)
@@ -3428,7 +3428,7 @@ func (c FtCreateStopwordsStopword) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateStopwordsStopwords Completed
+type FtCreateStopwordsStopwords Incomplete
 
 func (c FtCreateStopwordsStopwords) Stopword(stopword ...string) FtCreateStopwordsStopword {
 	c.cs.s = append(c.cs.s, stopword...)
@@ -3445,7 +3445,7 @@ func (c FtCreateStopwordsStopwords) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCreateTemporary Completed
+type FtCreateTemporary Incomplete
 
 func (c FtCreateTemporary) Nooffsets() FtCreateNooffsets {
 	c.cs.s = append(c.cs.s, "NOOFFSETS")
@@ -3482,7 +3482,7 @@ func (c FtCreateTemporary) Schema() FtCreateSchema {
 	return (FtCreateSchema)(c)
 }
 
-type FtCursorDel Completed
+type FtCursorDel Incomplete
 
 func (b Builder) FtCursorDel() (c FtCursorDel) {
 	c = FtCursorDel{cs: get(), ks: b.ks}
@@ -3495,21 +3495,21 @@ func (c FtCursorDel) Index(index string) FtCursorDelIndex {
 	return (FtCursorDelIndex)(c)
 }
 
-type FtCursorDelCursorId Completed
+type FtCursorDelCursorId Incomplete
 
 func (c FtCursorDelCursorId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCursorDelIndex Completed
+type FtCursorDelIndex Incomplete
 
 func (c FtCursorDelIndex) CursorId(cursorId int64) FtCursorDelCursorId {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(cursorId, 10))
 	return (FtCursorDelCursorId)(c)
 }
 
-type FtCursorRead Completed
+type FtCursorRead Incomplete
 
 func (b Builder) FtCursorRead() (c FtCursorRead) {
 	c = FtCursorRead{cs: get(), ks: b.ks}
@@ -3522,14 +3522,14 @@ func (c FtCursorRead) Index(index string) FtCursorReadIndex {
 	return (FtCursorReadIndex)(c)
 }
 
-type FtCursorReadCount Completed
+type FtCursorReadCount Incomplete
 
 func (c FtCursorReadCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCursorReadCursorId Completed
+type FtCursorReadCursorId Incomplete
 
 func (c FtCursorReadCursorId) Count(readSize int64) FtCursorReadCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(readSize, 10))
@@ -3538,17 +3538,17 @@ func (c FtCursorReadCursorId) Count(readSize int64) FtCursorReadCount {
 
 func (c FtCursorReadCursorId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtCursorReadIndex Completed
+type FtCursorReadIndex Incomplete
 
 func (c FtCursorReadIndex) CursorId(cursorId int64) FtCursorReadCursorId {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(cursorId, 10))
 	return (FtCursorReadCursorId)(c)
 }
 
-type FtDictadd Completed
+type FtDictadd Incomplete
 
 func (b Builder) FtDictadd() (c FtDictadd) {
 	c = FtDictadd{cs: get(), ks: b.ks}
@@ -3561,14 +3561,14 @@ func (c FtDictadd) Dict(dict string) FtDictaddDict {
 	return (FtDictaddDict)(c)
 }
 
-type FtDictaddDict Completed
+type FtDictaddDict Incomplete
 
 func (c FtDictaddDict) Term(term ...string) FtDictaddTerm {
 	c.cs.s = append(c.cs.s, term...)
 	return (FtDictaddTerm)(c)
 }
 
-type FtDictaddTerm Completed
+type FtDictaddTerm Incomplete
 
 func (c FtDictaddTerm) Term(term ...string) FtDictaddTerm {
 	c.cs.s = append(c.cs.s, term...)
@@ -3577,10 +3577,10 @@ func (c FtDictaddTerm) Term(term ...string) FtDictaddTerm {
 
 func (c FtDictaddTerm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtDictdel Completed
+type FtDictdel Incomplete
 
 func (b Builder) FtDictdel() (c FtDictdel) {
 	c = FtDictdel{cs: get(), ks: b.ks}
@@ -3593,14 +3593,14 @@ func (c FtDictdel) Dict(dict string) FtDictdelDict {
 	return (FtDictdelDict)(c)
 }
 
-type FtDictdelDict Completed
+type FtDictdelDict Incomplete
 
 func (c FtDictdelDict) Term(term ...string) FtDictdelTerm {
 	c.cs.s = append(c.cs.s, term...)
 	return (FtDictdelTerm)(c)
 }
 
-type FtDictdelTerm Completed
+type FtDictdelTerm Incomplete
 
 func (c FtDictdelTerm) Term(term ...string) FtDictdelTerm {
 	c.cs.s = append(c.cs.s, term...)
@@ -3609,10 +3609,10 @@ func (c FtDictdelTerm) Term(term ...string) FtDictdelTerm {
 
 func (c FtDictdelTerm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtDictdump Completed
+type FtDictdump Incomplete
 
 func (b Builder) FtDictdump() (c FtDictdump) {
 	c = FtDictdump{cs: get(), ks: b.ks}
@@ -3625,14 +3625,14 @@ func (c FtDictdump) Dict(dict string) FtDictdumpDict {
 	return (FtDictdumpDict)(c)
 }
 
-type FtDictdumpDict Completed
+type FtDictdumpDict Incomplete
 
 func (c FtDictdumpDict) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtDropindex Completed
+type FtDropindex Incomplete
 
 func (b Builder) FtDropindex() (c FtDropindex) {
 	c = FtDropindex{cs: get(), ks: b.ks}
@@ -3645,14 +3645,14 @@ func (c FtDropindex) Index(index string) FtDropindexIndex {
 	return (FtDropindexIndex)(c)
 }
 
-type FtDropindexDeleteDocsDd Completed
+type FtDropindexDeleteDocsDd Incomplete
 
 func (c FtDropindexDeleteDocsDd) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtDropindexIndex Completed
+type FtDropindexIndex Incomplete
 
 func (c FtDropindexIndex) Dd() FtDropindexDeleteDocsDd {
 	c.cs.s = append(c.cs.s, "DD")
@@ -3661,10 +3661,10 @@ func (c FtDropindexIndex) Dd() FtDropindexDeleteDocsDd {
 
 func (c FtDropindexIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtExplain Completed
+type FtExplain Incomplete
 
 func (b Builder) FtExplain() (c FtExplain) {
 	c = FtExplain{cs: get(), ks: b.ks}
@@ -3677,21 +3677,21 @@ func (c FtExplain) Index(index string) FtExplainIndex {
 	return (FtExplainIndex)(c)
 }
 
-type FtExplainDialect Completed
+type FtExplainDialect Incomplete
 
 func (c FtExplainDialect) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtExplainIndex Completed
+type FtExplainIndex Incomplete
 
 func (c FtExplainIndex) Query(query string) FtExplainQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (FtExplainQuery)(c)
 }
 
-type FtExplainQuery Completed
+type FtExplainQuery Incomplete
 
 func (c FtExplainQuery) Dialect(dialect int64) FtExplainDialect {
 	c.cs.s = append(c.cs.s, "DIALECT", strconv.FormatInt(dialect, 10))
@@ -3700,10 +3700,10 @@ func (c FtExplainQuery) Dialect(dialect int64) FtExplainDialect {
 
 func (c FtExplainQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtExplaincli Completed
+type FtExplaincli Incomplete
 
 func (b Builder) FtExplaincli() (c FtExplaincli) {
 	c = FtExplaincli{cs: get(), ks: b.ks}
@@ -3716,21 +3716,21 @@ func (c FtExplaincli) Index(index string) FtExplaincliIndex {
 	return (FtExplaincliIndex)(c)
 }
 
-type FtExplaincliDialect Completed
+type FtExplaincliDialect Incomplete
 
 func (c FtExplaincliDialect) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtExplaincliIndex Completed
+type FtExplaincliIndex Incomplete
 
 func (c FtExplaincliIndex) Query(query string) FtExplaincliQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (FtExplaincliQuery)(c)
 }
 
-type FtExplaincliQuery Completed
+type FtExplaincliQuery Incomplete
 
 func (c FtExplaincliQuery) Dialect(dialect int64) FtExplaincliDialect {
 	c.cs.s = append(c.cs.s, "DIALECT", strconv.FormatInt(dialect, 10))
@@ -3739,10 +3739,10 @@ func (c FtExplaincliQuery) Dialect(dialect int64) FtExplaincliDialect {
 
 func (c FtExplaincliQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtInfo Completed
+type FtInfo Incomplete
 
 func (b Builder) FtInfo() (c FtInfo) {
 	c = FtInfo{cs: get(), ks: b.ks}
@@ -3755,14 +3755,14 @@ func (c FtInfo) Index(index string) FtInfoIndex {
 	return (FtInfoIndex)(c)
 }
 
-type FtInfoIndex Completed
+type FtInfoIndex Incomplete
 
 func (c FtInfoIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtList Completed
+type FtList Incomplete
 
 func (b Builder) FtList() (c FtList) {
 	c = FtList{cs: get(), ks: b.ks}
@@ -3772,10 +3772,10 @@ func (b Builder) FtList() (c FtList) {
 
 func (c FtList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtProfile Completed
+type FtProfile Incomplete
 
 func (b Builder) FtProfile() (c FtProfile) {
 	c = FtProfile{cs: get(), ks: b.ks}
@@ -3788,7 +3788,7 @@ func (c FtProfile) Index(index string) FtProfileIndex {
 	return (FtProfileIndex)(c)
 }
 
-type FtProfileIndex Completed
+type FtProfileIndex Incomplete
 
 func (c FtProfileIndex) Search() FtProfileQuerytypeSearch {
 	c.cs.s = append(c.cs.s, "SEARCH")
@@ -3800,21 +3800,21 @@ func (c FtProfileIndex) Aggregate() FtProfileQuerytypeAggregate {
 	return (FtProfileQuerytypeAggregate)(c)
 }
 
-type FtProfileLimited Completed
+type FtProfileLimited Incomplete
 
 func (c FtProfileLimited) Query(query string) FtProfileQuery {
 	c.cs.s = append(c.cs.s, "QUERY", query)
 	return (FtProfileQuery)(c)
 }
 
-type FtProfileQuery Completed
+type FtProfileQuery Incomplete
 
 func (c FtProfileQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtProfileQuerytypeAggregate Completed
+type FtProfileQuerytypeAggregate Incomplete
 
 func (c FtProfileQuerytypeAggregate) Limited() FtProfileLimited {
 	c.cs.s = append(c.cs.s, "LIMITED")
@@ -3826,7 +3826,7 @@ func (c FtProfileQuerytypeAggregate) Query(query string) FtProfileQuery {
 	return (FtProfileQuery)(c)
 }
 
-type FtProfileQuerytypeSearch Completed
+type FtProfileQuerytypeSearch Incomplete
 
 func (c FtProfileQuerytypeSearch) Limited() FtProfileLimited {
 	c.cs.s = append(c.cs.s, "LIMITED")
@@ -3838,10 +3838,10 @@ func (c FtProfileQuerytypeSearch) Query(query string) FtProfileQuery {
 	return (FtProfileQuery)(c)
 }
 
-type FtSearch Completed
+type FtSearch Incomplete
 
 func (b Builder) FtSearch() (c FtSearch) {
-	c = FtSearch{cs: get(), ks: b.ks, cf: readonly}
+	c = FtSearch{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "FT.SEARCH")
 	return c
 }
@@ -3851,14 +3851,14 @@ func (c FtSearch) Index(index string) FtSearchIndex {
 	return (FtSearchIndex)(c)
 }
 
-type FtSearchDialect Completed
+type FtSearchDialect Incomplete
 
 func (c FtSearchDialect) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchExpander Completed
+type FtSearchExpander Incomplete
 
 func (c FtSearchExpander) Scorer(scorer string) FtSearchScorer {
 	c.cs.s = append(c.cs.s, "SCORER", scorer)
@@ -3897,10 +3897,10 @@ func (c FtSearchExpander) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchExpander) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchExplainscore Completed
+type FtSearchExplainscore Incomplete
 
 func (c FtSearchExplainscore) Payload(payload string) FtSearchPayload {
 	c.cs.s = append(c.cs.s, "PAYLOAD", payload)
@@ -3929,17 +3929,17 @@ func (c FtSearchExplainscore) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchExplainscore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchFilterFilter Completed
+type FtSearchFilterFilter Incomplete
 
 func (c FtSearchFilterFilter) Min(min float64) FtSearchFilterMin {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(min, 'f', -1, 64))
 	return (FtSearchFilterMin)(c)
 }
 
-type FtSearchFilterMax Completed
+type FtSearchFilterMax Incomplete
 
 func (c FtSearchFilterMax) Filter(numericField string) FtSearchFilterFilter {
 	c.cs.s = append(c.cs.s, "FILTER", numericField)
@@ -4038,38 +4038,38 @@ func (c FtSearchFilterMax) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchFilterMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchFilterMin Completed
+type FtSearchFilterMin Incomplete
 
 func (c FtSearchFilterMin) Max(max float64) FtSearchFilterMax {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(max, 'f', -1, 64))
 	return (FtSearchFilterMax)(c)
 }
 
-type FtSearchGeoFilterGeofilter Completed
+type FtSearchGeoFilterGeofilter Incomplete
 
 func (c FtSearchGeoFilterGeofilter) Lon(lon float64) FtSearchGeoFilterLon {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(lon, 'f', -1, 64))
 	return (FtSearchGeoFilterLon)(c)
 }
 
-type FtSearchGeoFilterLat Completed
+type FtSearchGeoFilterLat Incomplete
 
 func (c FtSearchGeoFilterLat) Radius(radius float64) FtSearchGeoFilterRadius {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(radius, 'f', -1, 64))
 	return (FtSearchGeoFilterRadius)(c)
 }
 
-type FtSearchGeoFilterLon Completed
+type FtSearchGeoFilterLon Incomplete
 
 func (c FtSearchGeoFilterLon) Lat(lat float64) FtSearchGeoFilterLat {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(lat, 'f', -1, 64))
 	return (FtSearchGeoFilterLat)(c)
 }
 
-type FtSearchGeoFilterRadius Completed
+type FtSearchGeoFilterRadius Incomplete
 
 func (c FtSearchGeoFilterRadius) M() FtSearchGeoFilterRadiusTypeM {
 	c.cs.s = append(c.cs.s, "m")
@@ -4091,7 +4091,7 @@ func (c FtSearchGeoFilterRadius) Ft() FtSearchGeoFilterRadiusTypeFt {
 	return (FtSearchGeoFilterRadiusTypeFt)(c)
 }
 
-type FtSearchGeoFilterRadiusTypeFt Completed
+type FtSearchGeoFilterRadiusTypeFt Incomplete
 
 func (c FtSearchGeoFilterRadiusTypeFt) Geofilter(geoField string) FtSearchGeoFilterGeofilter {
 	c.cs.s = append(c.cs.s, "GEOFILTER", geoField)
@@ -4185,10 +4185,10 @@ func (c FtSearchGeoFilterRadiusTypeFt) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchGeoFilterRadiusTypeFt) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchGeoFilterRadiusTypeKm Completed
+type FtSearchGeoFilterRadiusTypeKm Incomplete
 
 func (c FtSearchGeoFilterRadiusTypeKm) Geofilter(geoField string) FtSearchGeoFilterGeofilter {
 	c.cs.s = append(c.cs.s, "GEOFILTER", geoField)
@@ -4282,10 +4282,10 @@ func (c FtSearchGeoFilterRadiusTypeKm) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchGeoFilterRadiusTypeKm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchGeoFilterRadiusTypeM Completed
+type FtSearchGeoFilterRadiusTypeM Incomplete
 
 func (c FtSearchGeoFilterRadiusTypeM) Geofilter(geoField string) FtSearchGeoFilterGeofilter {
 	c.cs.s = append(c.cs.s, "GEOFILTER", geoField)
@@ -4379,10 +4379,10 @@ func (c FtSearchGeoFilterRadiusTypeM) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchGeoFilterRadiusTypeM) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchGeoFilterRadiusTypeMi Completed
+type FtSearchGeoFilterRadiusTypeMi Incomplete
 
 func (c FtSearchGeoFilterRadiusTypeMi) Geofilter(geoField string) FtSearchGeoFilterGeofilter {
 	c.cs.s = append(c.cs.s, "GEOFILTER", geoField)
@@ -4476,10 +4476,10 @@ func (c FtSearchGeoFilterRadiusTypeMi) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchGeoFilterRadiusTypeMi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchHighlightFieldsField Completed
+type FtSearchHighlightFieldsField Incomplete
 
 func (c FtSearchHighlightFieldsField) Field(field ...string) FtSearchHighlightFieldsField {
 	c.cs.s = append(c.cs.s, field...)
@@ -4553,17 +4553,17 @@ func (c FtSearchHighlightFieldsField) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchHighlightFieldsField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchHighlightFieldsFields Completed
+type FtSearchHighlightFieldsFields Incomplete
 
 func (c FtSearchHighlightFieldsFields) Field(field ...string) FtSearchHighlightFieldsField {
 	c.cs.s = append(c.cs.s, field...)
 	return (FtSearchHighlightFieldsField)(c)
 }
 
-type FtSearchHighlightHighlight Completed
+type FtSearchHighlightHighlight Incomplete
 
 func (c FtSearchHighlightHighlight) Fields(count string) FtSearchHighlightFieldsFields {
 	c.cs.s = append(c.cs.s, "FIELDS", count)
@@ -4637,10 +4637,10 @@ func (c FtSearchHighlightHighlight) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchHighlightHighlight) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchHighlightTagsOpenClose Completed
+type FtSearchHighlightTagsOpenClose Incomplete
 
 func (c FtSearchHighlightTagsOpenClose) Slop(slop int64) FtSearchSlop {
 	c.cs.s = append(c.cs.s, "SLOP", strconv.FormatInt(slop, 10))
@@ -4704,17 +4704,17 @@ func (c FtSearchHighlightTagsOpenClose) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchHighlightTagsOpenClose) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchHighlightTagsTags Completed
+type FtSearchHighlightTagsTags Incomplete
 
 func (c FtSearchHighlightTagsTags) OpenClose(open string, close string) FtSearchHighlightTagsOpenClose {
 	c.cs.s = append(c.cs.s, open, close)
 	return (FtSearchHighlightTagsOpenClose)(c)
 }
 
-type FtSearchInFieldsField Completed
+type FtSearchInFieldsField Incomplete
 
 func (c FtSearchInFieldsField) Field(field ...string) FtSearchInFieldsField {
 	c.cs.s = append(c.cs.s, field...)
@@ -4798,24 +4798,24 @@ func (c FtSearchInFieldsField) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchInFieldsField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchInFieldsInfields Completed
+type FtSearchInFieldsInfields Incomplete
 
 func (c FtSearchInFieldsInfields) Field(field ...string) FtSearchInFieldsField {
 	c.cs.s = append(c.cs.s, field...)
 	return (FtSearchInFieldsField)(c)
 }
 
-type FtSearchInKeysInkeys Completed
+type FtSearchInKeysInkeys Incomplete
 
 func (c FtSearchInKeysInkeys) Key(key ...string) FtSearchInKeysKey {
 	c.cs.s = append(c.cs.s, key...)
 	return (FtSearchInKeysKey)(c)
 }
 
-type FtSearchInKeysKey Completed
+type FtSearchInKeysKey Incomplete
 
 func (c FtSearchInKeysKey) Key(key ...string) FtSearchInKeysKey {
 	c.cs.s = append(c.cs.s, key...)
@@ -4904,17 +4904,17 @@ func (c FtSearchInKeysKey) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchInKeysKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchIndex Completed
+type FtSearchIndex Incomplete
 
 func (c FtSearchIndex) Query(query string) FtSearchQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (FtSearchQuery)(c)
 }
 
-type FtSearchLanguage Completed
+type FtSearchLanguage Incomplete
 
 func (c FtSearchLanguage) Expander(expander string) FtSearchExpander {
 	c.cs.s = append(c.cs.s, "EXPANDER", expander)
@@ -4958,17 +4958,17 @@ func (c FtSearchLanguage) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchLanguage) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchLimitLimit Completed
+type FtSearchLimitLimit Incomplete
 
 func (c FtSearchLimitLimit) OffsetNum(offset int64, num int64) FtSearchLimitOffsetNum {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(offset, 10), strconv.FormatInt(num, 10))
 	return (FtSearchLimitOffsetNum)(c)
 }
 
-type FtSearchLimitOffsetNum Completed
+type FtSearchLimitOffsetNum Incomplete
 
 func (c FtSearchLimitOffsetNum) Params() FtSearchParamsParams {
 	c.cs.s = append(c.cs.s, "PARAMS")
@@ -4982,10 +4982,10 @@ func (c FtSearchLimitOffsetNum) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchLimitOffsetNum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchNocontent Completed
+type FtSearchNocontent Incomplete
 
 func (c FtSearchNocontent) Verbatim() FtSearchVerbatim {
 	c.cs.s = append(c.cs.s, "VERBATIM")
@@ -5109,10 +5109,10 @@ func (c FtSearchNocontent) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchNocontent) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchNostopwords Completed
+type FtSearchNostopwords Incomplete
 
 func (c FtSearchNostopwords) Withscores() FtSearchWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -5226,10 +5226,10 @@ func (c FtSearchNostopwords) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchNostopwords) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchParamsNameValue Completed
+type FtSearchParamsNameValue Incomplete
 
 func (c FtSearchParamsNameValue) NameValue(name string, value string) FtSearchParamsNameValue {
 	c.cs.s = append(c.cs.s, name, value)
@@ -5243,23 +5243,23 @@ func (c FtSearchParamsNameValue) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchParamsNameValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchParamsNargs Completed
+type FtSearchParamsNargs Incomplete
 
 func (c FtSearchParamsNargs) NameValue() FtSearchParamsNameValue {
 	return (FtSearchParamsNameValue)(c)
 }
 
-type FtSearchParamsParams Completed
+type FtSearchParamsParams Incomplete
 
 func (c FtSearchParamsParams) Nargs(nargs int64) FtSearchParamsNargs {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(nargs, 10))
 	return (FtSearchParamsNargs)(c)
 }
 
-type FtSearchPayload Completed
+type FtSearchPayload Incomplete
 
 func (c FtSearchPayload) Sortby(sortby string) FtSearchSortbySortby {
 	c.cs.s = append(c.cs.s, "SORTBY", sortby)
@@ -5283,10 +5283,10 @@ func (c FtSearchPayload) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchPayload) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchQuery Completed
+type FtSearchQuery Incomplete
 
 func (c FtSearchQuery) Nocontent() FtSearchNocontent {
 	c.cs.s = append(c.cs.s, "NOCONTENT")
@@ -5415,10 +5415,10 @@ func (c FtSearchQuery) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchReturnIdentifiersAs Completed
+type FtSearchReturnIdentifiersAs Incomplete
 
 func (c FtSearchReturnIdentifiersAs) Identifier(identifier string) FtSearchReturnIdentifiersIdentifier {
 	c.cs.s = append(c.cs.s, identifier)
@@ -5497,10 +5497,10 @@ func (c FtSearchReturnIdentifiersAs) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchReturnIdentifiersAs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchReturnIdentifiersIdentifier Completed
+type FtSearchReturnIdentifiersIdentifier Incomplete
 
 func (c FtSearchReturnIdentifiersIdentifier) As(property string) FtSearchReturnIdentifiersAs {
 	c.cs.s = append(c.cs.s, "AS", property)
@@ -5584,17 +5584,17 @@ func (c FtSearchReturnIdentifiersIdentifier) Dialect(dialect int64) FtSearchDial
 
 func (c FtSearchReturnIdentifiersIdentifier) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchReturnReturn Completed
+type FtSearchReturnReturn Incomplete
 
 func (c FtSearchReturnReturn) Identifier(identifier string) FtSearchReturnIdentifiersIdentifier {
 	c.cs.s = append(c.cs.s, identifier)
 	return (FtSearchReturnIdentifiersIdentifier)(c)
 }
 
-type FtSearchScorer Completed
+type FtSearchScorer Incomplete
 
 func (c FtSearchScorer) Explainscore() FtSearchExplainscore {
 	c.cs.s = append(c.cs.s, "EXPLAINSCORE")
@@ -5628,10 +5628,10 @@ func (c FtSearchScorer) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchScorer) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSlop Completed
+type FtSearchSlop Incomplete
 
 func (c FtSearchSlop) Timeout(timeout int64) FtSearchTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT", strconv.FormatInt(timeout, 10))
@@ -5690,10 +5690,10 @@ func (c FtSearchSlop) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSlop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSortbyOrderAsc Completed
+type FtSearchSortbyOrderAsc Incomplete
 
 func (c FtSearchSortbyOrderAsc) Limit() FtSearchLimitLimit {
 	c.cs.s = append(c.cs.s, "LIMIT")
@@ -5712,10 +5712,10 @@ func (c FtSearchSortbyOrderAsc) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSortbyOrderAsc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSortbyOrderDesc Completed
+type FtSearchSortbyOrderDesc Incomplete
 
 func (c FtSearchSortbyOrderDesc) Limit() FtSearchLimitLimit {
 	c.cs.s = append(c.cs.s, "LIMIT")
@@ -5734,10 +5734,10 @@ func (c FtSearchSortbyOrderDesc) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSortbyOrderDesc) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSortbySortby Completed
+type FtSearchSortbySortby Incomplete
 
 func (c FtSearchSortbySortby) Asc() FtSearchSortbyOrderAsc {
 	c.cs.s = append(c.cs.s, "ASC")
@@ -5766,10 +5766,10 @@ func (c FtSearchSortbySortby) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSortbySortby) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSummarizeFieldsField Completed
+type FtSearchSummarizeFieldsField Incomplete
 
 func (c FtSearchSummarizeFieldsField) Field(field ...string) FtSearchSummarizeFieldsField {
 	c.cs.s = append(c.cs.s, field...)
@@ -5858,17 +5858,17 @@ func (c FtSearchSummarizeFieldsField) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSummarizeFieldsField) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSummarizeFieldsFields Completed
+type FtSearchSummarizeFieldsFields Incomplete
 
 func (c FtSearchSummarizeFieldsFields) Field(field ...string) FtSearchSummarizeFieldsField {
 	c.cs.s = append(c.cs.s, field...)
 	return (FtSearchSummarizeFieldsField)(c)
 }
 
-type FtSearchSummarizeFrags Completed
+type FtSearchSummarizeFrags Incomplete
 
 func (c FtSearchSummarizeFrags) Len(fragsize int64) FtSearchSummarizeLen {
 	c.cs.s = append(c.cs.s, "LEN", strconv.FormatInt(fragsize, 10))
@@ -5947,10 +5947,10 @@ func (c FtSearchSummarizeFrags) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSummarizeFrags) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSummarizeLen Completed
+type FtSearchSummarizeLen Incomplete
 
 func (c FtSearchSummarizeLen) Separator(separator string) FtSearchSummarizeSeparator {
 	c.cs.s = append(c.cs.s, "SEPARATOR", separator)
@@ -6024,10 +6024,10 @@ func (c FtSearchSummarizeLen) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSummarizeLen) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSummarizeSeparator Completed
+type FtSearchSummarizeSeparator Incomplete
 
 func (c FtSearchSummarizeSeparator) Highlight() FtSearchHighlightHighlight {
 	c.cs.s = append(c.cs.s, "HIGHLIGHT")
@@ -6096,10 +6096,10 @@ func (c FtSearchSummarizeSeparator) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSummarizeSeparator) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchSummarizeSummarize Completed
+type FtSearchSummarizeSummarize Incomplete
 
 func (c FtSearchSummarizeSummarize) Fields(count string) FtSearchSummarizeFieldsFields {
 	c.cs.s = append(c.cs.s, "FIELDS", count)
@@ -6188,10 +6188,10 @@ func (c FtSearchSummarizeSummarize) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchSummarizeSummarize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchTagsInorder Completed
+type FtSearchTagsInorder Incomplete
 
 func (c FtSearchTagsInorder) Language(language string) FtSearchLanguage {
 	c.cs.s = append(c.cs.s, "LANGUAGE", language)
@@ -6240,10 +6240,10 @@ func (c FtSearchTagsInorder) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchTagsInorder) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchTimeout Completed
+type FtSearchTimeout Incomplete
 
 func (c FtSearchTimeout) Inorder() FtSearchTagsInorder {
 	c.cs.s = append(c.cs.s, "INORDER")
@@ -6297,10 +6297,10 @@ func (c FtSearchTimeout) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchVerbatim Completed
+type FtSearchVerbatim Incomplete
 
 func (c FtSearchVerbatim) Nostopwords() FtSearchNostopwords {
 	c.cs.s = append(c.cs.s, "NOSTOPWORDS")
@@ -6419,10 +6419,10 @@ func (c FtSearchVerbatim) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchVerbatim) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchWithpayloads Completed
+type FtSearchWithpayloads Incomplete
 
 func (c FtSearchWithpayloads) Withsortkeys() FtSearchWithsortkeys {
 	c.cs.s = append(c.cs.s, "WITHSORTKEYS")
@@ -6526,10 +6526,10 @@ func (c FtSearchWithpayloads) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchWithpayloads) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchWithscores Completed
+type FtSearchWithscores Incomplete
 
 func (c FtSearchWithscores) Withpayloads() FtSearchWithpayloads {
 	c.cs.s = append(c.cs.s, "WITHPAYLOADS")
@@ -6638,10 +6638,10 @@ func (c FtSearchWithscores) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSearchWithsortkeys Completed
+type FtSearchWithsortkeys Incomplete
 
 func (c FtSearchWithsortkeys) Filter(numericField string) FtSearchFilterFilter {
 	c.cs.s = append(c.cs.s, "FILTER", numericField)
@@ -6740,10 +6740,10 @@ func (c FtSearchWithsortkeys) Dialect(dialect int64) FtSearchDialect {
 
 func (c FtSearchWithsortkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSpellcheck Completed
+type FtSpellcheck Incomplete
 
 func (b Builder) FtSpellcheck() (c FtSpellcheck) {
 	c = FtSpellcheck{cs: get(), ks: b.ks}
@@ -6756,14 +6756,14 @@ func (c FtSpellcheck) Index(index string) FtSpellcheckIndex {
 	return (FtSpellcheckIndex)(c)
 }
 
-type FtSpellcheckDialect Completed
+type FtSpellcheckDialect Incomplete
 
 func (c FtSpellcheckDialect) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSpellcheckDistance Completed
+type FtSpellcheckDistance Incomplete
 
 func (c FtSpellcheckDistance) TermsInclude() FtSpellcheckTermsTermsInclude {
 	c.cs.s = append(c.cs.s, "TERMS", "INCLUDE")
@@ -6782,17 +6782,17 @@ func (c FtSpellcheckDistance) Dialect(dialect int64) FtSpellcheckDialect {
 
 func (c FtSpellcheckDistance) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSpellcheckIndex Completed
+type FtSpellcheckIndex Incomplete
 
 func (c FtSpellcheckIndex) Query(query string) FtSpellcheckQuery {
 	c.cs.s = append(c.cs.s, query)
 	return (FtSpellcheckQuery)(c)
 }
 
-type FtSpellcheckQuery Completed
+type FtSpellcheckQuery Incomplete
 
 func (c FtSpellcheckQuery) Distance(distance int64) FtSpellcheckDistance {
 	c.cs.s = append(c.cs.s, "DISTANCE", strconv.FormatInt(distance, 10))
@@ -6816,10 +6816,10 @@ func (c FtSpellcheckQuery) Dialect(dialect int64) FtSpellcheckDialect {
 
 func (c FtSpellcheckQuery) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSpellcheckTermsDictionary Completed
+type FtSpellcheckTermsDictionary Incomplete
 
 func (c FtSpellcheckTermsDictionary) Terms(terms ...string) FtSpellcheckTermsTerms {
 	c.cs.s = append(c.cs.s, terms...)
@@ -6833,10 +6833,10 @@ func (c FtSpellcheckTermsDictionary) Dialect(dialect int64) FtSpellcheckDialect 
 
 func (c FtSpellcheckTermsDictionary) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSpellcheckTermsTerms Completed
+type FtSpellcheckTermsTerms Incomplete
 
 func (c FtSpellcheckTermsTerms) Terms(terms ...string) FtSpellcheckTermsTerms {
 	c.cs.s = append(c.cs.s, terms...)
@@ -6850,24 +6850,24 @@ func (c FtSpellcheckTermsTerms) Dialect(dialect int64) FtSpellcheckDialect {
 
 func (c FtSpellcheckTermsTerms) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSpellcheckTermsTermsExclude Completed
+type FtSpellcheckTermsTermsExclude Incomplete
 
 func (c FtSpellcheckTermsTermsExclude) Dictionary(dictionary string) FtSpellcheckTermsDictionary {
 	c.cs.s = append(c.cs.s, dictionary)
 	return (FtSpellcheckTermsDictionary)(c)
 }
 
-type FtSpellcheckTermsTermsInclude Completed
+type FtSpellcheckTermsTermsInclude Incomplete
 
 func (c FtSpellcheckTermsTermsInclude) Dictionary(dictionary string) FtSpellcheckTermsDictionary {
 	c.cs.s = append(c.cs.s, dictionary)
 	return (FtSpellcheckTermsDictionary)(c)
 }
 
-type FtSyndump Completed
+type FtSyndump Incomplete
 
 func (b Builder) FtSyndump() (c FtSyndump) {
 	c = FtSyndump{cs: get(), ks: b.ks}
@@ -6880,14 +6880,14 @@ func (c FtSyndump) Index(index string) FtSyndumpIndex {
 	return (FtSyndumpIndex)(c)
 }
 
-type FtSyndumpIndex Completed
+type FtSyndumpIndex Incomplete
 
 func (c FtSyndumpIndex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSynupdate Completed
+type FtSynupdate Incomplete
 
 func (b Builder) FtSynupdate() (c FtSynupdate) {
 	c = FtSynupdate{cs: get(), ks: b.ks}
@@ -6900,21 +6900,21 @@ func (c FtSynupdate) Index(index string) FtSynupdateIndex {
 	return (FtSynupdateIndex)(c)
 }
 
-type FtSynupdateIndex Completed
+type FtSynupdateIndex Incomplete
 
 func (c FtSynupdateIndex) SynonymGroupId(synonymGroupId string) FtSynupdateSynonymGroupId {
 	c.cs.s = append(c.cs.s, synonymGroupId)
 	return (FtSynupdateSynonymGroupId)(c)
 }
 
-type FtSynupdateSkipinitialscan Completed
+type FtSynupdateSkipinitialscan Incomplete
 
 func (c FtSynupdateSkipinitialscan) Term(term ...string) FtSynupdateTerm {
 	c.cs.s = append(c.cs.s, term...)
 	return (FtSynupdateTerm)(c)
 }
 
-type FtSynupdateSynonymGroupId Completed
+type FtSynupdateSynonymGroupId Incomplete
 
 func (c FtSynupdateSynonymGroupId) Skipinitialscan() FtSynupdateSkipinitialscan {
 	c.cs.s = append(c.cs.s, "SKIPINITIALSCAN")
@@ -6926,7 +6926,7 @@ func (c FtSynupdateSynonymGroupId) Term(term ...string) FtSynupdateTerm {
 	return (FtSynupdateTerm)(c)
 }
 
-type FtSynupdateTerm Completed
+type FtSynupdateTerm Incomplete
 
 func (c FtSynupdateTerm) Term(term ...string) FtSynupdateTerm {
 	c.cs.s = append(c.cs.s, term...)
@@ -6935,10 +6935,10 @@ func (c FtSynupdateTerm) Term(term ...string) FtSynupdateTerm {
 
 func (c FtSynupdateTerm) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtTagvals Completed
+type FtTagvals Incomplete
 
 func (b Builder) FtTagvals() (c FtTagvals) {
 	c = FtTagvals{cs: get(), ks: b.ks}
@@ -6951,14 +6951,14 @@ func (c FtTagvals) Index(index string) FtTagvalsIndex {
 	return (FtTagvalsIndex)(c)
 }
 
-type FtTagvalsFieldName Completed
+type FtTagvalsFieldName Incomplete
 
 func (c FtTagvalsFieldName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtTagvalsIndex Completed
+type FtTagvalsIndex Incomplete
 
 func (c FtTagvalsIndex) FieldName(fieldName string) FtTagvalsFieldName {
 	c.cs.s = append(c.cs.s, fieldName)

--- a/internal/cmds/gen_sentinel.go
+++ b/internal/cmds/gen_sentinel.go
@@ -2,7 +2,7 @@
 
 package cmds
 
-type SentinelFailover Completed
+type SentinelFailover Incomplete
 
 func (b Builder) SentinelFailover() (c SentinelFailover) {
 	c = SentinelFailover{cs: get(), ks: b.ks}
@@ -15,14 +15,14 @@ func (c SentinelFailover) Master(master string) SentinelFailoverMaster {
 	return (SentinelFailoverMaster)(c)
 }
 
-type SentinelFailoverMaster Completed
+type SentinelFailoverMaster Incomplete
 
 func (c SentinelFailoverMaster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SentinelGetMasterAddrByName Completed
+type SentinelGetMasterAddrByName Incomplete
 
 func (b Builder) SentinelGetMasterAddrByName() (c SentinelGetMasterAddrByName) {
 	c = SentinelGetMasterAddrByName{cs: get(), ks: b.ks}
@@ -35,14 +35,14 @@ func (c SentinelGetMasterAddrByName) Master(master string) SentinelGetMasterAddr
 	return (SentinelGetMasterAddrByNameMaster)(c)
 }
 
-type SentinelGetMasterAddrByNameMaster Completed
+type SentinelGetMasterAddrByNameMaster Incomplete
 
 func (c SentinelGetMasterAddrByNameMaster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SentinelReplicas Completed
+type SentinelReplicas Incomplete
 
 func (b Builder) SentinelReplicas() (c SentinelReplicas) {
 	c = SentinelReplicas{cs: get(), ks: b.ks}
@@ -55,14 +55,14 @@ func (c SentinelReplicas) Master(master string) SentinelReplicasMaster {
 	return (SentinelReplicasMaster)(c)
 }
 
-type SentinelReplicasMaster Completed
+type SentinelReplicasMaster Incomplete
 
 func (c SentinelReplicasMaster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SentinelSentinels Completed
+type SentinelSentinels Incomplete
 
 func (b Builder) SentinelSentinels() (c SentinelSentinels) {
 	c = SentinelSentinels{cs: get(), ks: b.ks}
@@ -75,9 +75,9 @@ func (c SentinelSentinels) Master(master string) SentinelSentinelsMaster {
 	return (SentinelSentinelsMaster)(c)
 }
 
-type SentinelSentinelsMaster Completed
+type SentinelSentinelsMaster Incomplete
 
 func (c SentinelSentinelsMaster) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_server.go
+++ b/internal/cmds/gen_server.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type AclCat Completed
+type AclCat Incomplete
 
 func (b Builder) AclCat() (c AclCat) {
 	c = AclCat{cs: get(), ks: b.ks}
@@ -19,17 +19,17 @@ func (c AclCat) Categoryname(categoryname string) AclCatCategoryname {
 
 func (c AclCat) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclCatCategoryname Completed
+type AclCatCategoryname Incomplete
 
 func (c AclCatCategoryname) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclDeluser Completed
+type AclDeluser Incomplete
 
 func (b Builder) AclDeluser() (c AclDeluser) {
 	c = AclDeluser{cs: get(), ks: b.ks}
@@ -42,7 +42,7 @@ func (c AclDeluser) Username(username ...string) AclDeluserUsername {
 	return (AclDeluserUsername)(c)
 }
 
-type AclDeluserUsername Completed
+type AclDeluserUsername Incomplete
 
 func (c AclDeluserUsername) Username(username ...string) AclDeluserUsername {
 	c.cs.s = append(c.cs.s, username...)
@@ -51,10 +51,10 @@ func (c AclDeluserUsername) Username(username ...string) AclDeluserUsername {
 
 func (c AclDeluserUsername) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclDryrun Completed
+type AclDryrun Incomplete
 
 func (b Builder) AclDryrun() (c AclDryrun) {
 	c = AclDryrun{cs: get(), ks: b.ks}
@@ -67,7 +67,7 @@ func (c AclDryrun) Username(username string) AclDryrunUsername {
 	return (AclDryrunUsername)(c)
 }
 
-type AclDryrunArg Completed
+type AclDryrunArg Incomplete
 
 func (c AclDryrunArg) Arg(arg ...string) AclDryrunArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -76,10 +76,10 @@ func (c AclDryrunArg) Arg(arg ...string) AclDryrunArg {
 
 func (c AclDryrunArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclDryrunCommand Completed
+type AclDryrunCommand Incomplete
 
 func (c AclDryrunCommand) Arg(arg ...string) AclDryrunArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -88,17 +88,17 @@ func (c AclDryrunCommand) Arg(arg ...string) AclDryrunArg {
 
 func (c AclDryrunCommand) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclDryrunUsername Completed
+type AclDryrunUsername Incomplete
 
 func (c AclDryrunUsername) Command(command string) AclDryrunCommand {
 	c.cs.s = append(c.cs.s, command)
 	return (AclDryrunCommand)(c)
 }
 
-type AclGenpass Completed
+type AclGenpass Incomplete
 
 func (b Builder) AclGenpass() (c AclGenpass) {
 	c = AclGenpass{cs: get(), ks: b.ks}
@@ -113,17 +113,17 @@ func (c AclGenpass) Bits(bits int64) AclGenpassBits {
 
 func (c AclGenpass) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclGenpassBits Completed
+type AclGenpassBits Incomplete
 
 func (c AclGenpassBits) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclGetuser Completed
+type AclGetuser Incomplete
 
 func (b Builder) AclGetuser() (c AclGetuser) {
 	c = AclGetuser{cs: get(), ks: b.ks}
@@ -136,14 +136,14 @@ func (c AclGetuser) Username(username string) AclGetuserUsername {
 	return (AclGetuserUsername)(c)
 }
 
-type AclGetuserUsername Completed
+type AclGetuserUsername Incomplete
 
 func (c AclGetuserUsername) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclHelp Completed
+type AclHelp Incomplete
 
 func (b Builder) AclHelp() (c AclHelp) {
 	c = AclHelp{cs: get(), ks: b.ks}
@@ -153,10 +153,10 @@ func (b Builder) AclHelp() (c AclHelp) {
 
 func (c AclHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclList Completed
+type AclList Incomplete
 
 func (b Builder) AclList() (c AclList) {
 	c = AclList{cs: get(), ks: b.ks}
@@ -166,10 +166,10 @@ func (b Builder) AclList() (c AclList) {
 
 func (c AclList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclLoad Completed
+type AclLoad Incomplete
 
 func (b Builder) AclLoad() (c AclLoad) {
 	c = AclLoad{cs: get(), ks: b.ks}
@@ -179,10 +179,10 @@ func (b Builder) AclLoad() (c AclLoad) {
 
 func (c AclLoad) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclLog Completed
+type AclLog Incomplete
 
 func (b Builder) AclLog() (c AclLog) {
 	c = AclLog{cs: get(), ks: b.ks}
@@ -200,7 +200,7 @@ func (c AclLog) Reset() AclLogCountReset {
 	return (AclLogCountReset)(c)
 }
 
-type AclLogCountCount Completed
+type AclLogCountCount Incomplete
 
 func (c AclLogCountCount) Reset() AclLogCountReset {
 	c.cs.s = append(c.cs.s, "RESET")
@@ -209,17 +209,17 @@ func (c AclLogCountCount) Reset() AclLogCountReset {
 
 func (c AclLogCountCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclLogCountReset Completed
+type AclLogCountReset Incomplete
 
 func (c AclLogCountReset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclSave Completed
+type AclSave Incomplete
 
 func (b Builder) AclSave() (c AclSave) {
 	c = AclSave{cs: get(), ks: b.ks}
@@ -229,10 +229,10 @@ func (b Builder) AclSave() (c AclSave) {
 
 func (c AclSave) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclSetuser Completed
+type AclSetuser Incomplete
 
 func (b Builder) AclSetuser() (c AclSetuser) {
 	c = AclSetuser{cs: get(), ks: b.ks}
@@ -245,7 +245,7 @@ func (c AclSetuser) Username(username string) AclSetuserUsername {
 	return (AclSetuserUsername)(c)
 }
 
-type AclSetuserRule Completed
+type AclSetuserRule Incomplete
 
 func (c AclSetuserRule) Rule(rule ...string) AclSetuserRule {
 	c.cs.s = append(c.cs.s, rule...)
@@ -254,10 +254,10 @@ func (c AclSetuserRule) Rule(rule ...string) AclSetuserRule {
 
 func (c AclSetuserRule) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclSetuserUsername Completed
+type AclSetuserUsername Incomplete
 
 func (c AclSetuserUsername) Rule(rule ...string) AclSetuserRule {
 	c.cs.s = append(c.cs.s, rule...)
@@ -266,10 +266,10 @@ func (c AclSetuserUsername) Rule(rule ...string) AclSetuserRule {
 
 func (c AclSetuserUsername) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclUsers Completed
+type AclUsers Incomplete
 
 func (b Builder) AclUsers() (c AclUsers) {
 	c = AclUsers{cs: get(), ks: b.ks}
@@ -279,10 +279,10 @@ func (b Builder) AclUsers() (c AclUsers) {
 
 func (c AclUsers) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AclWhoami Completed
+type AclWhoami Incomplete
 
 func (b Builder) AclWhoami() (c AclWhoami) {
 	c = AclWhoami{cs: get(), ks: b.ks}
@@ -292,10 +292,10 @@ func (b Builder) AclWhoami() (c AclWhoami) {
 
 func (c AclWhoami) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Bgrewriteaof Completed
+type Bgrewriteaof Incomplete
 
 func (b Builder) Bgrewriteaof() (c Bgrewriteaof) {
 	c = Bgrewriteaof{cs: get(), ks: b.ks}
@@ -305,10 +305,10 @@ func (b Builder) Bgrewriteaof() (c Bgrewriteaof) {
 
 func (c Bgrewriteaof) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Bgsave Completed
+type Bgsave Incomplete
 
 func (b Builder) Bgsave() (c Bgsave) {
 	c = Bgsave{cs: get(), ks: b.ks}
@@ -323,17 +323,17 @@ func (c Bgsave) Schedule() BgsaveSchedule {
 
 func (c Bgsave) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BgsaveSchedule Completed
+type BgsaveSchedule Incomplete
 
 func (c BgsaveSchedule) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Command Completed
+type Command Incomplete
 
 func (b Builder) Command() (c Command) {
 	c = Command{cs: get(), ks: b.ks}
@@ -343,10 +343,10 @@ func (b Builder) Command() (c Command) {
 
 func (c Command) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandCount Completed
+type CommandCount Incomplete
 
 func (b Builder) CommandCount() (c CommandCount) {
 	c = CommandCount{cs: get(), ks: b.ks}
@@ -356,10 +356,10 @@ func (b Builder) CommandCount() (c CommandCount) {
 
 func (c CommandCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandDocs Completed
+type CommandDocs Incomplete
 
 func (b Builder) CommandDocs() (c CommandDocs) {
 	c = CommandDocs{cs: get(), ks: b.ks}
@@ -374,10 +374,10 @@ func (c CommandDocs) CommandName(commandName ...string) CommandDocsCommandName {
 
 func (c CommandDocs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandDocsCommandName Completed
+type CommandDocsCommandName Incomplete
 
 func (c CommandDocsCommandName) CommandName(commandName ...string) CommandDocsCommandName {
 	c.cs.s = append(c.cs.s, commandName...)
@@ -386,10 +386,10 @@ func (c CommandDocsCommandName) CommandName(commandName ...string) CommandDocsCo
 
 func (c CommandDocsCommandName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandGetkeys Completed
+type CommandGetkeys Incomplete
 
 func (b Builder) CommandGetkeys() (c CommandGetkeys) {
 	c = CommandGetkeys{cs: get(), ks: b.ks}
@@ -402,7 +402,7 @@ func (c CommandGetkeys) Command(command string) CommandGetkeysCommand {
 	return (CommandGetkeysCommand)(c)
 }
 
-type CommandGetkeysArg Completed
+type CommandGetkeysArg Incomplete
 
 func (c CommandGetkeysArg) Arg(arg ...string) CommandGetkeysArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -411,10 +411,10 @@ func (c CommandGetkeysArg) Arg(arg ...string) CommandGetkeysArg {
 
 func (c CommandGetkeysArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandGetkeysCommand Completed
+type CommandGetkeysCommand Incomplete
 
 func (c CommandGetkeysCommand) Arg(arg ...string) CommandGetkeysArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -423,10 +423,10 @@ func (c CommandGetkeysCommand) Arg(arg ...string) CommandGetkeysArg {
 
 func (c CommandGetkeysCommand) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandGetkeysandflags Completed
+type CommandGetkeysandflags Incomplete
 
 func (b Builder) CommandGetkeysandflags() (c CommandGetkeysandflags) {
 	c = CommandGetkeysandflags{cs: get(), ks: b.ks}
@@ -439,7 +439,7 @@ func (c CommandGetkeysandflags) Command(command string) CommandGetkeysandflagsCo
 	return (CommandGetkeysandflagsCommand)(c)
 }
 
-type CommandGetkeysandflagsArg Completed
+type CommandGetkeysandflagsArg Incomplete
 
 func (c CommandGetkeysandflagsArg) Arg(arg ...string) CommandGetkeysandflagsArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -448,10 +448,10 @@ func (c CommandGetkeysandflagsArg) Arg(arg ...string) CommandGetkeysandflagsArg 
 
 func (c CommandGetkeysandflagsArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandGetkeysandflagsCommand Completed
+type CommandGetkeysandflagsCommand Incomplete
 
 func (c CommandGetkeysandflagsCommand) Arg(arg ...string) CommandGetkeysandflagsArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -460,10 +460,10 @@ func (c CommandGetkeysandflagsCommand) Arg(arg ...string) CommandGetkeysandflags
 
 func (c CommandGetkeysandflagsCommand) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandInfo Completed
+type CommandInfo Incomplete
 
 func (b Builder) CommandInfo() (c CommandInfo) {
 	c = CommandInfo{cs: get(), ks: b.ks}
@@ -478,10 +478,10 @@ func (c CommandInfo) CommandName(commandName ...string) CommandInfoCommandName {
 
 func (c CommandInfo) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandInfoCommandName Completed
+type CommandInfoCommandName Incomplete
 
 func (c CommandInfoCommandName) CommandName(commandName ...string) CommandInfoCommandName {
 	c.cs.s = append(c.cs.s, commandName...)
@@ -490,10 +490,10 @@ func (c CommandInfoCommandName) CommandName(commandName ...string) CommandInfoCo
 
 func (c CommandInfoCommandName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandList Completed
+type CommandList Incomplete
 
 func (b Builder) CommandList() (c CommandList) {
 	c = CommandList{cs: get(), ks: b.ks}
@@ -518,31 +518,31 @@ func (c CommandList) FilterbyPatternPattern(pattern string) CommandListFilterbyP
 
 func (c CommandList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandListFilterbyAclcatCategory Completed
+type CommandListFilterbyAclcatCategory Incomplete
 
 func (c CommandListFilterbyAclcatCategory) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandListFilterbyModuleName Completed
+type CommandListFilterbyModuleName Incomplete
 
 func (c CommandListFilterbyModuleName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type CommandListFilterbyPatternPattern Completed
+type CommandListFilterbyPatternPattern Incomplete
 
 func (c CommandListFilterbyPatternPattern) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ConfigGet Completed
+type ConfigGet Incomplete
 
 func (b Builder) ConfigGet() (c ConfigGet) {
 	c = ConfigGet{cs: get(), ks: b.ks}
@@ -555,7 +555,7 @@ func (c ConfigGet) Parameter(parameter ...string) ConfigGetParameter {
 	return (ConfigGetParameter)(c)
 }
 
-type ConfigGetParameter Completed
+type ConfigGetParameter Incomplete
 
 func (c ConfigGetParameter) Parameter(parameter ...string) ConfigGetParameter {
 	c.cs.s = append(c.cs.s, parameter...)
@@ -564,10 +564,10 @@ func (c ConfigGetParameter) Parameter(parameter ...string) ConfigGetParameter {
 
 func (c ConfigGetParameter) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ConfigResetstat Completed
+type ConfigResetstat Incomplete
 
 func (b Builder) ConfigResetstat() (c ConfigResetstat) {
 	c = ConfigResetstat{cs: get(), ks: b.ks}
@@ -577,10 +577,10 @@ func (b Builder) ConfigResetstat() (c ConfigResetstat) {
 
 func (c ConfigResetstat) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ConfigRewrite Completed
+type ConfigRewrite Incomplete
 
 func (b Builder) ConfigRewrite() (c ConfigRewrite) {
 	c = ConfigRewrite{cs: get(), ks: b.ks}
@@ -590,10 +590,10 @@ func (b Builder) ConfigRewrite() (c ConfigRewrite) {
 
 func (c ConfigRewrite) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ConfigSet Completed
+type ConfigSet Incomplete
 
 func (b Builder) ConfigSet() (c ConfigSet) {
 	c = ConfigSet{cs: get(), ks: b.ks}
@@ -605,7 +605,7 @@ func (c ConfigSet) ParameterValue() ConfigSetParameterValue {
 	return (ConfigSetParameterValue)(c)
 }
 
-type ConfigSetParameterValue Completed
+type ConfigSetParameterValue Incomplete
 
 func (c ConfigSetParameterValue) ParameterValue(parameter string, value string) ConfigSetParameterValue {
 	c.cs.s = append(c.cs.s, parameter, value)
@@ -614,23 +614,23 @@ func (c ConfigSetParameterValue) ParameterValue(parameter string, value string) 
 
 func (c ConfigSetParameterValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Dbsize Completed
+type Dbsize Incomplete
 
 func (b Builder) Dbsize() (c Dbsize) {
-	c = Dbsize{cs: get(), ks: b.ks, cf: readonly}
+	c = Dbsize{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "DBSIZE")
 	return c
 }
 
 func (c Dbsize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type DebugObject Completed
+type DebugObject Incomplete
 
 func (b Builder) DebugObject() (c DebugObject) {
 	c = DebugObject{cs: get(), ks: b.ks}
@@ -648,14 +648,14 @@ func (c DebugObject) Key(key string) DebugObjectKey {
 	return (DebugObjectKey)(c)
 }
 
-type DebugObjectKey Completed
+type DebugObjectKey Incomplete
 
 func (c DebugObjectKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type DebugSegfault Completed
+type DebugSegfault Incomplete
 
 func (b Builder) DebugSegfault() (c DebugSegfault) {
 	c = DebugSegfault{cs: get(), ks: b.ks}
@@ -665,10 +665,10 @@ func (b Builder) DebugSegfault() (c DebugSegfault) {
 
 func (c DebugSegfault) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Failover Completed
+type Failover Incomplete
 
 func (b Builder) Failover() (c Failover) {
 	c = Failover{cs: get(), ks: b.ks}
@@ -693,10 +693,10 @@ func (c Failover) Timeout(milliseconds int64) FailoverTimeout {
 
 func (c Failover) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FailoverAbort Completed
+type FailoverAbort Incomplete
 
 func (c FailoverAbort) Timeout(milliseconds int64) FailoverTimeout {
 	c.cs.s = append(c.cs.s, "TIMEOUT", strconv.FormatInt(milliseconds, 10))
@@ -705,10 +705,10 @@ func (c FailoverAbort) Timeout(milliseconds int64) FailoverTimeout {
 
 func (c FailoverAbort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FailoverTargetForce Completed
+type FailoverTargetForce Incomplete
 
 func (c FailoverTargetForce) Abort() FailoverAbort {
 	c.cs.s = append(c.cs.s, "ABORT")
@@ -722,17 +722,17 @@ func (c FailoverTargetForce) Timeout(milliseconds int64) FailoverTimeout {
 
 func (c FailoverTargetForce) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FailoverTargetHost Completed
+type FailoverTargetHost Incomplete
 
 func (c FailoverTargetHost) Port(port int64) FailoverTargetPort {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(port, 10))
 	return (FailoverTargetPort)(c)
 }
 
-type FailoverTargetPort Completed
+type FailoverTargetPort Incomplete
 
 func (c FailoverTargetPort) Force() FailoverTargetForce {
 	c.cs.s = append(c.cs.s, "FORCE")
@@ -751,24 +751,24 @@ func (c FailoverTargetPort) Timeout(milliseconds int64) FailoverTimeout {
 
 func (c FailoverTargetPort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FailoverTargetTo Completed
+type FailoverTargetTo Incomplete
 
 func (c FailoverTargetTo) Host(host string) FailoverTargetHost {
 	c.cs.s = append(c.cs.s, host)
 	return (FailoverTargetHost)(c)
 }
 
-type FailoverTimeout Completed
+type FailoverTimeout Incomplete
 
 func (c FailoverTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Flushall Completed
+type Flushall Incomplete
 
 func (b Builder) Flushall() (c Flushall) {
 	c = Flushall{cs: get(), ks: b.ks}
@@ -788,24 +788,24 @@ func (c Flushall) Sync() FlushallAsyncSync {
 
 func (c Flushall) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FlushallAsync Completed
+type FlushallAsync Incomplete
 
 func (c FlushallAsync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FlushallAsyncSync Completed
+type FlushallAsyncSync Incomplete
 
 func (c FlushallAsyncSync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Flushdb Completed
+type Flushdb Incomplete
 
 func (b Builder) Flushdb() (c Flushdb) {
 	c = Flushdb{cs: get(), ks: b.ks}
@@ -825,24 +825,24 @@ func (c Flushdb) Sync() FlushdbAsyncSync {
 
 func (c Flushdb) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FlushdbAsync Completed
+type FlushdbAsync Incomplete
 
 func (c FlushdbAsync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FlushdbAsyncSync Completed
+type FlushdbAsyncSync Incomplete
 
 func (c FlushdbAsyncSync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Info Completed
+type Info Incomplete
 
 func (b Builder) Info() (c Info) {
 	c = Info{cs: get(), ks: b.ks}
@@ -857,10 +857,10 @@ func (c Info) Section(section ...string) InfoSection {
 
 func (c Info) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type InfoSection Completed
+type InfoSection Incomplete
 
 func (c InfoSection) Section(section ...string) InfoSection {
 	c.cs.s = append(c.cs.s, section...)
@@ -869,10 +869,10 @@ func (c InfoSection) Section(section ...string) InfoSection {
 
 func (c InfoSection) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lastsave Completed
+type Lastsave Incomplete
 
 func (b Builder) Lastsave() (c Lastsave) {
 	c = Lastsave{cs: get(), ks: b.ks}
@@ -882,10 +882,10 @@ func (b Builder) Lastsave() (c Lastsave) {
 
 func (c Lastsave) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyDoctor Completed
+type LatencyDoctor Incomplete
 
 func (b Builder) LatencyDoctor() (c LatencyDoctor) {
 	c = LatencyDoctor{cs: get(), ks: b.ks}
@@ -895,10 +895,10 @@ func (b Builder) LatencyDoctor() (c LatencyDoctor) {
 
 func (c LatencyDoctor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyGraph Completed
+type LatencyGraph Incomplete
 
 func (b Builder) LatencyGraph() (c LatencyGraph) {
 	c = LatencyGraph{cs: get(), ks: b.ks}
@@ -911,14 +911,14 @@ func (c LatencyGraph) Event(event string) LatencyGraphEvent {
 	return (LatencyGraphEvent)(c)
 }
 
-type LatencyGraphEvent Completed
+type LatencyGraphEvent Incomplete
 
 func (c LatencyGraphEvent) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyHelp Completed
+type LatencyHelp Incomplete
 
 func (b Builder) LatencyHelp() (c LatencyHelp) {
 	c = LatencyHelp{cs: get(), ks: b.ks}
@@ -928,10 +928,10 @@ func (b Builder) LatencyHelp() (c LatencyHelp) {
 
 func (c LatencyHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyHistogram Completed
+type LatencyHistogram Incomplete
 
 func (b Builder) LatencyHistogram() (c LatencyHistogram) {
 	c = LatencyHistogram{cs: get(), ks: b.ks}
@@ -946,10 +946,10 @@ func (c LatencyHistogram) Command(command ...string) LatencyHistogramCommand {
 
 func (c LatencyHistogram) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyHistogramCommand Completed
+type LatencyHistogramCommand Incomplete
 
 func (c LatencyHistogramCommand) Command(command ...string) LatencyHistogramCommand {
 	c.cs.s = append(c.cs.s, command...)
@@ -958,10 +958,10 @@ func (c LatencyHistogramCommand) Command(command ...string) LatencyHistogramComm
 
 func (c LatencyHistogramCommand) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyHistory Completed
+type LatencyHistory Incomplete
 
 func (b Builder) LatencyHistory() (c LatencyHistory) {
 	c = LatencyHistory{cs: get(), ks: b.ks}
@@ -974,14 +974,14 @@ func (c LatencyHistory) Event(event string) LatencyHistoryEvent {
 	return (LatencyHistoryEvent)(c)
 }
 
-type LatencyHistoryEvent Completed
+type LatencyHistoryEvent Incomplete
 
 func (c LatencyHistoryEvent) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyLatest Completed
+type LatencyLatest Incomplete
 
 func (b Builder) LatencyLatest() (c LatencyLatest) {
 	c = LatencyLatest{cs: get(), ks: b.ks}
@@ -991,10 +991,10 @@ func (b Builder) LatencyLatest() (c LatencyLatest) {
 
 func (c LatencyLatest) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyReset Completed
+type LatencyReset Incomplete
 
 func (b Builder) LatencyReset() (c LatencyReset) {
 	c = LatencyReset{cs: get(), ks: b.ks}
@@ -1009,10 +1009,10 @@ func (c LatencyReset) Event(event ...string) LatencyResetEvent {
 
 func (c LatencyReset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LatencyResetEvent Completed
+type LatencyResetEvent Incomplete
 
 func (c LatencyResetEvent) Event(event ...string) LatencyResetEvent {
 	c.cs.s = append(c.cs.s, event...)
@@ -1021,13 +1021,13 @@ func (c LatencyResetEvent) Event(event ...string) LatencyResetEvent {
 
 func (c LatencyResetEvent) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Lolwut Completed
+type Lolwut Incomplete
 
 func (b Builder) Lolwut() (c Lolwut) {
-	c = Lolwut{cs: get(), ks: b.ks, cf: readonly}
+	c = Lolwut{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "LOLWUT")
 	return c
 }
@@ -1039,30 +1039,30 @@ func (c Lolwut) Version(version int64) LolwutVersion {
 
 func (c Lolwut) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LolwutVersion Completed
+type LolwutVersion Incomplete
 
 func (c LolwutVersion) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryDoctor Completed
+type MemoryDoctor Incomplete
 
 func (b Builder) MemoryDoctor() (c MemoryDoctor) {
-	c = MemoryDoctor{cs: get(), ks: b.ks, cf: readonly}
+	c = MemoryDoctor{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "MEMORY", "DOCTOR")
 	return c
 }
 
 func (c MemoryDoctor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryHelp Completed
+type MemoryHelp Incomplete
 
 func (b Builder) MemoryHelp() (c MemoryHelp) {
 	c = MemoryHelp{cs: get(), ks: b.ks}
@@ -1072,23 +1072,23 @@ func (b Builder) MemoryHelp() (c MemoryHelp) {
 
 func (c MemoryHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryMallocStats Completed
+type MemoryMallocStats Incomplete
 
 func (b Builder) MemoryMallocStats() (c MemoryMallocStats) {
-	c = MemoryMallocStats{cs: get(), ks: b.ks, cf: readonly}
+	c = MemoryMallocStats{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "MEMORY", "MALLOC-STATS")
 	return c
 }
 
 func (c MemoryMallocStats) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryPurge Completed
+type MemoryPurge Incomplete
 
 func (b Builder) MemoryPurge() (c MemoryPurge) {
 	c = MemoryPurge{cs: get(), ks: b.ks}
@@ -1098,26 +1098,26 @@ func (b Builder) MemoryPurge() (c MemoryPurge) {
 
 func (c MemoryPurge) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryStats Completed
+type MemoryStats Incomplete
 
 func (b Builder) MemoryStats() (c MemoryStats) {
-	c = MemoryStats{cs: get(), ks: b.ks, cf: readonly}
+	c = MemoryStats{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "MEMORY", "STATS")
 	return c
 }
 
 func (c MemoryStats) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryUsage Completed
+type MemoryUsage Incomplete
 
 func (b Builder) MemoryUsage() (c MemoryUsage) {
-	c = MemoryUsage{cs: get(), ks: b.ks, cf: readonly}
+	c = MemoryUsage{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "MEMORY", "USAGE")
 	return c
 }
@@ -1132,7 +1132,7 @@ func (c MemoryUsage) Key(key string) MemoryUsageKey {
 	return (MemoryUsageKey)(c)
 }
 
-type MemoryUsageKey Completed
+type MemoryUsageKey Incomplete
 
 func (c MemoryUsageKey) Samples(count int64) MemoryUsageSamples {
 	c.cs.s = append(c.cs.s, "SAMPLES", strconv.FormatInt(count, 10))
@@ -1141,17 +1141,17 @@ func (c MemoryUsageKey) Samples(count int64) MemoryUsageSamples {
 
 func (c MemoryUsageKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type MemoryUsageSamples Completed
+type MemoryUsageSamples Incomplete
 
 func (c MemoryUsageSamples) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleList Completed
+type ModuleList Incomplete
 
 func (b Builder) ModuleList() (c ModuleList) {
 	c = ModuleList{cs: get(), ks: b.ks}
@@ -1161,10 +1161,10 @@ func (b Builder) ModuleList() (c ModuleList) {
 
 func (c ModuleList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleLoad Completed
+type ModuleLoad Incomplete
 
 func (b Builder) ModuleLoad() (c ModuleLoad) {
 	c = ModuleLoad{cs: get(), ks: b.ks}
@@ -1177,7 +1177,7 @@ func (c ModuleLoad) Path(path string) ModuleLoadPath {
 	return (ModuleLoadPath)(c)
 }
 
-type ModuleLoadArg Completed
+type ModuleLoadArg Incomplete
 
 func (c ModuleLoadArg) Arg(arg ...string) ModuleLoadArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -1186,10 +1186,10 @@ func (c ModuleLoadArg) Arg(arg ...string) ModuleLoadArg {
 
 func (c ModuleLoadArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleLoadPath Completed
+type ModuleLoadPath Incomplete
 
 func (c ModuleLoadPath) Arg(arg ...string) ModuleLoadArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -1198,10 +1198,10 @@ func (c ModuleLoadPath) Arg(arg ...string) ModuleLoadArg {
 
 func (c ModuleLoadPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleLoadex Completed
+type ModuleLoadex Incomplete
 
 func (b Builder) ModuleLoadex() (c ModuleLoadex) {
 	c = ModuleLoadex{cs: get(), ks: b.ks}
@@ -1214,7 +1214,7 @@ func (c ModuleLoadex) Path(path string) ModuleLoadexPath {
 	return (ModuleLoadexPath)(c)
 }
 
-type ModuleLoadexArgs Completed
+type ModuleLoadexArgs Incomplete
 
 func (c ModuleLoadexArgs) Args(args ...string) ModuleLoadexArgs {
 	c.cs.s = append(c.cs.s, "ARGS")
@@ -1224,10 +1224,10 @@ func (c ModuleLoadexArgs) Args(args ...string) ModuleLoadexArgs {
 
 func (c ModuleLoadexArgs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleLoadexConfig Completed
+type ModuleLoadexConfig Incomplete
 
 func (c ModuleLoadexConfig) Config(name string, value string) ModuleLoadexConfig {
 	c.cs.s = append(c.cs.s, "CONFIG", name, value)
@@ -1242,10 +1242,10 @@ func (c ModuleLoadexConfig) Args(args ...string) ModuleLoadexArgs {
 
 func (c ModuleLoadexConfig) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleLoadexPath Completed
+type ModuleLoadexPath Incomplete
 
 func (c ModuleLoadexPath) Config() ModuleLoadexConfig {
 	return (ModuleLoadexConfig)(c)
@@ -1259,10 +1259,10 @@ func (c ModuleLoadexPath) Args(args ...string) ModuleLoadexArgs {
 
 func (c ModuleLoadexPath) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ModuleUnload Completed
+type ModuleUnload Incomplete
 
 func (b Builder) ModuleUnload() (c ModuleUnload) {
 	c = ModuleUnload{cs: get(), ks: b.ks}
@@ -1275,14 +1275,14 @@ func (c ModuleUnload) Name(name string) ModuleUnloadName {
 	return (ModuleUnloadName)(c)
 }
 
-type ModuleUnloadName Completed
+type ModuleUnloadName Incomplete
 
 func (c ModuleUnloadName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Monitor Completed
+type Monitor Incomplete
 
 func (b Builder) Monitor() (c Monitor) {
 	c = Monitor{cs: get(), ks: b.ks}
@@ -1292,10 +1292,10 @@ func (b Builder) Monitor() (c Monitor) {
 
 func (c Monitor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Psync Completed
+type Psync Incomplete
 
 func (b Builder) Psync() (c Psync) {
 	c = Psync{cs: get(), ks: b.ks}
@@ -1308,21 +1308,21 @@ func (c Psync) Replicationid(replicationid string) PsyncReplicationid {
 	return (PsyncReplicationid)(c)
 }
 
-type PsyncOffset Completed
+type PsyncOffset Incomplete
 
 func (c PsyncOffset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type PsyncReplicationid Completed
+type PsyncReplicationid Incomplete
 
 func (c PsyncReplicationid) Offset(offset int64) PsyncOffset {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(offset, 10))
 	return (PsyncOffset)(c)
 }
 
-type Replicaof Completed
+type Replicaof Incomplete
 
 func (b Builder) Replicaof() (c Replicaof) {
 	c = Replicaof{cs: get(), ks: b.ks}
@@ -1335,21 +1335,21 @@ func (c Replicaof) Host(host string) ReplicaofHost {
 	return (ReplicaofHost)(c)
 }
 
-type ReplicaofHost Completed
+type ReplicaofHost Incomplete
 
 func (c ReplicaofHost) Port(port int64) ReplicaofPort {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(port, 10))
 	return (ReplicaofPort)(c)
 }
 
-type ReplicaofPort Completed
+type ReplicaofPort Incomplete
 
 func (c ReplicaofPort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Role Completed
+type Role Incomplete
 
 func (b Builder) Role() (c Role) {
 	c = Role{cs: get(), ks: b.ks}
@@ -1359,10 +1359,10 @@ func (b Builder) Role() (c Role) {
 
 func (c Role) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Save Completed
+type Save Incomplete
 
 func (b Builder) Save() (c Save) {
 	c = Save{cs: get(), ks: b.ks}
@@ -1372,10 +1372,10 @@ func (b Builder) Save() (c Save) {
 
 func (c Save) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Shutdown Completed
+type Shutdown Incomplete
 
 func (b Builder) Shutdown() (c Shutdown) {
 	c = Shutdown{cs: get(), ks: b.ks}
@@ -1410,17 +1410,17 @@ func (c Shutdown) Abort() ShutdownAbort {
 
 func (c Shutdown) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ShutdownAbort Completed
+type ShutdownAbort Incomplete
 
 func (c ShutdownAbort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ShutdownForce Completed
+type ShutdownForce Incomplete
 
 func (c ShutdownForce) Abort() ShutdownAbort {
 	c.cs.s = append(c.cs.s, "ABORT")
@@ -1429,10 +1429,10 @@ func (c ShutdownForce) Abort() ShutdownAbort {
 
 func (c ShutdownForce) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ShutdownNow Completed
+type ShutdownNow Incomplete
 
 func (c ShutdownNow) Force() ShutdownForce {
 	c.cs.s = append(c.cs.s, "FORCE")
@@ -1446,10 +1446,10 @@ func (c ShutdownNow) Abort() ShutdownAbort {
 
 func (c ShutdownNow) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ShutdownSaveModeNosave Completed
+type ShutdownSaveModeNosave Incomplete
 
 func (c ShutdownSaveModeNosave) Now() ShutdownNow {
 	c.cs.s = append(c.cs.s, "NOW")
@@ -1468,10 +1468,10 @@ func (c ShutdownSaveModeNosave) Abort() ShutdownAbort {
 
 func (c ShutdownSaveModeNosave) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ShutdownSaveModeSave Completed
+type ShutdownSaveModeSave Incomplete
 
 func (c ShutdownSaveModeSave) Now() ShutdownNow {
 	c.cs.s = append(c.cs.s, "NOW")
@@ -1490,10 +1490,10 @@ func (c ShutdownSaveModeSave) Abort() ShutdownAbort {
 
 func (c ShutdownSaveModeSave) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Slaveof Completed
+type Slaveof Incomplete
 
 func (b Builder) Slaveof() (c Slaveof) {
 	c = Slaveof{cs: get(), ks: b.ks}
@@ -1506,24 +1506,24 @@ func (c Slaveof) Host(host string) SlaveofHost {
 	return (SlaveofHost)(c)
 }
 
-type SlaveofHost Completed
+type SlaveofHost Incomplete
 
 func (c SlaveofHost) Port(port int64) SlaveofPort {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(port, 10))
 	return (SlaveofPort)(c)
 }
 
-type SlaveofPort Completed
+type SlaveofPort Incomplete
 
 func (c SlaveofPort) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SlowlogGet Completed
+type SlowlogGet Incomplete
 
 func (b Builder) SlowlogGet() (c SlowlogGet) {
-	c = SlowlogGet{cs: get(), ks: b.ks, cf: readonly}
+	c = SlowlogGet{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SLOWLOG", "GET")
 	return c
 }
@@ -1535,43 +1535,43 @@ func (c SlowlogGet) Count(count int64) SlowlogGetCount {
 
 func (c SlowlogGet) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SlowlogGetCount Completed
+type SlowlogGetCount Incomplete
 
 func (c SlowlogGetCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SlowlogHelp Completed
+type SlowlogHelp Incomplete
 
 func (b Builder) SlowlogHelp() (c SlowlogHelp) {
-	c = SlowlogHelp{cs: get(), ks: b.ks, cf: readonly}
+	c = SlowlogHelp{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SLOWLOG", "HELP")
 	return c
 }
 
 func (c SlowlogHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SlowlogLen Completed
+type SlowlogLen Incomplete
 
 func (b Builder) SlowlogLen() (c SlowlogLen) {
-	c = SlowlogLen{cs: get(), ks: b.ks, cf: readonly}
+	c = SlowlogLen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SLOWLOG", "LEN")
 	return c
 }
 
 func (c SlowlogLen) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SlowlogReset Completed
+type SlowlogReset Incomplete
 
 func (b Builder) SlowlogReset() (c SlowlogReset) {
 	c = SlowlogReset{cs: get(), ks: b.ks}
@@ -1581,10 +1581,10 @@ func (b Builder) SlowlogReset() (c SlowlogReset) {
 
 func (c SlowlogReset) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Swapdb Completed
+type Swapdb Incomplete
 
 func (b Builder) Swapdb() (c Swapdb) {
 	c = Swapdb{cs: get(), ks: b.ks}
@@ -1597,21 +1597,21 @@ func (c Swapdb) Index1(index1 int64) SwapdbIndex1 {
 	return (SwapdbIndex1)(c)
 }
 
-type SwapdbIndex1 Completed
+type SwapdbIndex1 Incomplete
 
 func (c SwapdbIndex1) Index2(index2 int64) SwapdbIndex2 {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(index2, 10))
 	return (SwapdbIndex2)(c)
 }
 
-type SwapdbIndex2 Completed
+type SwapdbIndex2 Incomplete
 
 func (c SwapdbIndex2) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sync Completed
+type Sync Incomplete
 
 func (b Builder) Sync() (c Sync) {
 	c = Sync{cs: get(), ks: b.ks}
@@ -1621,10 +1621,10 @@ func (b Builder) Sync() (c Sync) {
 
 func (c Sync) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Time Completed
+type Time Incomplete
 
 func (b Builder) Time() (c Time) {
 	c = Time{cs: get(), ks: b.ks}
@@ -1634,5 +1634,5 @@ func (b Builder) Time() (c Time) {
 
 func (c Time) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_set.go
+++ b/internal/cmds/gen_set.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Sadd Completed
+type Sadd Incomplete
 
 func (b Builder) Sadd() (c Sadd) {
 	c = Sadd{cs: get(), ks: b.ks}
@@ -22,14 +22,14 @@ func (c Sadd) Key(key string) SaddKey {
 	return (SaddKey)(c)
 }
 
-type SaddKey Completed
+type SaddKey Incomplete
 
 func (c SaddKey) Member(member ...string) SaddMember {
 	c.cs.s = append(c.cs.s, member...)
 	return (SaddMember)(c)
 }
 
-type SaddMember Completed
+type SaddMember Incomplete
 
 func (c SaddMember) Member(member ...string) SaddMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -38,13 +38,13 @@ func (c SaddMember) Member(member ...string) SaddMember {
 
 func (c SaddMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Scard Completed
+type Scard Incomplete
 
 func (b Builder) Scard() (c Scard) {
-	c = Scard{cs: get(), ks: b.ks, cf: readonly}
+	c = Scard{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SCARD")
 	return c
 }
@@ -59,22 +59,22 @@ func (c Scard) Key(key string) ScardKey {
 	return (ScardKey)(c)
 }
 
-type ScardKey Completed
+type ScardKey Incomplete
 
 func (c ScardKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ScardKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sdiff Completed
+type Sdiff Incomplete
 
 func (b Builder) Sdiff() (c Sdiff) {
-	c = Sdiff{cs: get(), ks: b.ks, cf: readonly}
+	c = Sdiff{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SDIFF")
 	return c
 }
@@ -94,7 +94,7 @@ func (c Sdiff) Key(key ...string) SdiffKey {
 	return (SdiffKey)(c)
 }
 
-type SdiffKey Completed
+type SdiffKey Incomplete
 
 func (c SdiffKey) Key(key ...string) SdiffKey {
 	if c.ks&NoSlot == NoSlot {
@@ -113,10 +113,10 @@ func (c SdiffKey) Key(key ...string) SdiffKey {
 
 func (c SdiffKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sdiffstore Completed
+type Sdiffstore Incomplete
 
 func (b Builder) Sdiffstore() (c Sdiffstore) {
 	c = Sdiffstore{cs: get(), ks: b.ks}
@@ -134,7 +134,7 @@ func (c Sdiffstore) Destination(destination string) SdiffstoreDestination {
 	return (SdiffstoreDestination)(c)
 }
 
-type SdiffstoreDestination Completed
+type SdiffstoreDestination Incomplete
 
 func (c SdiffstoreDestination) Key(key ...string) SdiffstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -151,7 +151,7 @@ func (c SdiffstoreDestination) Key(key ...string) SdiffstoreKey {
 	return (SdiffstoreKey)(c)
 }
 
-type SdiffstoreKey Completed
+type SdiffstoreKey Incomplete
 
 func (c SdiffstoreKey) Key(key ...string) SdiffstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -170,13 +170,13 @@ func (c SdiffstoreKey) Key(key ...string) SdiffstoreKey {
 
 func (c SdiffstoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sinter Completed
+type Sinter Incomplete
 
 func (b Builder) Sinter() (c Sinter) {
-	c = Sinter{cs: get(), ks: b.ks, cf: readonly}
+	c = Sinter{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SINTER")
 	return c
 }
@@ -196,7 +196,7 @@ func (c Sinter) Key(key ...string) SinterKey {
 	return (SinterKey)(c)
 }
 
-type SinterKey Completed
+type SinterKey Incomplete
 
 func (c SinterKey) Key(key ...string) SinterKey {
 	if c.ks&NoSlot == NoSlot {
@@ -215,13 +215,13 @@ func (c SinterKey) Key(key ...string) SinterKey {
 
 func (c SinterKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sintercard Completed
+type Sintercard Incomplete
 
 func (b Builder) Sintercard() (c Sintercard) {
-	c = Sintercard{cs: get(), ks: b.ks, cf: readonly}
+	c = Sintercard{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SINTERCARD")
 	return c
 }
@@ -231,7 +231,7 @@ func (c Sintercard) Numkeys(numkeys int64) SintercardNumkeys {
 	return (SintercardNumkeys)(c)
 }
 
-type SintercardKey Completed
+type SintercardKey Incomplete
 
 func (c SintercardKey) Key(key ...string) SintercardKey {
 	if c.ks&NoSlot == NoSlot {
@@ -255,17 +255,17 @@ func (c SintercardKey) Limit(limit int64) SintercardLimit {
 
 func (c SintercardKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SintercardLimit Completed
+type SintercardLimit Incomplete
 
 func (c SintercardLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SintercardNumkeys Completed
+type SintercardNumkeys Incomplete
 
 func (c SintercardNumkeys) Key(key ...string) SintercardKey {
 	if c.ks&NoSlot == NoSlot {
@@ -282,7 +282,7 @@ func (c SintercardNumkeys) Key(key ...string) SintercardKey {
 	return (SintercardKey)(c)
 }
 
-type Sinterstore Completed
+type Sinterstore Incomplete
 
 func (b Builder) Sinterstore() (c Sinterstore) {
 	c = Sinterstore{cs: get(), ks: b.ks}
@@ -300,7 +300,7 @@ func (c Sinterstore) Destination(destination string) SinterstoreDestination {
 	return (SinterstoreDestination)(c)
 }
 
-type SinterstoreDestination Completed
+type SinterstoreDestination Incomplete
 
 func (c SinterstoreDestination) Key(key ...string) SinterstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -317,7 +317,7 @@ func (c SinterstoreDestination) Key(key ...string) SinterstoreKey {
 	return (SinterstoreKey)(c)
 }
 
-type SinterstoreKey Completed
+type SinterstoreKey Incomplete
 
 func (c SinterstoreKey) Key(key ...string) SinterstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -336,13 +336,13 @@ func (c SinterstoreKey) Key(key ...string) SinterstoreKey {
 
 func (c SinterstoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sismember Completed
+type Sismember Incomplete
 
 func (b Builder) Sismember() (c Sismember) {
-	c = Sismember{cs: get(), ks: b.ks, cf: readonly}
+	c = Sismember{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SISMEMBER")
 	return c
 }
@@ -357,29 +357,29 @@ func (c Sismember) Key(key string) SismemberKey {
 	return (SismemberKey)(c)
 }
 
-type SismemberKey Completed
+type SismemberKey Incomplete
 
 func (c SismemberKey) Member(member string) SismemberMember {
 	c.cs.s = append(c.cs.s, member)
 	return (SismemberMember)(c)
 }
 
-type SismemberMember Completed
+type SismemberMember Incomplete
 
 func (c SismemberMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SismemberMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Smembers Completed
+type Smembers Incomplete
 
 func (b Builder) Smembers() (c Smembers) {
-	c = Smembers{cs: get(), ks: b.ks, cf: readonly}
+	c = Smembers{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SMEMBERS")
 	return c
 }
@@ -394,22 +394,22 @@ func (c Smembers) Key(key string) SmembersKey {
 	return (SmembersKey)(c)
 }
 
-type SmembersKey Completed
+type SmembersKey Incomplete
 
 func (c SmembersKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SmembersKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Smismember Completed
+type Smismember Incomplete
 
 func (b Builder) Smismember() (c Smismember) {
-	c = Smismember{cs: get(), ks: b.ks, cf: readonly}
+	c = Smismember{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SMISMEMBER")
 	return c
 }
@@ -424,14 +424,14 @@ func (c Smismember) Key(key string) SmismemberKey {
 	return (SmismemberKey)(c)
 }
 
-type SmismemberKey Completed
+type SmismemberKey Incomplete
 
 func (c SmismemberKey) Member(member ...string) SmismemberMember {
 	c.cs.s = append(c.cs.s, member...)
 	return (SmismemberMember)(c)
 }
 
-type SmismemberMember Completed
+type SmismemberMember Incomplete
 
 func (c SmismemberMember) Member(member ...string) SmismemberMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -440,15 +440,15 @@ func (c SmismemberMember) Member(member ...string) SmismemberMember {
 
 func (c SmismemberMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c SmismemberMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Smove Completed
+type Smove Incomplete
 
 func (b Builder) Smove() (c Smove) {
 	c = Smove{cs: get(), ks: b.ks}
@@ -466,21 +466,21 @@ func (c Smove) Source(source string) SmoveSource {
 	return (SmoveSource)(c)
 }
 
-type SmoveDestination Completed
+type SmoveDestination Incomplete
 
 func (c SmoveDestination) Member(member string) SmoveMember {
 	c.cs.s = append(c.cs.s, member)
 	return (SmoveMember)(c)
 }
 
-type SmoveMember Completed
+type SmoveMember Incomplete
 
 func (c SmoveMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SmoveSource Completed
+type SmoveSource Incomplete
 
 func (c SmoveSource) Destination(destination string) SmoveDestination {
 	if c.ks&NoSlot == NoSlot {
@@ -492,7 +492,7 @@ func (c SmoveSource) Destination(destination string) SmoveDestination {
 	return (SmoveDestination)(c)
 }
 
-type Spop Completed
+type Spop Incomplete
 
 func (b Builder) Spop() (c Spop) {
 	c = Spop{cs: get(), ks: b.ks}
@@ -510,14 +510,14 @@ func (c Spop) Key(key string) SpopKey {
 	return (SpopKey)(c)
 }
 
-type SpopCount Completed
+type SpopCount Incomplete
 
 func (c SpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SpopKey Completed
+type SpopKey Incomplete
 
 func (c SpopKey) Count(count int64) SpopCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -526,13 +526,13 @@ func (c SpopKey) Count(count int64) SpopCount {
 
 func (c SpopKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Srandmember Completed
+type Srandmember Incomplete
 
 func (b Builder) Srandmember() (c Srandmember) {
-	c = Srandmember{cs: get(), ks: b.ks, cf: readonly}
+	c = Srandmember{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SRANDMEMBER")
 	return c
 }
@@ -547,14 +547,14 @@ func (c Srandmember) Key(key string) SrandmemberKey {
 	return (SrandmemberKey)(c)
 }
 
-type SrandmemberCount Completed
+type SrandmemberCount Incomplete
 
 func (c SrandmemberCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SrandmemberKey Completed
+type SrandmemberKey Incomplete
 
 func (c SrandmemberKey) Count(count int64) SrandmemberCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -563,10 +563,10 @@ func (c SrandmemberKey) Count(count int64) SrandmemberCount {
 
 func (c SrandmemberKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Srem Completed
+type Srem Incomplete
 
 func (b Builder) Srem() (c Srem) {
 	c = Srem{cs: get(), ks: b.ks}
@@ -584,14 +584,14 @@ func (c Srem) Key(key string) SremKey {
 	return (SremKey)(c)
 }
 
-type SremKey Completed
+type SremKey Incomplete
 
 func (c SremKey) Member(member ...string) SremMember {
 	c.cs.s = append(c.cs.s, member...)
 	return (SremMember)(c)
 }
 
-type SremMember Completed
+type SremMember Incomplete
 
 func (c SremMember) Member(member ...string) SremMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -600,13 +600,13 @@ func (c SremMember) Member(member ...string) SremMember {
 
 func (c SremMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sscan Completed
+type Sscan Incomplete
 
 func (b Builder) Sscan() (c Sscan) {
-	c = Sscan{cs: get(), ks: b.ks, cf: readonly}
+	c = Sscan{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SSCAN")
 	return c
 }
@@ -621,14 +621,14 @@ func (c Sscan) Key(key string) SscanKey {
 	return (SscanKey)(c)
 }
 
-type SscanCount Completed
+type SscanCount Incomplete
 
 func (c SscanCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SscanCursor Completed
+type SscanCursor Incomplete
 
 func (c SscanCursor) Match(pattern string) SscanMatch {
 	c.cs.s = append(c.cs.s, "MATCH", pattern)
@@ -642,17 +642,17 @@ func (c SscanCursor) Count(count int64) SscanCount {
 
 func (c SscanCursor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SscanKey Completed
+type SscanKey Incomplete
 
 func (c SscanKey) Cursor(cursor uint64) SscanCursor {
 	c.cs.s = append(c.cs.s, strconv.FormatUint(cursor, 10))
 	return (SscanCursor)(c)
 }
 
-type SscanMatch Completed
+type SscanMatch Incomplete
 
 func (c SscanMatch) Count(count int64) SscanCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -661,13 +661,13 @@ func (c SscanMatch) Count(count int64) SscanCount {
 
 func (c SscanMatch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sunion Completed
+type Sunion Incomplete
 
 func (b Builder) Sunion() (c Sunion) {
-	c = Sunion{cs: get(), ks: b.ks, cf: readonly}
+	c = Sunion{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "SUNION")
 	return c
 }
@@ -687,7 +687,7 @@ func (c Sunion) Key(key ...string) SunionKey {
 	return (SunionKey)(c)
 }
 
-type SunionKey Completed
+type SunionKey Incomplete
 
 func (c SunionKey) Key(key ...string) SunionKey {
 	if c.ks&NoSlot == NoSlot {
@@ -706,10 +706,10 @@ func (c SunionKey) Key(key ...string) SunionKey {
 
 func (c SunionKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Sunionstore Completed
+type Sunionstore Incomplete
 
 func (b Builder) Sunionstore() (c Sunionstore) {
 	c = Sunionstore{cs: get(), ks: b.ks}
@@ -727,7 +727,7 @@ func (c Sunionstore) Destination(destination string) SunionstoreDestination {
 	return (SunionstoreDestination)(c)
 }
 
-type SunionstoreDestination Completed
+type SunionstoreDestination Incomplete
 
 func (c SunionstoreDestination) Key(key ...string) SunionstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -744,7 +744,7 @@ func (c SunionstoreDestination) Key(key ...string) SunionstoreKey {
 	return (SunionstoreKey)(c)
 }
 
-type SunionstoreKey Completed
+type SunionstoreKey Incomplete
 
 func (c SunionstoreKey) Key(key ...string) SunionstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -763,5 +763,5 @@ func (c SunionstoreKey) Key(key ...string) SunionstoreKey {
 
 func (c SunionstoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_sorted_set.go
+++ b/internal/cmds/gen_sorted_set.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type Bzmpop Completed
+type Bzmpop Incomplete
 
 func (b Builder) Bzmpop() (c Bzmpop) {
-	c = Bzmpop{cs: get(), ks: b.ks, cf: blockTag}
+	c = Bzmpop{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BZMPOP")
 	return c
 }
@@ -17,14 +17,14 @@ func (c Bzmpop) Timeout(timeout float64) BzmpopTimeout {
 	return (BzmpopTimeout)(c)
 }
 
-type BzmpopCount Completed
+type BzmpopCount Incomplete
 
 func (c BzmpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BzmpopKey Completed
+type BzmpopKey Incomplete
 
 func (c BzmpopKey) Key(key ...string) BzmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -51,7 +51,7 @@ func (c BzmpopKey) Max() BzmpopWhereMax {
 	return (BzmpopWhereMax)(c)
 }
 
-type BzmpopNumkeys Completed
+type BzmpopNumkeys Incomplete
 
 func (c BzmpopNumkeys) Key(key ...string) BzmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -68,14 +68,14 @@ func (c BzmpopNumkeys) Key(key ...string) BzmpopKey {
 	return (BzmpopKey)(c)
 }
 
-type BzmpopTimeout Completed
+type BzmpopTimeout Incomplete
 
 func (c BzmpopTimeout) Numkeys(numkeys int64) BzmpopNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (BzmpopNumkeys)(c)
 }
 
-type BzmpopWhereMax Completed
+type BzmpopWhereMax Incomplete
 
 func (c BzmpopWhereMax) Count(count int64) BzmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -84,10 +84,10 @@ func (c BzmpopWhereMax) Count(count int64) BzmpopCount {
 
 func (c BzmpopWhereMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type BzmpopWhereMin Completed
+type BzmpopWhereMin Incomplete
 
 func (c BzmpopWhereMin) Count(count int64) BzmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -96,13 +96,13 @@ func (c BzmpopWhereMin) Count(count int64) BzmpopCount {
 
 func (c BzmpopWhereMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Bzpopmax Completed
+type Bzpopmax Incomplete
 
 func (b Builder) Bzpopmax() (c Bzpopmax) {
-	c = Bzpopmax{cs: get(), ks: b.ks, cf: blockTag}
+	c = Bzpopmax{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BZPOPMAX")
 	return c
 }
@@ -122,7 +122,7 @@ func (c Bzpopmax) Key(key ...string) BzpopmaxKey {
 	return (BzpopmaxKey)(c)
 }
 
-type BzpopmaxKey Completed
+type BzpopmaxKey Incomplete
 
 func (c BzpopmaxKey) Key(key ...string) BzpopmaxKey {
 	if c.ks&NoSlot == NoSlot {
@@ -144,17 +144,17 @@ func (c BzpopmaxKey) Timeout(timeout float64) BzpopmaxTimeout {
 	return (BzpopmaxTimeout)(c)
 }
 
-type BzpopmaxTimeout Completed
+type BzpopmaxTimeout Incomplete
 
 func (c BzpopmaxTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Bzpopmin Completed
+type Bzpopmin Incomplete
 
 func (b Builder) Bzpopmin() (c Bzpopmin) {
-	c = Bzpopmin{cs: get(), ks: b.ks, cf: blockTag}
+	c = Bzpopmin{cs: get(), ks: b.ks, cf: int16(blockTag)}
 	c.cs.s = append(c.cs.s, "BZPOPMIN")
 	return c
 }
@@ -174,7 +174,7 @@ func (c Bzpopmin) Key(key ...string) BzpopminKey {
 	return (BzpopminKey)(c)
 }
 
-type BzpopminKey Completed
+type BzpopminKey Incomplete
 
 func (c BzpopminKey) Key(key ...string) BzpopminKey {
 	if c.ks&NoSlot == NoSlot {
@@ -196,14 +196,14 @@ func (c BzpopminKey) Timeout(timeout float64) BzpopminTimeout {
 	return (BzpopminTimeout)(c)
 }
 
-type BzpopminTimeout Completed
+type BzpopminTimeout Incomplete
 
 func (c BzpopminTimeout) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zadd Completed
+type Zadd Incomplete
 
 func (b Builder) Zadd() (c Zadd) {
 	c = Zadd{cs: get(), ks: b.ks}
@@ -221,7 +221,7 @@ func (c Zadd) Key(key string) ZaddKey {
 	return (ZaddKey)(c)
 }
 
-type ZaddChangeCh Completed
+type ZaddChangeCh Incomplete
 
 func (c ZaddChangeCh) Incr() ZaddIncrementIncr {
 	c.cs.s = append(c.cs.s, "INCR")
@@ -232,7 +232,7 @@ func (c ZaddChangeCh) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddComparisonGt Completed
+type ZaddComparisonGt Incomplete
 
 func (c ZaddComparisonGt) Ch() ZaddChangeCh {
 	c.cs.s = append(c.cs.s, "CH")
@@ -248,7 +248,7 @@ func (c ZaddComparisonGt) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddComparisonLt Completed
+type ZaddComparisonLt Incomplete
 
 func (c ZaddComparisonLt) Ch() ZaddChangeCh {
 	c.cs.s = append(c.cs.s, "CH")
@@ -264,7 +264,7 @@ func (c ZaddComparisonLt) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddConditionNx Completed
+type ZaddConditionNx Incomplete
 
 func (c ZaddConditionNx) Gt() ZaddComparisonGt {
 	c.cs.s = append(c.cs.s, "GT")
@@ -290,7 +290,7 @@ func (c ZaddConditionNx) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddConditionXx Completed
+type ZaddConditionXx Incomplete
 
 func (c ZaddConditionXx) Gt() ZaddComparisonGt {
 	c.cs.s = append(c.cs.s, "GT")
@@ -316,13 +316,13 @@ func (c ZaddConditionXx) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddIncrementIncr Completed
+type ZaddIncrementIncr Incomplete
 
 func (c ZaddIncrementIncr) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddKey Completed
+type ZaddKey Incomplete
 
 func (c ZaddKey) Nx() ZaddConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -358,7 +358,7 @@ func (c ZaddKey) ScoreMember() ZaddScoreMember {
 	return (ZaddScoreMember)(c)
 }
 
-type ZaddScoreMember Completed
+type ZaddScoreMember Incomplete
 
 func (c ZaddScoreMember) ScoreMember(score float64, member string) ZaddScoreMember {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(score, 'f', -1, 64), member)
@@ -367,13 +367,13 @@ func (c ZaddScoreMember) ScoreMember(score float64, member string) ZaddScoreMemb
 
 func (c ZaddScoreMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zcard Completed
+type Zcard Incomplete
 
 func (b Builder) Zcard() (c Zcard) {
-	c = Zcard{cs: get(), ks: b.ks, cf: readonly}
+	c = Zcard{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZCARD")
 	return c
 }
@@ -388,22 +388,22 @@ func (c Zcard) Key(key string) ZcardKey {
 	return (ZcardKey)(c)
 }
 
-type ZcardKey Completed
+type ZcardKey Incomplete
 
 func (c ZcardKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZcardKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zcount Completed
+type Zcount Incomplete
 
 func (b Builder) Zcount() (c Zcount) {
-	c = Zcount{cs: get(), ks: b.ks, cf: readonly}
+	c = Zcount{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZCOUNT")
 	return c
 }
@@ -418,36 +418,36 @@ func (c Zcount) Key(key string) ZcountKey {
 	return (ZcountKey)(c)
 }
 
-type ZcountKey Completed
+type ZcountKey Incomplete
 
 func (c ZcountKey) Min(min string) ZcountMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZcountMin)(c)
 }
 
-type ZcountMax Completed
+type ZcountMax Incomplete
 
 func (c ZcountMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZcountMax) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZcountMin Completed
+type ZcountMin Incomplete
 
 func (c ZcountMin) Max(max string) ZcountMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZcountMax)(c)
 }
 
-type Zdiff Completed
+type Zdiff Incomplete
 
 func (b Builder) Zdiff() (c Zdiff) {
-	c = Zdiff{cs: get(), ks: b.ks, cf: readonly}
+	c = Zdiff{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZDIFF")
 	return c
 }
@@ -457,7 +457,7 @@ func (c Zdiff) Numkeys(numkeys int64) ZdiffNumkeys {
 	return (ZdiffNumkeys)(c)
 }
 
-type ZdiffKey Completed
+type ZdiffKey Incomplete
 
 func (c ZdiffKey) Key(key ...string) ZdiffKey {
 	if c.ks&NoSlot == NoSlot {
@@ -481,10 +481,10 @@ func (c ZdiffKey) Withscores() ZdiffWithscores {
 
 func (c ZdiffKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZdiffNumkeys Completed
+type ZdiffNumkeys Incomplete
 
 func (c ZdiffNumkeys) Key(key ...string) ZdiffKey {
 	if c.ks&NoSlot == NoSlot {
@@ -501,14 +501,14 @@ func (c ZdiffNumkeys) Key(key ...string) ZdiffKey {
 	return (ZdiffKey)(c)
 }
 
-type ZdiffWithscores Completed
+type ZdiffWithscores Incomplete
 
 func (c ZdiffWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zdiffstore Completed
+type Zdiffstore Incomplete
 
 func (b Builder) Zdiffstore() (c Zdiffstore) {
 	c = Zdiffstore{cs: get(), ks: b.ks}
@@ -526,14 +526,14 @@ func (c Zdiffstore) Destination(destination string) ZdiffstoreDestination {
 	return (ZdiffstoreDestination)(c)
 }
 
-type ZdiffstoreDestination Completed
+type ZdiffstoreDestination Incomplete
 
 func (c ZdiffstoreDestination) Numkeys(numkeys int64) ZdiffstoreNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (ZdiffstoreNumkeys)(c)
 }
 
-type ZdiffstoreKey Completed
+type ZdiffstoreKey Incomplete
 
 func (c ZdiffstoreKey) Key(key ...string) ZdiffstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -552,10 +552,10 @@ func (c ZdiffstoreKey) Key(key ...string) ZdiffstoreKey {
 
 func (c ZdiffstoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZdiffstoreNumkeys Completed
+type ZdiffstoreNumkeys Incomplete
 
 func (c ZdiffstoreNumkeys) Key(key ...string) ZdiffstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -572,7 +572,7 @@ func (c ZdiffstoreNumkeys) Key(key ...string) ZdiffstoreKey {
 	return (ZdiffstoreKey)(c)
 }
 
-type Zincrby Completed
+type Zincrby Incomplete
 
 func (b Builder) Zincrby() (c Zincrby) {
 	c = Zincrby{cs: get(), ks: b.ks}
@@ -590,31 +590,31 @@ func (c Zincrby) Key(key string) ZincrbyKey {
 	return (ZincrbyKey)(c)
 }
 
-type ZincrbyIncrement Completed
+type ZincrbyIncrement Incomplete
 
 func (c ZincrbyIncrement) Member(member string) ZincrbyMember {
 	c.cs.s = append(c.cs.s, member)
 	return (ZincrbyMember)(c)
 }
 
-type ZincrbyKey Completed
+type ZincrbyKey Incomplete
 
 func (c ZincrbyKey) Increment(increment float64) ZincrbyIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(increment, 'f', -1, 64))
 	return (ZincrbyIncrement)(c)
 }
 
-type ZincrbyMember Completed
+type ZincrbyMember Incomplete
 
 func (c ZincrbyMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zinter Completed
+type Zinter Incomplete
 
 func (b Builder) Zinter() (c Zinter) {
-	c = Zinter{cs: get(), ks: b.ks, cf: readonly}
+	c = Zinter{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZINTER")
 	return c
 }
@@ -624,7 +624,7 @@ func (c Zinter) Numkeys(numkeys int64) ZinterNumkeys {
 	return (ZinterNumkeys)(c)
 }
 
-type ZinterAggregateMax Completed
+type ZinterAggregateMax Incomplete
 
 func (c ZinterAggregateMax) Withscores() ZinterWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -633,10 +633,10 @@ func (c ZinterAggregateMax) Withscores() ZinterWithscores {
 
 func (c ZinterAggregateMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterAggregateMin Completed
+type ZinterAggregateMin Incomplete
 
 func (c ZinterAggregateMin) Withscores() ZinterWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -645,10 +645,10 @@ func (c ZinterAggregateMin) Withscores() ZinterWithscores {
 
 func (c ZinterAggregateMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterAggregateSum Completed
+type ZinterAggregateSum Incomplete
 
 func (c ZinterAggregateSum) Withscores() ZinterWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -657,10 +657,10 @@ func (c ZinterAggregateSum) Withscores() ZinterWithscores {
 
 func (c ZinterAggregateSum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterKey Completed
+type ZinterKey Incomplete
 
 func (c ZinterKey) Key(key ...string) ZinterKey {
 	if c.ks&NoSlot == NoSlot {
@@ -707,10 +707,10 @@ func (c ZinterKey) Withscores() ZinterWithscores {
 
 func (c ZinterKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterNumkeys Completed
+type ZinterNumkeys Incomplete
 
 func (c ZinterNumkeys) Key(key ...string) ZinterKey {
 	if c.ks&NoSlot == NoSlot {
@@ -727,7 +727,7 @@ func (c ZinterNumkeys) Key(key ...string) ZinterKey {
 	return (ZinterKey)(c)
 }
 
-type ZinterWeights Completed
+type ZinterWeights Incomplete
 
 func (c ZinterWeights) Weights(weight ...int64) ZinterWeights {
 	c.cs.s = append(c.cs.s, "WEIGHTS")
@@ -759,20 +759,20 @@ func (c ZinterWeights) Withscores() ZinterWithscores {
 
 func (c ZinterWeights) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterWithscores Completed
+type ZinterWithscores Incomplete
 
 func (c ZinterWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zintercard Completed
+type Zintercard Incomplete
 
 func (b Builder) Zintercard() (c Zintercard) {
-	c = Zintercard{cs: get(), ks: b.ks, cf: readonly}
+	c = Zintercard{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZINTERCARD")
 	return c
 }
@@ -782,7 +782,7 @@ func (c Zintercard) Numkeys(numkeys int64) ZintercardNumkeys {
 	return (ZintercardNumkeys)(c)
 }
 
-type ZintercardKey Completed
+type ZintercardKey Incomplete
 
 func (c ZintercardKey) Key(key ...string) ZintercardKey {
 	if c.ks&NoSlot == NoSlot {
@@ -806,17 +806,17 @@ func (c ZintercardKey) Limit(limit int64) ZintercardLimit {
 
 func (c ZintercardKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZintercardLimit Completed
+type ZintercardLimit Incomplete
 
 func (c ZintercardLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZintercardNumkeys Completed
+type ZintercardNumkeys Incomplete
 
 func (c ZintercardNumkeys) Key(key ...string) ZintercardKey {
 	if c.ks&NoSlot == NoSlot {
@@ -833,7 +833,7 @@ func (c ZintercardNumkeys) Key(key ...string) ZintercardKey {
 	return (ZintercardKey)(c)
 }
 
-type Zinterstore Completed
+type Zinterstore Incomplete
 
 func (b Builder) Zinterstore() (c Zinterstore) {
 	c = Zinterstore{cs: get(), ks: b.ks}
@@ -851,35 +851,35 @@ func (c Zinterstore) Destination(destination string) ZinterstoreDestination {
 	return (ZinterstoreDestination)(c)
 }
 
-type ZinterstoreAggregateMax Completed
+type ZinterstoreAggregateMax Incomplete
 
 func (c ZinterstoreAggregateMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterstoreAggregateMin Completed
+type ZinterstoreAggregateMin Incomplete
 
 func (c ZinterstoreAggregateMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterstoreAggregateSum Completed
+type ZinterstoreAggregateSum Incomplete
 
 func (c ZinterstoreAggregateSum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterstoreDestination Completed
+type ZinterstoreDestination Incomplete
 
 func (c ZinterstoreDestination) Numkeys(numkeys int64) ZinterstoreNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (ZinterstoreNumkeys)(c)
 }
 
-type ZinterstoreKey Completed
+type ZinterstoreKey Incomplete
 
 func (c ZinterstoreKey) Key(key ...string) ZinterstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -921,10 +921,10 @@ func (c ZinterstoreKey) AggregateMax() ZinterstoreAggregateMax {
 
 func (c ZinterstoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZinterstoreNumkeys Completed
+type ZinterstoreNumkeys Incomplete
 
 func (c ZinterstoreNumkeys) Key(key ...string) ZinterstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -941,7 +941,7 @@ func (c ZinterstoreNumkeys) Key(key ...string) ZinterstoreKey {
 	return (ZinterstoreKey)(c)
 }
 
-type ZinterstoreWeights Completed
+type ZinterstoreWeights Incomplete
 
 func (c ZinterstoreWeights) Weights(weight ...int64) ZinterstoreWeights {
 	c.cs.s = append(c.cs.s, "WEIGHTS")
@@ -968,13 +968,13 @@ func (c ZinterstoreWeights) AggregateMax() ZinterstoreAggregateMax {
 
 func (c ZinterstoreWeights) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zlexcount Completed
+type Zlexcount Incomplete
 
 func (b Builder) Zlexcount() (c Zlexcount) {
-	c = Zlexcount{cs: get(), ks: b.ks, cf: readonly}
+	c = Zlexcount{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZLEXCOUNT")
 	return c
 }
@@ -989,33 +989,33 @@ func (c Zlexcount) Key(key string) ZlexcountKey {
 	return (ZlexcountKey)(c)
 }
 
-type ZlexcountKey Completed
+type ZlexcountKey Incomplete
 
 func (c ZlexcountKey) Min(min string) ZlexcountMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZlexcountMin)(c)
 }
 
-type ZlexcountMax Completed
+type ZlexcountMax Incomplete
 
 func (c ZlexcountMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZlexcountMax) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZlexcountMin Completed
+type ZlexcountMin Incomplete
 
 func (c ZlexcountMin) Max(max string) ZlexcountMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZlexcountMax)(c)
 }
 
-type Zmpop Completed
+type Zmpop Incomplete
 
 func (b Builder) Zmpop() (c Zmpop) {
 	c = Zmpop{cs: get(), ks: b.ks}
@@ -1028,14 +1028,14 @@ func (c Zmpop) Numkeys(numkeys int64) ZmpopNumkeys {
 	return (ZmpopNumkeys)(c)
 }
 
-type ZmpopCount Completed
+type ZmpopCount Incomplete
 
 func (c ZmpopCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZmpopKey Completed
+type ZmpopKey Incomplete
 
 func (c ZmpopKey) Key(key ...string) ZmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1062,7 +1062,7 @@ func (c ZmpopKey) Max() ZmpopWhereMax {
 	return (ZmpopWhereMax)(c)
 }
 
-type ZmpopNumkeys Completed
+type ZmpopNumkeys Incomplete
 
 func (c ZmpopNumkeys) Key(key ...string) ZmpopKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1079,7 +1079,7 @@ func (c ZmpopNumkeys) Key(key ...string) ZmpopKey {
 	return (ZmpopKey)(c)
 }
 
-type ZmpopWhereMax Completed
+type ZmpopWhereMax Incomplete
 
 func (c ZmpopWhereMax) Count(count int64) ZmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1088,10 +1088,10 @@ func (c ZmpopWhereMax) Count(count int64) ZmpopCount {
 
 func (c ZmpopWhereMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZmpopWhereMin Completed
+type ZmpopWhereMin Incomplete
 
 func (c ZmpopWhereMin) Count(count int64) ZmpopCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1100,13 +1100,13 @@ func (c ZmpopWhereMin) Count(count int64) ZmpopCount {
 
 func (c ZmpopWhereMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zmscore Completed
+type Zmscore Incomplete
 
 func (b Builder) Zmscore() (c Zmscore) {
-	c = Zmscore{cs: get(), ks: b.ks, cf: readonly}
+	c = Zmscore{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZMSCORE")
 	return c
 }
@@ -1121,14 +1121,14 @@ func (c Zmscore) Key(key string) ZmscoreKey {
 	return (ZmscoreKey)(c)
 }
 
-type ZmscoreKey Completed
+type ZmscoreKey Incomplete
 
 func (c ZmscoreKey) Member(member ...string) ZmscoreMember {
 	c.cs.s = append(c.cs.s, member...)
 	return (ZmscoreMember)(c)
 }
 
-type ZmscoreMember Completed
+type ZmscoreMember Incomplete
 
 func (c ZmscoreMember) Member(member ...string) ZmscoreMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -1137,15 +1137,15 @@ func (c ZmscoreMember) Member(member ...string) ZmscoreMember {
 
 func (c ZmscoreMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZmscoreMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zpopmax Completed
+type Zpopmax Incomplete
 
 func (b Builder) Zpopmax() (c Zpopmax) {
 	c = Zpopmax{cs: get(), ks: b.ks}
@@ -1163,14 +1163,14 @@ func (c Zpopmax) Key(key string) ZpopmaxKey {
 	return (ZpopmaxKey)(c)
 }
 
-type ZpopmaxCount Completed
+type ZpopmaxCount Incomplete
 
 func (c ZpopmaxCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZpopmaxKey Completed
+type ZpopmaxKey Incomplete
 
 func (c ZpopmaxKey) Count(count int64) ZpopmaxCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -1179,10 +1179,10 @@ func (c ZpopmaxKey) Count(count int64) ZpopmaxCount {
 
 func (c ZpopmaxKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zpopmin Completed
+type Zpopmin Incomplete
 
 func (b Builder) Zpopmin() (c Zpopmin) {
 	c = Zpopmin{cs: get(), ks: b.ks}
@@ -1200,14 +1200,14 @@ func (c Zpopmin) Key(key string) ZpopminKey {
 	return (ZpopminKey)(c)
 }
 
-type ZpopminCount Completed
+type ZpopminCount Incomplete
 
 func (c ZpopminCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZpopminKey Completed
+type ZpopminKey Incomplete
 
 func (c ZpopminKey) Count(count int64) ZpopminCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -1216,13 +1216,13 @@ func (c ZpopminKey) Count(count int64) ZpopminCount {
 
 func (c ZpopminKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrandmember Completed
+type Zrandmember Incomplete
 
 func (b Builder) Zrandmember() (c Zrandmember) {
-	c = Zrandmember{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrandmember{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZRANDMEMBER")
 	return c
 }
@@ -1237,7 +1237,7 @@ func (c Zrandmember) Key(key string) ZrandmemberKey {
 	return (ZrandmemberKey)(c)
 }
 
-type ZrandmemberKey Completed
+type ZrandmemberKey Incomplete
 
 func (c ZrandmemberKey) Count(count int64) ZrandmemberOptionsCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
@@ -1246,10 +1246,10 @@ func (c ZrandmemberKey) Count(count int64) ZrandmemberOptionsCount {
 
 func (c ZrandmemberKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrandmemberOptionsCount Completed
+type ZrandmemberOptionsCount Incomplete
 
 func (c ZrandmemberOptionsCount) Withscores() ZrandmemberOptionsWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -1258,20 +1258,20 @@ func (c ZrandmemberOptionsCount) Withscores() ZrandmemberOptionsWithscores {
 
 func (c ZrandmemberOptionsCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrandmemberOptionsWithscores Completed
+type ZrandmemberOptionsWithscores Incomplete
 
 func (c ZrandmemberOptionsWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrange Completed
+type Zrange Incomplete
 
 func (b Builder) Zrange() (c Zrange) {
-	c = Zrange{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZRANGE")
 	return c
 }
@@ -1286,14 +1286,14 @@ func (c Zrange) Key(key string) ZrangeKey {
 	return (ZrangeKey)(c)
 }
 
-type ZrangeKey Completed
+type ZrangeKey Incomplete
 
 func (c ZrangeKey) Min(min string) ZrangeMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZrangeMin)(c)
 }
 
-type ZrangeLimit Completed
+type ZrangeLimit Incomplete
 
 func (c ZrangeLimit) Withscores() ZrangeWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -1302,15 +1302,15 @@ func (c ZrangeLimit) Withscores() ZrangeWithscores {
 
 func (c ZrangeLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangeLimit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangeMax Completed
+type ZrangeMax Incomplete
 
 func (c ZrangeMax) Byscore() ZrangeSortbyByscore {
 	c.cs.s = append(c.cs.s, "BYSCORE")
@@ -1339,22 +1339,22 @@ func (c ZrangeMax) Withscores() ZrangeWithscores {
 
 func (c ZrangeMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangeMax) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangeMin Completed
+type ZrangeMin Incomplete
 
 func (c ZrangeMin) Max(max string) ZrangeMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZrangeMax)(c)
 }
 
-type ZrangeRev Completed
+type ZrangeRev Incomplete
 
 func (c ZrangeRev) Limit(offset int64, count int64) ZrangeLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -1368,15 +1368,15 @@ func (c ZrangeRev) Withscores() ZrangeWithscores {
 
 func (c ZrangeRev) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangeRev) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangeSortbyBylex Completed
+type ZrangeSortbyBylex Incomplete
 
 func (c ZrangeSortbyBylex) Rev() ZrangeRev {
 	c.cs.s = append(c.cs.s, "REV")
@@ -1395,15 +1395,15 @@ func (c ZrangeSortbyBylex) Withscores() ZrangeWithscores {
 
 func (c ZrangeSortbyBylex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangeSortbyBylex) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangeSortbyByscore Completed
+type ZrangeSortbyByscore Incomplete
 
 func (c ZrangeSortbyByscore) Rev() ZrangeRev {
 	c.cs.s = append(c.cs.s, "REV")
@@ -1422,30 +1422,30 @@ func (c ZrangeSortbyByscore) Withscores() ZrangeWithscores {
 
 func (c ZrangeSortbyByscore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangeSortbyByscore) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangeWithscores Completed
+type ZrangeWithscores Incomplete
 
 func (c ZrangeWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangeWithscores) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrangebylex Completed
+type Zrangebylex Incomplete
 
 func (b Builder) Zrangebylex() (c Zrangebylex) {
-	c = Zrangebylex{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrangebylex{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZRANGEBYLEX")
 	return c
 }
@@ -1460,26 +1460,26 @@ func (c Zrangebylex) Key(key string) ZrangebylexKey {
 	return (ZrangebylexKey)(c)
 }
 
-type ZrangebylexKey Completed
+type ZrangebylexKey Incomplete
 
 func (c ZrangebylexKey) Min(min string) ZrangebylexMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZrangebylexMin)(c)
 }
 
-type ZrangebylexLimit Completed
+type ZrangebylexLimit Incomplete
 
 func (c ZrangebylexLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangebylexLimit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangebylexMax Completed
+type ZrangebylexMax Incomplete
 
 func (c ZrangebylexMax) Limit(offset int64, count int64) ZrangebylexLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -1488,25 +1488,25 @@ func (c ZrangebylexMax) Limit(offset int64, count int64) ZrangebylexLimit {
 
 func (c ZrangebylexMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangebylexMax) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangebylexMin Completed
+type ZrangebylexMin Incomplete
 
 func (c ZrangebylexMin) Max(max string) ZrangebylexMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZrangebylexMax)(c)
 }
 
-type Zrangebyscore Completed
+type Zrangebyscore Incomplete
 
 func (b Builder) Zrangebyscore() (c Zrangebyscore) {
-	c = Zrangebyscore{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrangebyscore{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZRANGEBYSCORE")
 	return c
 }
@@ -1521,26 +1521,26 @@ func (c Zrangebyscore) Key(key string) ZrangebyscoreKey {
 	return (ZrangebyscoreKey)(c)
 }
 
-type ZrangebyscoreKey Completed
+type ZrangebyscoreKey Incomplete
 
 func (c ZrangebyscoreKey) Min(min string) ZrangebyscoreMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZrangebyscoreMin)(c)
 }
 
-type ZrangebyscoreLimit Completed
+type ZrangebyscoreLimit Incomplete
 
 func (c ZrangebyscoreLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangebyscoreLimit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangebyscoreMax Completed
+type ZrangebyscoreMax Incomplete
 
 func (c ZrangebyscoreMax) Withscores() ZrangebyscoreWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -1554,22 +1554,22 @@ func (c ZrangebyscoreMax) Limit(offset int64, count int64) ZrangebyscoreLimit {
 
 func (c ZrangebyscoreMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangebyscoreMax) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangebyscoreMin Completed
+type ZrangebyscoreMin Incomplete
 
 func (c ZrangebyscoreMin) Max(max string) ZrangebyscoreMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZrangebyscoreMax)(c)
 }
 
-type ZrangebyscoreWithscores Completed
+type ZrangebyscoreWithscores Incomplete
 
 func (c ZrangebyscoreWithscores) Limit(offset int64, count int64) ZrangebyscoreLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -1578,15 +1578,15 @@ func (c ZrangebyscoreWithscores) Limit(offset int64, count int64) ZrangebyscoreL
 
 func (c ZrangebyscoreWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrangebyscoreWithscores) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrangestore Completed
+type Zrangestore Incomplete
 
 func (b Builder) Zrangestore() (c Zrangestore) {
 	c = Zrangestore{cs: get(), ks: b.ks}
@@ -1604,7 +1604,7 @@ func (c Zrangestore) Dst(dst string) ZrangestoreDst {
 	return (ZrangestoreDst)(c)
 }
 
-type ZrangestoreDst Completed
+type ZrangestoreDst Incomplete
 
 func (c ZrangestoreDst) Src(src string) ZrangestoreSrc {
 	if c.ks&NoSlot == NoSlot {
@@ -1616,14 +1616,14 @@ func (c ZrangestoreDst) Src(src string) ZrangestoreSrc {
 	return (ZrangestoreSrc)(c)
 }
 
-type ZrangestoreLimit Completed
+type ZrangestoreLimit Incomplete
 
 func (c ZrangestoreLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangestoreMax Completed
+type ZrangestoreMax Incomplete
 
 func (c ZrangestoreMax) Byscore() ZrangestoreSortbyByscore {
 	c.cs.s = append(c.cs.s, "BYSCORE")
@@ -1647,17 +1647,17 @@ func (c ZrangestoreMax) Limit(offset int64, count int64) ZrangestoreLimit {
 
 func (c ZrangestoreMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangestoreMin Completed
+type ZrangestoreMin Incomplete
 
 func (c ZrangestoreMin) Max(max string) ZrangestoreMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZrangestoreMax)(c)
 }
 
-type ZrangestoreRev Completed
+type ZrangestoreRev Incomplete
 
 func (c ZrangestoreRev) Limit(offset int64, count int64) ZrangestoreLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -1666,10 +1666,10 @@ func (c ZrangestoreRev) Limit(offset int64, count int64) ZrangestoreLimit {
 
 func (c ZrangestoreRev) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangestoreSortbyBylex Completed
+type ZrangestoreSortbyBylex Incomplete
 
 func (c ZrangestoreSortbyBylex) Rev() ZrangestoreRev {
 	c.cs.s = append(c.cs.s, "REV")
@@ -1683,10 +1683,10 @@ func (c ZrangestoreSortbyBylex) Limit(offset int64, count int64) ZrangestoreLimi
 
 func (c ZrangestoreSortbyBylex) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangestoreSortbyByscore Completed
+type ZrangestoreSortbyByscore Incomplete
 
 func (c ZrangestoreSortbyByscore) Rev() ZrangestoreRev {
 	c.cs.s = append(c.cs.s, "REV")
@@ -1700,20 +1700,20 @@ func (c ZrangestoreSortbyByscore) Limit(offset int64, count int64) ZrangestoreLi
 
 func (c ZrangestoreSortbyByscore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrangestoreSrc Completed
+type ZrangestoreSrc Incomplete
 
 func (c ZrangestoreSrc) Min(min string) ZrangestoreMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZrangestoreMin)(c)
 }
 
-type Zrank Completed
+type Zrank Incomplete
 
 func (b Builder) Zrank() (c Zrank) {
-	c = Zrank{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrank{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZRANK")
 	return c
 }
@@ -1728,14 +1728,14 @@ func (c Zrank) Key(key string) ZrankKey {
 	return (ZrankKey)(c)
 }
 
-type ZrankKey Completed
+type ZrankKey Incomplete
 
 func (c ZrankKey) Member(member string) ZrankMember {
 	c.cs.s = append(c.cs.s, member)
 	return (ZrankMember)(c)
 }
 
-type ZrankMember Completed
+type ZrankMember Incomplete
 
 func (c ZrankMember) Withscore() ZrankWithscore {
 	c.cs.s = append(c.cs.s, "WITHSCORE")
@@ -1744,27 +1744,27 @@ func (c ZrankMember) Withscore() ZrankWithscore {
 
 func (c ZrankMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrankMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrankWithscore Completed
+type ZrankWithscore Incomplete
 
 func (c ZrankWithscore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrankWithscore) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrem Completed
+type Zrem Incomplete
 
 func (b Builder) Zrem() (c Zrem) {
 	c = Zrem{cs: get(), ks: b.ks}
@@ -1782,14 +1782,14 @@ func (c Zrem) Key(key string) ZremKey {
 	return (ZremKey)(c)
 }
 
-type ZremKey Completed
+type ZremKey Incomplete
 
 func (c ZremKey) Member(member ...string) ZremMember {
 	c.cs.s = append(c.cs.s, member...)
 	return (ZremMember)(c)
 }
 
-type ZremMember Completed
+type ZremMember Incomplete
 
 func (c ZremMember) Member(member ...string) ZremMember {
 	c.cs.s = append(c.cs.s, member...)
@@ -1798,10 +1798,10 @@ func (c ZremMember) Member(member ...string) ZremMember {
 
 func (c ZremMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zremrangebylex Completed
+type Zremrangebylex Incomplete
 
 func (b Builder) Zremrangebylex() (c Zremrangebylex) {
 	c = Zremrangebylex{cs: get(), ks: b.ks}
@@ -1819,28 +1819,28 @@ func (c Zremrangebylex) Key(key string) ZremrangebylexKey {
 	return (ZremrangebylexKey)(c)
 }
 
-type ZremrangebylexKey Completed
+type ZremrangebylexKey Incomplete
 
 func (c ZremrangebylexKey) Min(min string) ZremrangebylexMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZremrangebylexMin)(c)
 }
 
-type ZremrangebylexMax Completed
+type ZremrangebylexMax Incomplete
 
 func (c ZremrangebylexMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZremrangebylexMin Completed
+type ZremrangebylexMin Incomplete
 
 func (c ZremrangebylexMin) Max(max string) ZremrangebylexMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZremrangebylexMax)(c)
 }
 
-type Zremrangebyrank Completed
+type Zremrangebyrank Incomplete
 
 func (b Builder) Zremrangebyrank() (c Zremrangebyrank) {
 	c = Zremrangebyrank{cs: get(), ks: b.ks}
@@ -1858,28 +1858,28 @@ func (c Zremrangebyrank) Key(key string) ZremrangebyrankKey {
 	return (ZremrangebyrankKey)(c)
 }
 
-type ZremrangebyrankKey Completed
+type ZremrangebyrankKey Incomplete
 
 func (c ZremrangebyrankKey) Start(start int64) ZremrangebyrankStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
 	return (ZremrangebyrankStart)(c)
 }
 
-type ZremrangebyrankStart Completed
+type ZremrangebyrankStart Incomplete
 
 func (c ZremrangebyrankStart) Stop(stop int64) ZremrangebyrankStop {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(stop, 10))
 	return (ZremrangebyrankStop)(c)
 }
 
-type ZremrangebyrankStop Completed
+type ZremrangebyrankStop Incomplete
 
 func (c ZremrangebyrankStop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zremrangebyscore Completed
+type Zremrangebyscore Incomplete
 
 func (b Builder) Zremrangebyscore() (c Zremrangebyscore) {
 	c = Zremrangebyscore{cs: get(), ks: b.ks}
@@ -1897,31 +1897,31 @@ func (c Zremrangebyscore) Key(key string) ZremrangebyscoreKey {
 	return (ZremrangebyscoreKey)(c)
 }
 
-type ZremrangebyscoreKey Completed
+type ZremrangebyscoreKey Incomplete
 
 func (c ZremrangebyscoreKey) Min(min string) ZremrangebyscoreMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZremrangebyscoreMin)(c)
 }
 
-type ZremrangebyscoreMax Completed
+type ZremrangebyscoreMax Incomplete
 
 func (c ZremrangebyscoreMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZremrangebyscoreMin Completed
+type ZremrangebyscoreMin Incomplete
 
 func (c ZremrangebyscoreMin) Max(max string) ZremrangebyscoreMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZremrangebyscoreMax)(c)
 }
 
-type Zrevrange Completed
+type Zrevrange Incomplete
 
 func (b Builder) Zrevrange() (c Zrevrange) {
-	c = Zrevrange{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrevrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZREVRANGE")
 	return c
 }
@@ -1936,21 +1936,21 @@ func (c Zrevrange) Key(key string) ZrevrangeKey {
 	return (ZrevrangeKey)(c)
 }
 
-type ZrevrangeKey Completed
+type ZrevrangeKey Incomplete
 
 func (c ZrevrangeKey) Start(start int64) ZrevrangeStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
 	return (ZrevrangeStart)(c)
 }
 
-type ZrevrangeStart Completed
+type ZrevrangeStart Incomplete
 
 func (c ZrevrangeStart) Stop(stop int64) ZrevrangeStop {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(stop, 10))
 	return (ZrevrangeStop)(c)
 }
 
-type ZrevrangeStop Completed
+type ZrevrangeStop Incomplete
 
 func (c ZrevrangeStop) Withscores() ZrevrangeWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -1959,30 +1959,30 @@ func (c ZrevrangeStop) Withscores() ZrevrangeWithscores {
 
 func (c ZrevrangeStop) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangeStop) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrevrangeWithscores Completed
+type ZrevrangeWithscores Incomplete
 
 func (c ZrevrangeWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangeWithscores) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrevrangebylex Completed
+type Zrevrangebylex Incomplete
 
 func (b Builder) Zrevrangebylex() (c Zrevrangebylex) {
-	c = Zrevrangebylex{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrevrangebylex{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZREVRANGEBYLEX")
 	return c
 }
@@ -1997,33 +1997,33 @@ func (c Zrevrangebylex) Key(key string) ZrevrangebylexKey {
 	return (ZrevrangebylexKey)(c)
 }
 
-type ZrevrangebylexKey Completed
+type ZrevrangebylexKey Incomplete
 
 func (c ZrevrangebylexKey) Max(max string) ZrevrangebylexMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZrevrangebylexMax)(c)
 }
 
-type ZrevrangebylexLimit Completed
+type ZrevrangebylexLimit Incomplete
 
 func (c ZrevrangebylexLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangebylexLimit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrevrangebylexMax Completed
+type ZrevrangebylexMax Incomplete
 
 func (c ZrevrangebylexMax) Min(min string) ZrevrangebylexMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZrevrangebylexMin)(c)
 }
 
-type ZrevrangebylexMin Completed
+type ZrevrangebylexMin Incomplete
 
 func (c ZrevrangebylexMin) Limit(offset int64, count int64) ZrevrangebylexLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -2032,18 +2032,18 @@ func (c ZrevrangebylexMin) Limit(offset int64, count int64) ZrevrangebylexLimit 
 
 func (c ZrevrangebylexMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangebylexMin) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrevrangebyscore Completed
+type Zrevrangebyscore Incomplete
 
 func (b Builder) Zrevrangebyscore() (c Zrevrangebyscore) {
-	c = Zrevrangebyscore{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrevrangebyscore{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZREVRANGEBYSCORE")
 	return c
 }
@@ -2058,33 +2058,33 @@ func (c Zrevrangebyscore) Key(key string) ZrevrangebyscoreKey {
 	return (ZrevrangebyscoreKey)(c)
 }
 
-type ZrevrangebyscoreKey Completed
+type ZrevrangebyscoreKey Incomplete
 
 func (c ZrevrangebyscoreKey) Max(max string) ZrevrangebyscoreMax {
 	c.cs.s = append(c.cs.s, max)
 	return (ZrevrangebyscoreMax)(c)
 }
 
-type ZrevrangebyscoreLimit Completed
+type ZrevrangebyscoreLimit Incomplete
 
 func (c ZrevrangebyscoreLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangebyscoreLimit) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrevrangebyscoreMax Completed
+type ZrevrangebyscoreMax Incomplete
 
 func (c ZrevrangebyscoreMax) Min(min string) ZrevrangebyscoreMin {
 	c.cs.s = append(c.cs.s, min)
 	return (ZrevrangebyscoreMin)(c)
 }
 
-type ZrevrangebyscoreMin Completed
+type ZrevrangebyscoreMin Incomplete
 
 func (c ZrevrangebyscoreMin) Withscores() ZrevrangebyscoreWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -2098,15 +2098,15 @@ func (c ZrevrangebyscoreMin) Limit(offset int64, count int64) ZrevrangebyscoreLi
 
 func (c ZrevrangebyscoreMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangebyscoreMin) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrevrangebyscoreWithscores Completed
+type ZrevrangebyscoreWithscores Incomplete
 
 func (c ZrevrangebyscoreWithscores) Limit(offset int64, count int64) ZrevrangebyscoreLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(offset, 10), strconv.FormatInt(count, 10))
@@ -2115,18 +2115,18 @@ func (c ZrevrangebyscoreWithscores) Limit(offset int64, count int64) Zrevrangeby
 
 func (c ZrevrangebyscoreWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrangebyscoreWithscores) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zrevrank Completed
+type Zrevrank Incomplete
 
 func (b Builder) Zrevrank() (c Zrevrank) {
-	c = Zrevrank{cs: get(), ks: b.ks, cf: readonly}
+	c = Zrevrank{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZREVRANK")
 	return c
 }
@@ -2141,14 +2141,14 @@ func (c Zrevrank) Key(key string) ZrevrankKey {
 	return (ZrevrankKey)(c)
 }
 
-type ZrevrankKey Completed
+type ZrevrankKey Incomplete
 
 func (c ZrevrankKey) Member(member string) ZrevrankMember {
 	c.cs.s = append(c.cs.s, member)
 	return (ZrevrankMember)(c)
 }
 
-type ZrevrankMember Completed
+type ZrevrankMember Incomplete
 
 func (c ZrevrankMember) Withscore() ZrevrankWithscore {
 	c.cs.s = append(c.cs.s, "WITHSCORE")
@@ -2157,30 +2157,30 @@ func (c ZrevrankMember) Withscore() ZrevrankWithscore {
 
 func (c ZrevrankMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrankMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZrevrankWithscore Completed
+type ZrevrankWithscore Incomplete
 
 func (c ZrevrankWithscore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZrevrankWithscore) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zscan Completed
+type Zscan Incomplete
 
 func (b Builder) Zscan() (c Zscan) {
-	c = Zscan{cs: get(), ks: b.ks, cf: readonly}
+	c = Zscan{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZSCAN")
 	return c
 }
@@ -2195,14 +2195,14 @@ func (c Zscan) Key(key string) ZscanKey {
 	return (ZscanKey)(c)
 }
 
-type ZscanCount Completed
+type ZscanCount Incomplete
 
 func (c ZscanCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZscanCursor Completed
+type ZscanCursor Incomplete
 
 func (c ZscanCursor) Match(pattern string) ZscanMatch {
 	c.cs.s = append(c.cs.s, "MATCH", pattern)
@@ -2216,17 +2216,17 @@ func (c ZscanCursor) Count(count int64) ZscanCount {
 
 func (c ZscanCursor) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZscanKey Completed
+type ZscanKey Incomplete
 
 func (c ZscanKey) Cursor(cursor uint64) ZscanCursor {
 	c.cs.s = append(c.cs.s, strconv.FormatUint(cursor, 10))
 	return (ZscanCursor)(c)
 }
 
-type ZscanMatch Completed
+type ZscanMatch Incomplete
 
 func (c ZscanMatch) Count(count int64) ZscanCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -2235,13 +2235,13 @@ func (c ZscanMatch) Count(count int64) ZscanCount {
 
 func (c ZscanMatch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zscore Completed
+type Zscore Incomplete
 
 func (b Builder) Zscore() (c Zscore) {
-	c = Zscore{cs: get(), ks: b.ks, cf: readonly}
+	c = Zscore{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZSCORE")
 	return c
 }
@@ -2256,29 +2256,29 @@ func (c Zscore) Key(key string) ZscoreKey {
 	return (ZscoreKey)(c)
 }
 
-type ZscoreKey Completed
+type ZscoreKey Incomplete
 
 func (c ZscoreKey) Member(member string) ZscoreMember {
 	c.cs.s = append(c.cs.s, member)
 	return (ZscoreMember)(c)
 }
 
-type ZscoreMember Completed
+type ZscoreMember Incomplete
 
 func (c ZscoreMember) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c ZscoreMember) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zunion Completed
+type Zunion Incomplete
 
 func (b Builder) Zunion() (c Zunion) {
-	c = Zunion{cs: get(), ks: b.ks, cf: readonly}
+	c = Zunion{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "ZUNION")
 	return c
 }
@@ -2288,7 +2288,7 @@ func (c Zunion) Numkeys(numkeys int64) ZunionNumkeys {
 	return (ZunionNumkeys)(c)
 }
 
-type ZunionAggregateMax Completed
+type ZunionAggregateMax Incomplete
 
 func (c ZunionAggregateMax) Withscores() ZunionWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -2297,10 +2297,10 @@ func (c ZunionAggregateMax) Withscores() ZunionWithscores {
 
 func (c ZunionAggregateMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionAggregateMin Completed
+type ZunionAggregateMin Incomplete
 
 func (c ZunionAggregateMin) Withscores() ZunionWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -2309,10 +2309,10 @@ func (c ZunionAggregateMin) Withscores() ZunionWithscores {
 
 func (c ZunionAggregateMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionAggregateSum Completed
+type ZunionAggregateSum Incomplete
 
 func (c ZunionAggregateSum) Withscores() ZunionWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -2321,10 +2321,10 @@ func (c ZunionAggregateSum) Withscores() ZunionWithscores {
 
 func (c ZunionAggregateSum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionKey Completed
+type ZunionKey Incomplete
 
 func (c ZunionKey) Key(key ...string) ZunionKey {
 	if c.ks&NoSlot == NoSlot {
@@ -2371,10 +2371,10 @@ func (c ZunionKey) Withscores() ZunionWithscores {
 
 func (c ZunionKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionNumkeys Completed
+type ZunionNumkeys Incomplete
 
 func (c ZunionNumkeys) Key(key ...string) ZunionKey {
 	if c.ks&NoSlot == NoSlot {
@@ -2391,7 +2391,7 @@ func (c ZunionNumkeys) Key(key ...string) ZunionKey {
 	return (ZunionKey)(c)
 }
 
-type ZunionWeights Completed
+type ZunionWeights Incomplete
 
 func (c ZunionWeights) Weights(weight ...int64) ZunionWeights {
 	c.cs.s = append(c.cs.s, "WEIGHTS")
@@ -2423,17 +2423,17 @@ func (c ZunionWeights) Withscores() ZunionWithscores {
 
 func (c ZunionWeights) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionWithscores Completed
+type ZunionWithscores Incomplete
 
 func (c ZunionWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Zunionstore Completed
+type Zunionstore Incomplete
 
 func (b Builder) Zunionstore() (c Zunionstore) {
 	c = Zunionstore{cs: get(), ks: b.ks}
@@ -2451,35 +2451,35 @@ func (c Zunionstore) Destination(destination string) ZunionstoreDestination {
 	return (ZunionstoreDestination)(c)
 }
 
-type ZunionstoreAggregateMax Completed
+type ZunionstoreAggregateMax Incomplete
 
 func (c ZunionstoreAggregateMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionstoreAggregateMin Completed
+type ZunionstoreAggregateMin Incomplete
 
 func (c ZunionstoreAggregateMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionstoreAggregateSum Completed
+type ZunionstoreAggregateSum Incomplete
 
 func (c ZunionstoreAggregateSum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionstoreDestination Completed
+type ZunionstoreDestination Incomplete
 
 func (c ZunionstoreDestination) Numkeys(numkeys int64) ZunionstoreNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (ZunionstoreNumkeys)(c)
 }
 
-type ZunionstoreKey Completed
+type ZunionstoreKey Incomplete
 
 func (c ZunionstoreKey) Key(key ...string) ZunionstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -2521,10 +2521,10 @@ func (c ZunionstoreKey) AggregateMax() ZunionstoreAggregateMax {
 
 func (c ZunionstoreKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type ZunionstoreNumkeys Completed
+type ZunionstoreNumkeys Incomplete
 
 func (c ZunionstoreNumkeys) Key(key ...string) ZunionstoreKey {
 	if c.ks&NoSlot == NoSlot {
@@ -2541,7 +2541,7 @@ func (c ZunionstoreNumkeys) Key(key ...string) ZunionstoreKey {
 	return (ZunionstoreKey)(c)
 }
 
-type ZunionstoreWeights Completed
+type ZunionstoreWeights Incomplete
 
 func (c ZunionstoreWeights) Weights(weight ...int64) ZunionstoreWeights {
 	c.cs.s = append(c.cs.s, "WEIGHTS")
@@ -2568,5 +2568,5 @@ func (c ZunionstoreWeights) AggregateMax() ZunionstoreAggregateMax {
 
 func (c ZunionstoreWeights) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_stream.go
+++ b/internal/cmds/gen_stream.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Xack Completed
+type Xack Incomplete
 
 func (b Builder) Xack() (c Xack) {
 	c = Xack{cs: get(), ks: b.ks}
@@ -22,14 +22,14 @@ func (c Xack) Key(key string) XackKey {
 	return (XackKey)(c)
 }
 
-type XackGroup Completed
+type XackGroup Incomplete
 
 func (c XackGroup) Id(id ...string) XackId {
 	c.cs.s = append(c.cs.s, id...)
 	return (XackId)(c)
 }
 
-type XackId Completed
+type XackId Incomplete
 
 func (c XackId) Id(id ...string) XackId {
 	c.cs.s = append(c.cs.s, id...)
@@ -38,17 +38,17 @@ func (c XackId) Id(id ...string) XackId {
 
 func (c XackId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XackKey Completed
+type XackKey Incomplete
 
 func (c XackKey) Group(group string) XackGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XackGroup)(c)
 }
 
-type Xadd Completed
+type Xadd Incomplete
 
 func (b Builder) Xadd() (c Xadd) {
 	c = Xadd{cs: get(), ks: b.ks}
@@ -66,7 +66,7 @@ func (c Xadd) Key(key string) XaddKey {
 	return (XaddKey)(c)
 }
 
-type XaddFieldValue Completed
+type XaddFieldValue Incomplete
 
 func (c XaddFieldValue) FieldValue(field string, value string) XaddFieldValue {
 	c.cs.s = append(c.cs.s, field, value)
@@ -75,16 +75,16 @@ func (c XaddFieldValue) FieldValue(field string, value string) XaddFieldValue {
 
 func (c XaddFieldValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XaddId Completed
+type XaddId Incomplete
 
 func (c XaddId) FieldValue() XaddFieldValue {
 	return (XaddFieldValue)(c)
 }
 
-type XaddKey Completed
+type XaddKey Incomplete
 
 func (c XaddKey) Nomkstream() XaddNomkstream {
 	c.cs.s = append(c.cs.s, "NOMKSTREAM")
@@ -106,7 +106,7 @@ func (c XaddKey) Id(id string) XaddId {
 	return (XaddId)(c)
 }
 
-type XaddNomkstream Completed
+type XaddNomkstream Incomplete
 
 func (c XaddNomkstream) Maxlen() XaddTrimStrategyMaxlen {
 	c.cs.s = append(c.cs.s, "MAXLEN")
@@ -123,28 +123,28 @@ func (c XaddNomkstream) Id(id string) XaddId {
 	return (XaddId)(c)
 }
 
-type XaddTrimLimit Completed
+type XaddTrimLimit Incomplete
 
 func (c XaddTrimLimit) Id(id string) XaddId {
 	c.cs.s = append(c.cs.s, id)
 	return (XaddId)(c)
 }
 
-type XaddTrimOperatorAlmost Completed
+type XaddTrimOperatorAlmost Incomplete
 
 func (c XaddTrimOperatorAlmost) Threshold(threshold string) XaddTrimThreshold {
 	c.cs.s = append(c.cs.s, threshold)
 	return (XaddTrimThreshold)(c)
 }
 
-type XaddTrimOperatorExact Completed
+type XaddTrimOperatorExact Incomplete
 
 func (c XaddTrimOperatorExact) Threshold(threshold string) XaddTrimThreshold {
 	c.cs.s = append(c.cs.s, threshold)
 	return (XaddTrimThreshold)(c)
 }
 
-type XaddTrimStrategyMaxlen Completed
+type XaddTrimStrategyMaxlen Incomplete
 
 func (c XaddTrimStrategyMaxlen) Exact() XaddTrimOperatorExact {
 	c.cs.s = append(c.cs.s, "=")
@@ -161,7 +161,7 @@ func (c XaddTrimStrategyMaxlen) Threshold(threshold string) XaddTrimThreshold {
 	return (XaddTrimThreshold)(c)
 }
 
-type XaddTrimStrategyMinid Completed
+type XaddTrimStrategyMinid Incomplete
 
 func (c XaddTrimStrategyMinid) Exact() XaddTrimOperatorExact {
 	c.cs.s = append(c.cs.s, "=")
@@ -178,7 +178,7 @@ func (c XaddTrimStrategyMinid) Threshold(threshold string) XaddTrimThreshold {
 	return (XaddTrimThreshold)(c)
 }
 
-type XaddTrimThreshold Completed
+type XaddTrimThreshold Incomplete
 
 func (c XaddTrimThreshold) Limit(count int64) XaddTrimLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(count, 10))
@@ -190,7 +190,7 @@ func (c XaddTrimThreshold) Id(id string) XaddId {
 	return (XaddId)(c)
 }
 
-type Xautoclaim Completed
+type Xautoclaim Incomplete
 
 func (b Builder) Xautoclaim() (c Xautoclaim) {
 	c = Xautoclaim{cs: get(), ks: b.ks}
@@ -208,14 +208,14 @@ func (c Xautoclaim) Key(key string) XautoclaimKey {
 	return (XautoclaimKey)(c)
 }
 
-type XautoclaimConsumer Completed
+type XautoclaimConsumer Incomplete
 
 func (c XautoclaimConsumer) MinIdleTime(minIdleTime string) XautoclaimMinIdleTime {
 	c.cs.s = append(c.cs.s, minIdleTime)
 	return (XautoclaimMinIdleTime)(c)
 }
 
-type XautoclaimCount Completed
+type XautoclaimCount Incomplete
 
 func (c XautoclaimCount) Justid() XautoclaimJustid {
 	c.cs.s = append(c.cs.s, "JUSTID")
@@ -224,38 +224,38 @@ func (c XautoclaimCount) Justid() XautoclaimJustid {
 
 func (c XautoclaimCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XautoclaimGroup Completed
+type XautoclaimGroup Incomplete
 
 func (c XautoclaimGroup) Consumer(consumer string) XautoclaimConsumer {
 	c.cs.s = append(c.cs.s, consumer)
 	return (XautoclaimConsumer)(c)
 }
 
-type XautoclaimJustid Completed
+type XautoclaimJustid Incomplete
 
 func (c XautoclaimJustid) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XautoclaimKey Completed
+type XautoclaimKey Incomplete
 
 func (c XautoclaimKey) Group(group string) XautoclaimGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XautoclaimGroup)(c)
 }
 
-type XautoclaimMinIdleTime Completed
+type XautoclaimMinIdleTime Incomplete
 
 func (c XautoclaimMinIdleTime) Start(start string) XautoclaimStart {
 	c.cs.s = append(c.cs.s, start)
 	return (XautoclaimStart)(c)
 }
 
-type XautoclaimStart Completed
+type XautoclaimStart Incomplete
 
 func (c XautoclaimStart) Count(count int64) XautoclaimCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -269,10 +269,10 @@ func (c XautoclaimStart) Justid() XautoclaimJustid {
 
 func (c XautoclaimStart) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Xclaim Completed
+type Xclaim Incomplete
 
 func (b Builder) Xclaim() (c Xclaim) {
 	c = Xclaim{cs: get(), ks: b.ks}
@@ -290,14 +290,14 @@ func (c Xclaim) Key(key string) XclaimKey {
 	return (XclaimKey)(c)
 }
 
-type XclaimConsumer Completed
+type XclaimConsumer Incomplete
 
 func (c XclaimConsumer) MinIdleTime(minIdleTime string) XclaimMinIdleTime {
 	c.cs.s = append(c.cs.s, minIdleTime)
 	return (XclaimMinIdleTime)(c)
 }
 
-type XclaimForce Completed
+type XclaimForce Incomplete
 
 func (c XclaimForce) Justid() XclaimJustid {
 	c.cs.s = append(c.cs.s, "JUSTID")
@@ -311,17 +311,17 @@ func (c XclaimForce) Lastid() XclaimLastid {
 
 func (c XclaimForce) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XclaimGroup Completed
+type XclaimGroup Incomplete
 
 func (c XclaimGroup) Consumer(consumer string) XclaimConsumer {
 	c.cs.s = append(c.cs.s, consumer)
 	return (XclaimConsumer)(c)
 }
 
-type XclaimId Completed
+type XclaimId Incomplete
 
 func (c XclaimId) Id(id ...string) XclaimId {
 	c.cs.s = append(c.cs.s, id...)
@@ -360,10 +360,10 @@ func (c XclaimId) Lastid() XclaimLastid {
 
 func (c XclaimId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XclaimIdle Completed
+type XclaimIdle Incomplete
 
 func (c XclaimIdle) Time(msUnixTime int64) XclaimTime {
 	c.cs.s = append(c.cs.s, "TIME", strconv.FormatInt(msUnixTime, 10))
@@ -392,10 +392,10 @@ func (c XclaimIdle) Lastid() XclaimLastid {
 
 func (c XclaimIdle) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XclaimJustid Completed
+type XclaimJustid Incomplete
 
 func (c XclaimJustid) Lastid() XclaimLastid {
 	c.cs.s = append(c.cs.s, "LASTID")
@@ -404,31 +404,31 @@ func (c XclaimJustid) Lastid() XclaimLastid {
 
 func (c XclaimJustid) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XclaimKey Completed
+type XclaimKey Incomplete
 
 func (c XclaimKey) Group(group string) XclaimGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XclaimGroup)(c)
 }
 
-type XclaimLastid Completed
+type XclaimLastid Incomplete
 
 func (c XclaimLastid) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XclaimMinIdleTime Completed
+type XclaimMinIdleTime Incomplete
 
 func (c XclaimMinIdleTime) Id(id ...string) XclaimId {
 	c.cs.s = append(c.cs.s, id...)
 	return (XclaimId)(c)
 }
 
-type XclaimRetrycount Completed
+type XclaimRetrycount Incomplete
 
 func (c XclaimRetrycount) Force() XclaimForce {
 	c.cs.s = append(c.cs.s, "FORCE")
@@ -447,10 +447,10 @@ func (c XclaimRetrycount) Lastid() XclaimLastid {
 
 func (c XclaimRetrycount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XclaimTime Completed
+type XclaimTime Incomplete
 
 func (c XclaimTime) Retrycount(count int64) XclaimRetrycount {
 	c.cs.s = append(c.cs.s, "RETRYCOUNT", strconv.FormatInt(count, 10))
@@ -474,10 +474,10 @@ func (c XclaimTime) Lastid() XclaimLastid {
 
 func (c XclaimTime) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Xdel Completed
+type Xdel Incomplete
 
 func (b Builder) Xdel() (c Xdel) {
 	c = Xdel{cs: get(), ks: b.ks}
@@ -495,7 +495,7 @@ func (c Xdel) Key(key string) XdelKey {
 	return (XdelKey)(c)
 }
 
-type XdelId Completed
+type XdelId Incomplete
 
 func (c XdelId) Id(id ...string) XdelId {
 	c.cs.s = append(c.cs.s, id...)
@@ -504,17 +504,17 @@ func (c XdelId) Id(id ...string) XdelId {
 
 func (c XdelId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XdelKey Completed
+type XdelKey Incomplete
 
 func (c XdelKey) Id(id ...string) XdelId {
 	c.cs.s = append(c.cs.s, id...)
 	return (XdelId)(c)
 }
 
-type XgroupCreate Completed
+type XgroupCreate Incomplete
 
 func (b Builder) XgroupCreate() (c XgroupCreate) {
 	c = XgroupCreate{cs: get(), ks: b.ks}
@@ -532,21 +532,21 @@ func (c XgroupCreate) Key(key string) XgroupCreateKey {
 	return (XgroupCreateKey)(c)
 }
 
-type XgroupCreateEntriesread Completed
+type XgroupCreateEntriesread Incomplete
 
 func (c XgroupCreateEntriesread) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupCreateGroup Completed
+type XgroupCreateGroup Incomplete
 
 func (c XgroupCreateGroup) Id(id string) XgroupCreateId {
 	c.cs.s = append(c.cs.s, id)
 	return (XgroupCreateId)(c)
 }
 
-type XgroupCreateId Completed
+type XgroupCreateId Incomplete
 
 func (c XgroupCreateId) Mkstream() XgroupCreateMkstream {
 	c.cs.s = append(c.cs.s, "MKSTREAM")
@@ -560,17 +560,17 @@ func (c XgroupCreateId) Entriesread(entriesRead int64) XgroupCreateEntriesread {
 
 func (c XgroupCreateId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupCreateKey Completed
+type XgroupCreateKey Incomplete
 
 func (c XgroupCreateKey) Group(group string) XgroupCreateGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XgroupCreateGroup)(c)
 }
 
-type XgroupCreateMkstream Completed
+type XgroupCreateMkstream Incomplete
 
 func (c XgroupCreateMkstream) Entriesread(entriesRead int64) XgroupCreateEntriesread {
 	c.cs.s = append(c.cs.s, "ENTRIESREAD", strconv.FormatInt(entriesRead, 10))
@@ -579,10 +579,10 @@ func (c XgroupCreateMkstream) Entriesread(entriesRead int64) XgroupCreateEntries
 
 func (c XgroupCreateMkstream) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupCreateconsumer Completed
+type XgroupCreateconsumer Incomplete
 
 func (b Builder) XgroupCreateconsumer() (c XgroupCreateconsumer) {
 	c = XgroupCreateconsumer{cs: get(), ks: b.ks}
@@ -600,28 +600,28 @@ func (c XgroupCreateconsumer) Key(key string) XgroupCreateconsumerKey {
 	return (XgroupCreateconsumerKey)(c)
 }
 
-type XgroupCreateconsumerConsumer Completed
+type XgroupCreateconsumerConsumer Incomplete
 
 func (c XgroupCreateconsumerConsumer) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupCreateconsumerGroup Completed
+type XgroupCreateconsumerGroup Incomplete
 
 func (c XgroupCreateconsumerGroup) Consumer(consumer string) XgroupCreateconsumerConsumer {
 	c.cs.s = append(c.cs.s, consumer)
 	return (XgroupCreateconsumerConsumer)(c)
 }
 
-type XgroupCreateconsumerKey Completed
+type XgroupCreateconsumerKey Incomplete
 
 func (c XgroupCreateconsumerKey) Group(group string) XgroupCreateconsumerGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XgroupCreateconsumerGroup)(c)
 }
 
-type XgroupDelconsumer Completed
+type XgroupDelconsumer Incomplete
 
 func (b Builder) XgroupDelconsumer() (c XgroupDelconsumer) {
 	c = XgroupDelconsumer{cs: get(), ks: b.ks}
@@ -639,28 +639,28 @@ func (c XgroupDelconsumer) Key(key string) XgroupDelconsumerKey {
 	return (XgroupDelconsumerKey)(c)
 }
 
-type XgroupDelconsumerConsumername Completed
+type XgroupDelconsumerConsumername Incomplete
 
 func (c XgroupDelconsumerConsumername) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupDelconsumerGroup Completed
+type XgroupDelconsumerGroup Incomplete
 
 func (c XgroupDelconsumerGroup) Consumername(consumername string) XgroupDelconsumerConsumername {
 	c.cs.s = append(c.cs.s, consumername)
 	return (XgroupDelconsumerConsumername)(c)
 }
 
-type XgroupDelconsumerKey Completed
+type XgroupDelconsumerKey Incomplete
 
 func (c XgroupDelconsumerKey) Group(group string) XgroupDelconsumerGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XgroupDelconsumerGroup)(c)
 }
 
-type XgroupDestroy Completed
+type XgroupDestroy Incomplete
 
 func (b Builder) XgroupDestroy() (c XgroupDestroy) {
 	c = XgroupDestroy{cs: get(), ks: b.ks}
@@ -678,21 +678,21 @@ func (c XgroupDestroy) Key(key string) XgroupDestroyKey {
 	return (XgroupDestroyKey)(c)
 }
 
-type XgroupDestroyGroup Completed
+type XgroupDestroyGroup Incomplete
 
 func (c XgroupDestroyGroup) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupDestroyKey Completed
+type XgroupDestroyKey Incomplete
 
 func (c XgroupDestroyKey) Group(group string) XgroupDestroyGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XgroupDestroyGroup)(c)
 }
 
-type XgroupHelp Completed
+type XgroupHelp Incomplete
 
 func (b Builder) XgroupHelp() (c XgroupHelp) {
 	c = XgroupHelp{cs: get(), ks: b.ks}
@@ -702,10 +702,10 @@ func (b Builder) XgroupHelp() (c XgroupHelp) {
 
 func (c XgroupHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupSetid Completed
+type XgroupSetid Incomplete
 
 func (b Builder) XgroupSetid() (c XgroupSetid) {
 	c = XgroupSetid{cs: get(), ks: b.ks}
@@ -723,21 +723,21 @@ func (c XgroupSetid) Key(key string) XgroupSetidKey {
 	return (XgroupSetidKey)(c)
 }
 
-type XgroupSetidEntriesread Completed
+type XgroupSetidEntriesread Incomplete
 
 func (c XgroupSetidEntriesread) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupSetidGroup Completed
+type XgroupSetidGroup Incomplete
 
 func (c XgroupSetidGroup) Id(id string) XgroupSetidId {
 	c.cs.s = append(c.cs.s, id)
 	return (XgroupSetidId)(c)
 }
 
-type XgroupSetidId Completed
+type XgroupSetidId Incomplete
 
 func (c XgroupSetidId) Entriesread(entriesRead int64) XgroupSetidEntriesread {
 	c.cs.s = append(c.cs.s, "ENTRIESREAD", strconv.FormatInt(entriesRead, 10))
@@ -746,20 +746,20 @@ func (c XgroupSetidId) Entriesread(entriesRead int64) XgroupSetidEntriesread {
 
 func (c XgroupSetidId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XgroupSetidKey Completed
+type XgroupSetidKey Incomplete
 
 func (c XgroupSetidKey) Group(group string) XgroupSetidGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XgroupSetidGroup)(c)
 }
 
-type XinfoConsumers Completed
+type XinfoConsumers Incomplete
 
 func (b Builder) XinfoConsumers() (c XinfoConsumers) {
-	c = XinfoConsumers{cs: get(), ks: b.ks, cf: readonly}
+	c = XinfoConsumers{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XINFO", "CONSUMERS")
 	return c
 }
@@ -774,24 +774,24 @@ func (c XinfoConsumers) Key(key string) XinfoConsumersKey {
 	return (XinfoConsumersKey)(c)
 }
 
-type XinfoConsumersGroup Completed
+type XinfoConsumersGroup Incomplete
 
 func (c XinfoConsumersGroup) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XinfoConsumersKey Completed
+type XinfoConsumersKey Incomplete
 
 func (c XinfoConsumersKey) Group(group string) XinfoConsumersGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XinfoConsumersGroup)(c)
 }
 
-type XinfoGroups Completed
+type XinfoGroups Incomplete
 
 func (b Builder) XinfoGroups() (c XinfoGroups) {
-	c = XinfoGroups{cs: get(), ks: b.ks, cf: readonly}
+	c = XinfoGroups{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XINFO", "GROUPS")
 	return c
 }
@@ -806,30 +806,30 @@ func (c XinfoGroups) Key(key string) XinfoGroupsKey {
 	return (XinfoGroupsKey)(c)
 }
 
-type XinfoGroupsKey Completed
+type XinfoGroupsKey Incomplete
 
 func (c XinfoGroupsKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XinfoHelp Completed
+type XinfoHelp Incomplete
 
 func (b Builder) XinfoHelp() (c XinfoHelp) {
-	c = XinfoHelp{cs: get(), ks: b.ks, cf: readonly}
+	c = XinfoHelp{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XINFO", "HELP")
 	return c
 }
 
 func (c XinfoHelp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XinfoStream Completed
+type XinfoStream Incomplete
 
 func (b Builder) XinfoStream() (c XinfoStream) {
-	c = XinfoStream{cs: get(), ks: b.ks, cf: readonly}
+	c = XinfoStream{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XINFO", "STREAM")
 	return c
 }
@@ -844,14 +844,14 @@ func (c XinfoStream) Key(key string) XinfoStreamKey {
 	return (XinfoStreamKey)(c)
 }
 
-type XinfoStreamFullCount Completed
+type XinfoStreamFullCount Incomplete
 
 func (c XinfoStreamFullCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XinfoStreamFullFull Completed
+type XinfoStreamFullFull Incomplete
 
 func (c XinfoStreamFullFull) Count(count int64) XinfoStreamFullCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -860,10 +860,10 @@ func (c XinfoStreamFullFull) Count(count int64) XinfoStreamFullCount {
 
 func (c XinfoStreamFullFull) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XinfoStreamKey Completed
+type XinfoStreamKey Incomplete
 
 func (c XinfoStreamKey) Full() XinfoStreamFullFull {
 	c.cs.s = append(c.cs.s, "FULL")
@@ -872,13 +872,13 @@ func (c XinfoStreamKey) Full() XinfoStreamFullFull {
 
 func (c XinfoStreamKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Xlen Completed
+type Xlen Incomplete
 
 func (b Builder) Xlen() (c Xlen) {
-	c = Xlen{cs: get(), ks: b.ks, cf: readonly}
+	c = Xlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XLEN")
 	return c
 }
@@ -893,17 +893,17 @@ func (c Xlen) Key(key string) XlenKey {
 	return (XlenKey)(c)
 }
 
-type XlenKey Completed
+type XlenKey Incomplete
 
 func (c XlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Xpending Completed
+type Xpending Incomplete
 
 func (b Builder) Xpending() (c Xpending) {
-	c = Xpending{cs: get(), ks: b.ks, cf: readonly}
+	c = Xpending{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XPENDING")
 	return c
 }
@@ -918,14 +918,14 @@ func (c Xpending) Key(key string) XpendingKey {
 	return (XpendingKey)(c)
 }
 
-type XpendingFiltersConsumer Completed
+type XpendingFiltersConsumer Incomplete
 
 func (c XpendingFiltersConsumer) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XpendingFiltersCount Completed
+type XpendingFiltersCount Incomplete
 
 func (c XpendingFiltersCount) Consumer(consumer string) XpendingFiltersConsumer {
 	c.cs.s = append(c.cs.s, consumer)
@@ -934,31 +934,31 @@ func (c XpendingFiltersCount) Consumer(consumer string) XpendingFiltersConsumer 
 
 func (c XpendingFiltersCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XpendingFiltersEnd Completed
+type XpendingFiltersEnd Incomplete
 
 func (c XpendingFiltersEnd) Count(count int64) XpendingFiltersCount {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(count, 10))
 	return (XpendingFiltersCount)(c)
 }
 
-type XpendingFiltersIdle Completed
+type XpendingFiltersIdle Incomplete
 
 func (c XpendingFiltersIdle) Start(start string) XpendingFiltersStart {
 	c.cs.s = append(c.cs.s, start)
 	return (XpendingFiltersStart)(c)
 }
 
-type XpendingFiltersStart Completed
+type XpendingFiltersStart Incomplete
 
 func (c XpendingFiltersStart) End(end string) XpendingFiltersEnd {
 	c.cs.s = append(c.cs.s, end)
 	return (XpendingFiltersEnd)(c)
 }
 
-type XpendingGroup Completed
+type XpendingGroup Incomplete
 
 func (c XpendingGroup) Idle(minIdleTime int64) XpendingFiltersIdle {
 	c.cs.s = append(c.cs.s, "IDLE", strconv.FormatInt(minIdleTime, 10))
@@ -972,20 +972,20 @@ func (c XpendingGroup) Start(start string) XpendingFiltersStart {
 
 func (c XpendingGroup) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XpendingKey Completed
+type XpendingKey Incomplete
 
 func (c XpendingKey) Group(group string) XpendingGroup {
 	c.cs.s = append(c.cs.s, group)
 	return (XpendingGroup)(c)
 }
 
-type Xrange Completed
+type Xrange Incomplete
 
 func (b Builder) Xrange() (c Xrange) {
-	c = Xrange{cs: get(), ks: b.ks, cf: readonly}
+	c = Xrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XRANGE")
 	return c
 }
@@ -1000,14 +1000,14 @@ func (c Xrange) Key(key string) XrangeKey {
 	return (XrangeKey)(c)
 }
 
-type XrangeCount Completed
+type XrangeCount Incomplete
 
 func (c XrangeCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XrangeEnd Completed
+type XrangeEnd Incomplete
 
 func (c XrangeEnd) Count(count int64) XrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1016,27 +1016,27 @@ func (c XrangeEnd) Count(count int64) XrangeCount {
 
 func (c XrangeEnd) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XrangeKey Completed
+type XrangeKey Incomplete
 
 func (c XrangeKey) Start(start string) XrangeStart {
 	c.cs.s = append(c.cs.s, start)
 	return (XrangeStart)(c)
 }
 
-type XrangeStart Completed
+type XrangeStart Incomplete
 
 func (c XrangeStart) End(end string) XrangeEnd {
 	c.cs.s = append(c.cs.s, end)
 	return (XrangeEnd)(c)
 }
 
-type Xread Completed
+type Xread Incomplete
 
 func (b Builder) Xread() (c Xread) {
-	c = Xread{cs: get(), ks: b.ks, cf: readonly}
+	c = Xread{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XREAD")
 	return c
 }
@@ -1047,7 +1047,7 @@ func (c Xread) Count(count int64) XreadCount {
 }
 
 func (c Xread) Block(milliseconds int64) XreadBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "BLOCK", strconv.FormatInt(milliseconds, 10))
 	return (XreadBlock)(c)
 }
@@ -1057,17 +1057,17 @@ func (c Xread) Streams() XreadStreams {
 	return (XreadStreams)(c)
 }
 
-type XreadBlock Completed
+type XreadBlock Incomplete
 
 func (c XreadBlock) Streams() XreadStreams {
 	c.cs.s = append(c.cs.s, "STREAMS")
 	return (XreadStreams)(c)
 }
 
-type XreadCount Completed
+type XreadCount Incomplete
 
 func (c XreadCount) Block(milliseconds int64) XreadBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "BLOCK", strconv.FormatInt(milliseconds, 10))
 	return (XreadBlock)(c)
 }
@@ -1077,7 +1077,7 @@ func (c XreadCount) Streams() XreadStreams {
 	return (XreadStreams)(c)
 }
 
-type XreadId Completed
+type XreadId Incomplete
 
 func (c XreadId) Id(id ...string) XreadId {
 	c.cs.s = append(c.cs.s, id...)
@@ -1086,10 +1086,10 @@ func (c XreadId) Id(id ...string) XreadId {
 
 func (c XreadId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XreadKey Completed
+type XreadKey Incomplete
 
 func (c XreadKey) Key(key ...string) XreadKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1111,7 +1111,7 @@ func (c XreadKey) Id(id ...string) XreadId {
 	return (XreadId)(c)
 }
 
-type XreadStreams Completed
+type XreadStreams Incomplete
 
 func (c XreadStreams) Key(key ...string) XreadKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1128,7 +1128,7 @@ func (c XreadStreams) Key(key ...string) XreadKey {
 	return (XreadKey)(c)
 }
 
-type Xreadgroup Completed
+type Xreadgroup Incomplete
 
 func (b Builder) Xreadgroup() (c Xreadgroup) {
 	c = Xreadgroup{cs: get(), ks: b.ks}
@@ -1141,7 +1141,7 @@ func (c Xreadgroup) Group(group string, consumer string) XreadgroupGroup {
 	return (XreadgroupGroup)(c)
 }
 
-type XreadgroupBlock Completed
+type XreadgroupBlock Incomplete
 
 func (c XreadgroupBlock) Noack() XreadgroupNoack {
 	c.cs.s = append(c.cs.s, "NOACK")
@@ -1153,10 +1153,10 @@ func (c XreadgroupBlock) Streams() XreadgroupStreams {
 	return (XreadgroupStreams)(c)
 }
 
-type XreadgroupCount Completed
+type XreadgroupCount Incomplete
 
 func (c XreadgroupCount) Block(milliseconds int64) XreadgroupBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "BLOCK", strconv.FormatInt(milliseconds, 10))
 	return (XreadgroupBlock)(c)
 }
@@ -1171,7 +1171,7 @@ func (c XreadgroupCount) Streams() XreadgroupStreams {
 	return (XreadgroupStreams)(c)
 }
 
-type XreadgroupGroup Completed
+type XreadgroupGroup Incomplete
 
 func (c XreadgroupGroup) Count(count int64) XreadgroupCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1179,7 +1179,7 @@ func (c XreadgroupGroup) Count(count int64) XreadgroupCount {
 }
 
 func (c XreadgroupGroup) Block(milliseconds int64) XreadgroupBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "BLOCK", strconv.FormatInt(milliseconds, 10))
 	return (XreadgroupBlock)(c)
 }
@@ -1194,7 +1194,7 @@ func (c XreadgroupGroup) Streams() XreadgroupStreams {
 	return (XreadgroupStreams)(c)
 }
 
-type XreadgroupId Completed
+type XreadgroupId Incomplete
 
 func (c XreadgroupId) Id(id ...string) XreadgroupId {
 	c.cs.s = append(c.cs.s, id...)
@@ -1203,10 +1203,10 @@ func (c XreadgroupId) Id(id ...string) XreadgroupId {
 
 func (c XreadgroupId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XreadgroupKey Completed
+type XreadgroupKey Incomplete
 
 func (c XreadgroupKey) Key(key ...string) XreadgroupKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1228,14 +1228,14 @@ func (c XreadgroupKey) Id(id ...string) XreadgroupId {
 	return (XreadgroupId)(c)
 }
 
-type XreadgroupNoack Completed
+type XreadgroupNoack Incomplete
 
 func (c XreadgroupNoack) Streams() XreadgroupStreams {
 	c.cs.s = append(c.cs.s, "STREAMS")
 	return (XreadgroupStreams)(c)
 }
 
-type XreadgroupStreams Completed
+type XreadgroupStreams Incomplete
 
 func (c XreadgroupStreams) Key(key ...string) XreadgroupKey {
 	if c.ks&NoSlot == NoSlot {
@@ -1252,10 +1252,10 @@ func (c XreadgroupStreams) Key(key ...string) XreadgroupKey {
 	return (XreadgroupKey)(c)
 }
 
-type Xrevrange Completed
+type Xrevrange Incomplete
 
 func (b Builder) Xrevrange() (c Xrevrange) {
-	c = Xrevrange{cs: get(), ks: b.ks, cf: readonly}
+	c = Xrevrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "XREVRANGE")
 	return c
 }
@@ -1270,28 +1270,28 @@ func (c Xrevrange) Key(key string) XrevrangeKey {
 	return (XrevrangeKey)(c)
 }
 
-type XrevrangeCount Completed
+type XrevrangeCount Incomplete
 
 func (c XrevrangeCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XrevrangeEnd Completed
+type XrevrangeEnd Incomplete
 
 func (c XrevrangeEnd) Start(start string) XrevrangeStart {
 	c.cs.s = append(c.cs.s, start)
 	return (XrevrangeStart)(c)
 }
 
-type XrevrangeKey Completed
+type XrevrangeKey Incomplete
 
 func (c XrevrangeKey) End(end string) XrevrangeEnd {
 	c.cs.s = append(c.cs.s, end)
 	return (XrevrangeEnd)(c)
 }
 
-type XrevrangeStart Completed
+type XrevrangeStart Incomplete
 
 func (c XrevrangeStart) Count(count int64) XrevrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -1300,10 +1300,10 @@ func (c XrevrangeStart) Count(count int64) XrevrangeCount {
 
 func (c XrevrangeStart) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Xsetid Completed
+type Xsetid Incomplete
 
 func (b Builder) Xsetid() (c Xsetid) {
 	c = Xsetid{cs: get(), ks: b.ks}
@@ -1321,7 +1321,7 @@ func (c Xsetid) Key(key string) XsetidKey {
 	return (XsetidKey)(c)
 }
 
-type XsetidEntriesadded Completed
+type XsetidEntriesadded Incomplete
 
 func (c XsetidEntriesadded) Maxdeletedid(maxDeletedEntryId string) XsetidMaxdeletedid {
 	c.cs.s = append(c.cs.s, "MAXDELETEDID", maxDeletedEntryId)
@@ -1330,17 +1330,17 @@ func (c XsetidEntriesadded) Maxdeletedid(maxDeletedEntryId string) XsetidMaxdele
 
 func (c XsetidEntriesadded) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XsetidKey Completed
+type XsetidKey Incomplete
 
 func (c XsetidKey) LastId(lastId string) XsetidLastId {
 	c.cs.s = append(c.cs.s, lastId)
 	return (XsetidLastId)(c)
 }
 
-type XsetidLastId Completed
+type XsetidLastId Incomplete
 
 func (c XsetidLastId) Entriesadded(entriesAdded int64) XsetidEntriesadded {
 	c.cs.s = append(c.cs.s, "ENTRIESADDED", strconv.FormatInt(entriesAdded, 10))
@@ -1354,17 +1354,17 @@ func (c XsetidLastId) Maxdeletedid(maxDeletedEntryId string) XsetidMaxdeletedid 
 
 func (c XsetidLastId) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XsetidMaxdeletedid Completed
+type XsetidMaxdeletedid Incomplete
 
 func (c XsetidMaxdeletedid) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Xtrim Completed
+type Xtrim Incomplete
 
 func (b Builder) Xtrim() (c Xtrim) {
 	c = Xtrim{cs: get(), ks: b.ks}
@@ -1382,7 +1382,7 @@ func (c Xtrim) Key(key string) XtrimKey {
 	return (XtrimKey)(c)
 }
 
-type XtrimKey Completed
+type XtrimKey Incomplete
 
 func (c XtrimKey) Maxlen() XtrimTrimStrategyMaxlen {
 	c.cs.s = append(c.cs.s, "MAXLEN")
@@ -1394,28 +1394,28 @@ func (c XtrimKey) Minid() XtrimTrimStrategyMinid {
 	return (XtrimTrimStrategyMinid)(c)
 }
 
-type XtrimTrimLimit Completed
+type XtrimTrimLimit Incomplete
 
 func (c XtrimTrimLimit) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type XtrimTrimOperatorAlmost Completed
+type XtrimTrimOperatorAlmost Incomplete
 
 func (c XtrimTrimOperatorAlmost) Threshold(threshold string) XtrimTrimThreshold {
 	c.cs.s = append(c.cs.s, threshold)
 	return (XtrimTrimThreshold)(c)
 }
 
-type XtrimTrimOperatorExact Completed
+type XtrimTrimOperatorExact Incomplete
 
 func (c XtrimTrimOperatorExact) Threshold(threshold string) XtrimTrimThreshold {
 	c.cs.s = append(c.cs.s, threshold)
 	return (XtrimTrimThreshold)(c)
 }
 
-type XtrimTrimStrategyMaxlen Completed
+type XtrimTrimStrategyMaxlen Incomplete
 
 func (c XtrimTrimStrategyMaxlen) Exact() XtrimTrimOperatorExact {
 	c.cs.s = append(c.cs.s, "=")
@@ -1432,7 +1432,7 @@ func (c XtrimTrimStrategyMaxlen) Threshold(threshold string) XtrimTrimThreshold 
 	return (XtrimTrimThreshold)(c)
 }
 
-type XtrimTrimStrategyMinid Completed
+type XtrimTrimStrategyMinid Incomplete
 
 func (c XtrimTrimStrategyMinid) Exact() XtrimTrimOperatorExact {
 	c.cs.s = append(c.cs.s, "=")
@@ -1449,7 +1449,7 @@ func (c XtrimTrimStrategyMinid) Threshold(threshold string) XtrimTrimThreshold {
 	return (XtrimTrimThreshold)(c)
 }
 
-type XtrimTrimThreshold Completed
+type XtrimTrimThreshold Incomplete
 
 func (c XtrimTrimThreshold) Limit(count int64) XtrimTrimLimit {
 	c.cs.s = append(c.cs.s, "LIMIT", strconv.FormatInt(count, 10))
@@ -1458,5 +1458,5 @@ func (c XtrimTrimThreshold) Limit(count int64) XtrimTrimLimit {
 
 func (c XtrimTrimThreshold) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_string.go
+++ b/internal/cmds/gen_string.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-type Append Completed
+type Append Incomplete
 
 func (b Builder) Append() (c Append) {
 	c = Append{cs: get(), ks: b.ks}
@@ -25,21 +25,21 @@ func (c Append) Key(key string) AppendKey {
 	return (AppendKey)(c)
 }
 
-type AppendKey Completed
+type AppendKey Incomplete
 
 func (c AppendKey) Value(value string) AppendValue {
 	c.cs.s = append(c.cs.s, value)
 	return (AppendValue)(c)
 }
 
-type AppendValue Completed
+type AppendValue Incomplete
 
 func (c AppendValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Decr Completed
+type Decr Incomplete
 
 func (b Builder) Decr() (c Decr) {
 	c = Decr{cs: get(), ks: b.ks}
@@ -57,14 +57,14 @@ func (c Decr) Key(key string) DecrKey {
 	return (DecrKey)(c)
 }
 
-type DecrKey Completed
+type DecrKey Incomplete
 
 func (c DecrKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Decrby Completed
+type Decrby Incomplete
 
 func (b Builder) Decrby() (c Decrby) {
 	c = Decrby{cs: get(), ks: b.ks}
@@ -82,24 +82,24 @@ func (c Decrby) Key(key string) DecrbyKey {
 	return (DecrbyKey)(c)
 }
 
-type DecrbyDecrement Completed
+type DecrbyDecrement Incomplete
 
 func (c DecrbyDecrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type DecrbyKey Completed
+type DecrbyKey Incomplete
 
 func (c DecrbyKey) Decrement(decrement int64) DecrbyDecrement {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(decrement, 10))
 	return (DecrbyDecrement)(c)
 }
 
-type Get Completed
+type Get Incomplete
 
 func (b Builder) Get() (c Get) {
-	c = Get{cs: get(), ks: b.ks, cf: readonly}
+	c = Get{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GET")
 	return c
 }
@@ -114,19 +114,19 @@ func (c Get) Key(key string) GetKey {
 	return (GetKey)(c)
 }
 
-type GetKey Completed
+type GetKey Incomplete
 
 func (c GetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GetKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Getdel Completed
+type Getdel Incomplete
 
 func (b Builder) Getdel() (c Getdel) {
 	c = Getdel{cs: get(), ks: b.ks}
@@ -144,14 +144,14 @@ func (c Getdel) Key(key string) GetdelKey {
 	return (GetdelKey)(c)
 }
 
-type GetdelKey Completed
+type GetdelKey Incomplete
 
 func (c GetdelKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Getex Completed
+type Getex Incomplete
 
 func (b Builder) Getex() (c Getex) {
 	c = Getex{cs: get(), ks: b.ks}
@@ -169,70 +169,70 @@ func (c Getex) Key(key string) GetexKey {
 	return (GetexKey)(c)
 }
 
-type GetexExpirationExSecTyped Completed
+type GetexExpirationExSecTyped Incomplete
 
 func (c GetexExpirationExSecTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationExSeconds Completed
+type GetexExpirationExSeconds Incomplete
 
 func (c GetexExpirationExSeconds) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationExatTimestamp Completed
+type GetexExpirationExatTimestamp Incomplete
 
 func (c GetexExpirationExatTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationExatTimestampTyped Completed
+type GetexExpirationExatTimestampTyped Incomplete
 
 func (c GetexExpirationExatTimestampTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationPersist Completed
+type GetexExpirationPersist Incomplete
 
 func (c GetexExpirationPersist) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationPxMilliseconds Completed
+type GetexExpirationPxMilliseconds Incomplete
 
 func (c GetexExpirationPxMilliseconds) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationPxMsTyped Completed
+type GetexExpirationPxMsTyped Incomplete
 
 func (c GetexExpirationPxMsTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationPxatMillisecondsTimestamp Completed
+type GetexExpirationPxatMillisecondsTimestamp Incomplete
 
 func (c GetexExpirationPxatMillisecondsTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexExpirationPxatMsTimestampTyped Completed
+type GetexExpirationPxatMsTimestampTyped Incomplete
 
 func (c GetexExpirationPxatMsTimestampTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetexKey Completed
+type GetexKey Incomplete
 
 func (c GetexKey) ExSeconds(seconds int64) GetexExpirationExSeconds {
 	c.cs.s = append(c.cs.s, "EX", strconv.FormatInt(seconds, 10))
@@ -281,13 +281,13 @@ func (c GetexKey) Pxat(timestamp time.Time) GetexExpirationPxatMsTimestampTyped 
 
 func (c GetexKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Getrange Completed
+type Getrange Incomplete
 
 func (b Builder) Getrange() (c Getrange) {
-	c = Getrange{cs: get(), ks: b.ks, cf: readonly}
+	c = Getrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "GETRANGE")
 	return c
 }
@@ -302,33 +302,33 @@ func (c Getrange) Key(key string) GetrangeKey {
 	return (GetrangeKey)(c)
 }
 
-type GetrangeEnd Completed
+type GetrangeEnd Incomplete
 
 func (c GetrangeEnd) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c GetrangeEnd) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type GetrangeKey Completed
+type GetrangeKey Incomplete
 
 func (c GetrangeKey) Start(start int64) GetrangeStart {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(start, 10))
 	return (GetrangeStart)(c)
 }
 
-type GetrangeStart Completed
+type GetrangeStart Incomplete
 
 func (c GetrangeStart) End(end int64) GetrangeEnd {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(end, 10))
 	return (GetrangeEnd)(c)
 }
 
-type Getset Completed
+type Getset Incomplete
 
 func (b Builder) Getset() (c Getset) {
 	c = Getset{cs: get(), ks: b.ks}
@@ -346,21 +346,21 @@ func (c Getset) Key(key string) GetsetKey {
 	return (GetsetKey)(c)
 }
 
-type GetsetKey Completed
+type GetsetKey Incomplete
 
 func (c GetsetKey) Value(value string) GetsetValue {
 	c.cs.s = append(c.cs.s, value)
 	return (GetsetValue)(c)
 }
 
-type GetsetValue Completed
+type GetsetValue Incomplete
 
 func (c GetsetValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Incr Completed
+type Incr Incomplete
 
 func (b Builder) Incr() (c Incr) {
 	c = Incr{cs: get(), ks: b.ks}
@@ -378,14 +378,14 @@ func (c Incr) Key(key string) IncrKey {
 	return (IncrKey)(c)
 }
 
-type IncrKey Completed
+type IncrKey Incomplete
 
 func (c IncrKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Incrby Completed
+type Incrby Incomplete
 
 func (b Builder) Incrby() (c Incrby) {
 	c = Incrby{cs: get(), ks: b.ks}
@@ -403,21 +403,21 @@ func (c Incrby) Key(key string) IncrbyKey {
 	return (IncrbyKey)(c)
 }
 
-type IncrbyIncrement Completed
+type IncrbyIncrement Incomplete
 
 func (c IncrbyIncrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type IncrbyKey Completed
+type IncrbyKey Incomplete
 
 func (c IncrbyKey) Increment(increment int64) IncrbyIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(increment, 10))
 	return (IncrbyIncrement)(c)
 }
 
-type Incrbyfloat Completed
+type Incrbyfloat Incomplete
 
 func (b Builder) Incrbyfloat() (c Incrbyfloat) {
 	c = Incrbyfloat{cs: get(), ks: b.ks}
@@ -435,24 +435,24 @@ func (c Incrbyfloat) Key(key string) IncrbyfloatKey {
 	return (IncrbyfloatKey)(c)
 }
 
-type IncrbyfloatIncrement Completed
+type IncrbyfloatIncrement Incomplete
 
 func (c IncrbyfloatIncrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type IncrbyfloatKey Completed
+type IncrbyfloatKey Incomplete
 
 func (c IncrbyfloatKey) Increment(increment float64) IncrbyfloatIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(increment, 'f', -1, 64))
 	return (IncrbyfloatIncrement)(c)
 }
 
-type Lcs Completed
+type Lcs Incomplete
 
 func (b Builder) Lcs() (c Lcs) {
-	c = Lcs{cs: get(), ks: b.ks, cf: readonly}
+	c = Lcs{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "LCS")
 	return c
 }
@@ -467,7 +467,7 @@ func (c Lcs) Key1(key1 string) LcsKey1 {
 	return (LcsKey1)(c)
 }
 
-type LcsIdx Completed
+type LcsIdx Incomplete
 
 func (c LcsIdx) Minmatchlen(len int64) LcsMinmatchlen {
 	c.cs.s = append(c.cs.s, "MINMATCHLEN", strconv.FormatInt(len, 10))
@@ -481,10 +481,10 @@ func (c LcsIdx) Withmatchlen() LcsWithmatchlen {
 
 func (c LcsIdx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LcsKey1 Completed
+type LcsKey1 Incomplete
 
 func (c LcsKey1) Key2(key2 string) LcsKey2 {
 	if c.ks&NoSlot == NoSlot {
@@ -496,7 +496,7 @@ func (c LcsKey1) Key2(key2 string) LcsKey2 {
 	return (LcsKey2)(c)
 }
 
-type LcsKey2 Completed
+type LcsKey2 Incomplete
 
 func (c LcsKey2) Len() LcsLen {
 	c.cs.s = append(c.cs.s, "LEN")
@@ -520,10 +520,10 @@ func (c LcsKey2) Withmatchlen() LcsWithmatchlen {
 
 func (c LcsKey2) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LcsLen Completed
+type LcsLen Incomplete
 
 func (c LcsLen) Idx() LcsIdx {
 	c.cs.s = append(c.cs.s, "IDX")
@@ -542,10 +542,10 @@ func (c LcsLen) Withmatchlen() LcsWithmatchlen {
 
 func (c LcsLen) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LcsMinmatchlen Completed
+type LcsMinmatchlen Incomplete
 
 func (c LcsMinmatchlen) Withmatchlen() LcsWithmatchlen {
 	c.cs.s = append(c.cs.s, "WITHMATCHLEN")
@@ -554,20 +554,20 @@ func (c LcsMinmatchlen) Withmatchlen() LcsWithmatchlen {
 
 func (c LcsMinmatchlen) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type LcsWithmatchlen Completed
+type LcsWithmatchlen Incomplete
 
 func (c LcsWithmatchlen) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Mget Completed
+type Mget Incomplete
 
 func (b Builder) Mget() (c Mget) {
-	c = Mget{cs: get(), ks: b.ks, cf: mtGetTag}
+	c = Mget{cs: get(), ks: b.ks, cf: int16(mtGetTag)}
 	c.cs.s = append(c.cs.s, "MGET")
 	return c
 }
@@ -587,7 +587,7 @@ func (c Mget) Key(key ...string) MgetKey {
 	return (MgetKey)(c)
 }
 
-type MgetKey Completed
+type MgetKey Incomplete
 
 func (c MgetKey) Key(key ...string) MgetKey {
 	if c.ks&NoSlot == NoSlot {
@@ -606,15 +606,15 @@ func (c MgetKey) Key(key ...string) MgetKey {
 
 func (c MgetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c MgetKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Mset Completed
+type Mset Incomplete
 
 func (b Builder) Mset() (c Mset) {
 	c = Mset{cs: get(), ks: b.ks}
@@ -626,7 +626,7 @@ func (c Mset) KeyValue() MsetKeyValue {
 	return (MsetKeyValue)(c)
 }
 
-type MsetKeyValue Completed
+type MsetKeyValue Incomplete
 
 func (c MsetKeyValue) KeyValue(key string, value string) MsetKeyValue {
 	if c.ks&NoSlot == NoSlot {
@@ -640,10 +640,10 @@ func (c MsetKeyValue) KeyValue(key string, value string) MsetKeyValue {
 
 func (c MsetKeyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Msetnx Completed
+type Msetnx Incomplete
 
 func (b Builder) Msetnx() (c Msetnx) {
 	c = Msetnx{cs: get(), ks: b.ks}
@@ -655,7 +655,7 @@ func (c Msetnx) KeyValue() MsetnxKeyValue {
 	return (MsetnxKeyValue)(c)
 }
 
-type MsetnxKeyValue Completed
+type MsetnxKeyValue Incomplete
 
 func (c MsetnxKeyValue) KeyValue(key string, value string) MsetnxKeyValue {
 	if c.ks&NoSlot == NoSlot {
@@ -669,10 +669,10 @@ func (c MsetnxKeyValue) KeyValue(key string, value string) MsetnxKeyValue {
 
 func (c MsetnxKeyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Psetex Completed
+type Psetex Incomplete
 
 func (b Builder) Psetex() (c Psetex) {
 	c = Psetex{cs: get(), ks: b.ks}
@@ -690,28 +690,28 @@ func (c Psetex) Key(key string) PsetexKey {
 	return (PsetexKey)(c)
 }
 
-type PsetexKey Completed
+type PsetexKey Incomplete
 
 func (c PsetexKey) Milliseconds(milliseconds int64) PsetexMilliseconds {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(milliseconds, 10))
 	return (PsetexMilliseconds)(c)
 }
 
-type PsetexMilliseconds Completed
+type PsetexMilliseconds Incomplete
 
 func (c PsetexMilliseconds) Value(value string) PsetexValue {
 	c.cs.s = append(c.cs.s, value)
 	return (PsetexValue)(c)
 }
 
-type PsetexValue Completed
+type PsetexValue Incomplete
 
 func (c PsetexValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Set Completed
+type Set Incomplete
 
 func (b Builder) Set() (c Set) {
 	c = Set{cs: get(), ks: b.ks}
@@ -729,7 +729,7 @@ func (c Set) Key(key string) SetKey {
 	return (SetKey)(c)
 }
 
-type SetConditionNx Completed
+type SetConditionNx Incomplete
 
 func (c SetConditionNx) Get() SetGet {
 	c.cs.s = append(c.cs.s, "GET")
@@ -783,10 +783,10 @@ func (c SetConditionNx) Pxat(timestamp time.Time) SetExpirationPxatMsTimestampTy
 
 func (c SetConditionNx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetConditionXx Completed
+type SetConditionXx Incomplete
 
 func (c SetConditionXx) Get() SetGet {
 	c.cs.s = append(c.cs.s, "GET")
@@ -840,73 +840,73 @@ func (c SetConditionXx) Pxat(timestamp time.Time) SetExpirationPxatMsTimestampTy
 
 func (c SetConditionXx) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationExSecTyped Completed
+type SetExpirationExSecTyped Incomplete
 
 func (c SetExpirationExSecTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationExSeconds Completed
+type SetExpirationExSeconds Incomplete
 
 func (c SetExpirationExSeconds) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationExatTimestamp Completed
+type SetExpirationExatTimestamp Incomplete
 
 func (c SetExpirationExatTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationExatTimestampTyped Completed
+type SetExpirationExatTimestampTyped Incomplete
 
 func (c SetExpirationExatTimestampTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationKeepttl Completed
+type SetExpirationKeepttl Incomplete
 
 func (c SetExpirationKeepttl) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationPxMilliseconds Completed
+type SetExpirationPxMilliseconds Incomplete
 
 func (c SetExpirationPxMilliseconds) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationPxMsTyped Completed
+type SetExpirationPxMsTyped Incomplete
 
 func (c SetExpirationPxMsTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationPxatMillisecondsTimestamp Completed
+type SetExpirationPxatMillisecondsTimestamp Incomplete
 
 func (c SetExpirationPxatMillisecondsTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetExpirationPxatMsTimestampTyped Completed
+type SetExpirationPxatMsTimestampTyped Incomplete
 
 func (c SetExpirationPxatMsTimestampTyped) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetGet Completed
+type SetGet Incomplete
 
 func (c SetGet) ExSeconds(seconds int64) SetExpirationExSeconds {
 	c.cs.s = append(c.cs.s, "EX", strconv.FormatInt(seconds, 10))
@@ -955,17 +955,17 @@ func (c SetGet) Pxat(timestamp time.Time) SetExpirationPxatMsTimestampTyped {
 
 func (c SetGet) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type SetKey Completed
+type SetKey Incomplete
 
 func (c SetKey) Value(value string) SetValue {
 	c.cs.s = append(c.cs.s, value)
 	return (SetValue)(c)
 }
 
-type SetValue Completed
+type SetValue Incomplete
 
 func (c SetValue) Nx() SetConditionNx {
 	c.cs.s = append(c.cs.s, "NX")
@@ -1029,10 +1029,10 @@ func (c SetValue) Pxat(timestamp time.Time) SetExpirationPxatMsTimestampTyped {
 
 func (c SetValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Setex Completed
+type Setex Incomplete
 
 func (b Builder) Setex() (c Setex) {
 	c = Setex{cs: get(), ks: b.ks}
@@ -1050,28 +1050,28 @@ func (c Setex) Key(key string) SetexKey {
 	return (SetexKey)(c)
 }
 
-type SetexKey Completed
+type SetexKey Incomplete
 
 func (c SetexKey) Seconds(seconds int64) SetexSeconds {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(seconds, 10))
 	return (SetexSeconds)(c)
 }
 
-type SetexSeconds Completed
+type SetexSeconds Incomplete
 
 func (c SetexSeconds) Value(value string) SetexValue {
 	c.cs.s = append(c.cs.s, value)
 	return (SetexValue)(c)
 }
 
-type SetexValue Completed
+type SetexValue Incomplete
 
 func (c SetexValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Setnx Completed
+type Setnx Incomplete
 
 func (b Builder) Setnx() (c Setnx) {
 	c = Setnx{cs: get(), ks: b.ks}
@@ -1089,21 +1089,21 @@ func (c Setnx) Key(key string) SetnxKey {
 	return (SetnxKey)(c)
 }
 
-type SetnxKey Completed
+type SetnxKey Incomplete
 
 func (c SetnxKey) Value(value string) SetnxValue {
 	c.cs.s = append(c.cs.s, value)
 	return (SetnxValue)(c)
 }
 
-type SetnxValue Completed
+type SetnxValue Incomplete
 
 func (c SetnxValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Setrange Completed
+type Setrange Incomplete
 
 func (b Builder) Setrange() (c Setrange) {
 	c = Setrange{cs: get(), ks: b.ks}
@@ -1121,31 +1121,31 @@ func (c Setrange) Key(key string) SetrangeKey {
 	return (SetrangeKey)(c)
 }
 
-type SetrangeKey Completed
+type SetrangeKey Incomplete
 
 func (c SetrangeKey) Offset(offset int64) SetrangeOffset {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(offset, 10))
 	return (SetrangeOffset)(c)
 }
 
-type SetrangeOffset Completed
+type SetrangeOffset Incomplete
 
 func (c SetrangeOffset) Value(value string) SetrangeValue {
 	c.cs.s = append(c.cs.s, value)
 	return (SetrangeValue)(c)
 }
 
-type SetrangeValue Completed
+type SetrangeValue Incomplete
 
 func (c SetrangeValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Strlen Completed
+type Strlen Incomplete
 
 func (b Builder) Strlen() (c Strlen) {
-	c = Strlen{cs: get(), ks: b.ks, cf: readonly}
+	c = Strlen{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "STRLEN")
 	return c
 }
@@ -1160,14 +1160,14 @@ func (c Strlen) Key(key string) StrlenKey {
 	return (StrlenKey)(c)
 }
 
-type StrlenKey Completed
+type StrlenKey Incomplete
 
 func (c StrlenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c StrlenKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_suggestion.go
+++ b/internal/cmds/gen_suggestion.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type FtSugadd Completed
+type FtSugadd Incomplete
 
 func (b Builder) FtSugadd() (c FtSugadd) {
 	c = FtSugadd{cs: get(), ks: b.ks}
@@ -17,7 +17,7 @@ func (c FtSugadd) Key(key string) FtSugaddKey {
 	return (FtSugaddKey)(c)
 }
 
-type FtSugaddIncrementScoreIncr Completed
+type FtSugaddIncrementScoreIncr Incomplete
 
 func (c FtSugaddIncrementScoreIncr) Payload(payload string) FtSugaddPayload {
 	c.cs.s = append(c.cs.s, "PAYLOAD", payload)
@@ -26,24 +26,24 @@ func (c FtSugaddIncrementScoreIncr) Payload(payload string) FtSugaddPayload {
 
 func (c FtSugaddIncrementScoreIncr) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSugaddKey Completed
+type FtSugaddKey Incomplete
 
 func (c FtSugaddKey) String(string string) FtSugaddString {
 	c.cs.s = append(c.cs.s, string)
 	return (FtSugaddString)(c)
 }
 
-type FtSugaddPayload Completed
+type FtSugaddPayload Incomplete
 
 func (c FtSugaddPayload) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSugaddScore Completed
+type FtSugaddScore Incomplete
 
 func (c FtSugaddScore) Incr() FtSugaddIncrementScoreIncr {
 	c.cs.s = append(c.cs.s, "INCR")
@@ -57,17 +57,17 @@ func (c FtSugaddScore) Payload(payload string) FtSugaddPayload {
 
 func (c FtSugaddScore) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSugaddString Completed
+type FtSugaddString Incomplete
 
 func (c FtSugaddString) Score(score float64) FtSugaddScore {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(score, 'f', -1, 64))
 	return (FtSugaddScore)(c)
 }
 
-type FtSugdel Completed
+type FtSugdel Incomplete
 
 func (b Builder) FtSugdel() (c FtSugdel) {
 	c = FtSugdel{cs: get(), ks: b.ks}
@@ -80,21 +80,21 @@ func (c FtSugdel) Key(key string) FtSugdelKey {
 	return (FtSugdelKey)(c)
 }
 
-type FtSugdelKey Completed
+type FtSugdelKey Incomplete
 
 func (c FtSugdelKey) String(string string) FtSugdelString {
 	c.cs.s = append(c.cs.s, string)
 	return (FtSugdelString)(c)
 }
 
-type FtSugdelString Completed
+type FtSugdelString Incomplete
 
 func (c FtSugdelString) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSugget Completed
+type FtSugget Incomplete
 
 func (b Builder) FtSugget() (c FtSugget) {
 	c = FtSugget{cs: get(), ks: b.ks}
@@ -107,7 +107,7 @@ func (c FtSugget) Key(key string) FtSuggetKey {
 	return (FtSuggetKey)(c)
 }
 
-type FtSuggetFuzzy Completed
+type FtSuggetFuzzy Incomplete
 
 func (c FtSuggetFuzzy) Withscores() FtSuggetWithscores {
 	c.cs.s = append(c.cs.s, "WITHSCORES")
@@ -126,24 +126,24 @@ func (c FtSuggetFuzzy) Max(max int64) FtSuggetMax {
 
 func (c FtSuggetFuzzy) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSuggetKey Completed
+type FtSuggetKey Incomplete
 
 func (c FtSuggetKey) Prefix(prefix string) FtSuggetPrefix {
 	c.cs.s = append(c.cs.s, prefix)
 	return (FtSuggetPrefix)(c)
 }
 
-type FtSuggetMax Completed
+type FtSuggetMax Incomplete
 
 func (c FtSuggetMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSuggetPrefix Completed
+type FtSuggetPrefix Incomplete
 
 func (c FtSuggetPrefix) Fuzzy() FtSuggetFuzzy {
 	c.cs.s = append(c.cs.s, "FUZZY")
@@ -167,10 +167,10 @@ func (c FtSuggetPrefix) Max(max int64) FtSuggetMax {
 
 func (c FtSuggetPrefix) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSuggetWithpayloads Completed
+type FtSuggetWithpayloads Incomplete
 
 func (c FtSuggetWithpayloads) Max(max int64) FtSuggetMax {
 	c.cs.s = append(c.cs.s, "MAX", strconv.FormatInt(max, 10))
@@ -179,10 +179,10 @@ func (c FtSuggetWithpayloads) Max(max int64) FtSuggetMax {
 
 func (c FtSuggetWithpayloads) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSuggetWithscores Completed
+type FtSuggetWithscores Incomplete
 
 func (c FtSuggetWithscores) Withpayloads() FtSuggetWithpayloads {
 	c.cs.s = append(c.cs.s, "WITHPAYLOADS")
@@ -196,10 +196,10 @@ func (c FtSuggetWithscores) Max(max int64) FtSuggetMax {
 
 func (c FtSuggetWithscores) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type FtSuglen Completed
+type FtSuglen Incomplete
 
 func (b Builder) FtSuglen() (c FtSuglen) {
 	c = FtSuglen{cs: get(), ks: b.ks}
@@ -212,9 +212,9 @@ func (c FtSuglen) Key(key string) FtSuglenKey {
 	return (FtSuglenKey)(c)
 }
 
-type FtSuglenKey Completed
+type FtSuglenKey Incomplete
 
 func (c FtSuglenKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_tdigest.go
+++ b/internal/cmds/gen_tdigest.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type TdigestAdd Completed
+type TdigestAdd Incomplete
 
 func (b Builder) TdigestAdd() (c TdigestAdd) {
 	c = TdigestAdd{cs: get(), ks: b.ks}
@@ -22,14 +22,14 @@ func (c TdigestAdd) Key(key string) TdigestAddKey {
 	return (TdigestAddKey)(c)
 }
 
-type TdigestAddKey Completed
+type TdigestAddKey Incomplete
 
 func (c TdigestAddKey) Value(value float64) TdigestAddValuesValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
 	return (TdigestAddValuesValue)(c)
 }
 
-type TdigestAddValuesValue Completed
+type TdigestAddValuesValue Incomplete
 
 func (c TdigestAddValuesValue) Value(value float64) TdigestAddValuesValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
@@ -38,10 +38,10 @@ func (c TdigestAddValuesValue) Value(value float64) TdigestAddValuesValue {
 
 func (c TdigestAddValuesValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestByrank Completed
+type TdigestByrank Incomplete
 
 func (b Builder) TdigestByrank() (c TdigestByrank) {
 	c = TdigestByrank{cs: get(), ks: b.ks}
@@ -59,7 +59,7 @@ func (c TdigestByrank) Key(key string) TdigestByrankKey {
 	return (TdigestByrankKey)(c)
 }
 
-type TdigestByrankKey Completed
+type TdigestByrankKey Incomplete
 
 func (c TdigestByrankKey) Rank(rank ...float64) TdigestByrankRank {
 	for _, n := range rank {
@@ -68,7 +68,7 @@ func (c TdigestByrankKey) Rank(rank ...float64) TdigestByrankRank {
 	return (TdigestByrankRank)(c)
 }
 
-type TdigestByrankRank Completed
+type TdigestByrankRank Incomplete
 
 func (c TdigestByrankRank) Rank(rank ...float64) TdigestByrankRank {
 	for _, n := range rank {
@@ -79,10 +79,10 @@ func (c TdigestByrankRank) Rank(rank ...float64) TdigestByrankRank {
 
 func (c TdigestByrankRank) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestByrevrank Completed
+type TdigestByrevrank Incomplete
 
 func (b Builder) TdigestByrevrank() (c TdigestByrevrank) {
 	c = TdigestByrevrank{cs: get(), ks: b.ks}
@@ -100,7 +100,7 @@ func (c TdigestByrevrank) Key(key string) TdigestByrevrankKey {
 	return (TdigestByrevrankKey)(c)
 }
 
-type TdigestByrevrankKey Completed
+type TdigestByrevrankKey Incomplete
 
 func (c TdigestByrevrankKey) ReverseRank(reverseRank ...float64) TdigestByrevrankReverseRank {
 	for _, n := range reverseRank {
@@ -109,7 +109,7 @@ func (c TdigestByrevrankKey) ReverseRank(reverseRank ...float64) TdigestByrevran
 	return (TdigestByrevrankReverseRank)(c)
 }
 
-type TdigestByrevrankReverseRank Completed
+type TdigestByrevrankReverseRank Incomplete
 
 func (c TdigestByrevrankReverseRank) ReverseRank(reverseRank ...float64) TdigestByrevrankReverseRank {
 	for _, n := range reverseRank {
@@ -120,10 +120,10 @@ func (c TdigestByrevrankReverseRank) ReverseRank(reverseRank ...float64) Tdigest
 
 func (c TdigestByrevrankReverseRank) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestCdf Completed
+type TdigestCdf Incomplete
 
 func (b Builder) TdigestCdf() (c TdigestCdf) {
 	c = TdigestCdf{cs: get(), ks: b.ks}
@@ -141,7 +141,7 @@ func (c TdigestCdf) Key(key string) TdigestCdfKey {
 	return (TdigestCdfKey)(c)
 }
 
-type TdigestCdfKey Completed
+type TdigestCdfKey Incomplete
 
 func (c TdigestCdfKey) Value(value ...float64) TdigestCdfValue {
 	for _, n := range value {
@@ -150,7 +150,7 @@ func (c TdigestCdfKey) Value(value ...float64) TdigestCdfValue {
 	return (TdigestCdfValue)(c)
 }
 
-type TdigestCdfValue Completed
+type TdigestCdfValue Incomplete
 
 func (c TdigestCdfValue) Value(value ...float64) TdigestCdfValue {
 	for _, n := range value {
@@ -161,10 +161,10 @@ func (c TdigestCdfValue) Value(value ...float64) TdigestCdfValue {
 
 func (c TdigestCdfValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestCreate Completed
+type TdigestCreate Incomplete
 
 func (b Builder) TdigestCreate() (c TdigestCreate) {
 	c = TdigestCreate{cs: get(), ks: b.ks}
@@ -182,14 +182,14 @@ func (c TdigestCreate) Key(key string) TdigestCreateKey {
 	return (TdigestCreateKey)(c)
 }
 
-type TdigestCreateCompression Completed
+type TdigestCreateCompression Incomplete
 
 func (c TdigestCreateCompression) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestCreateKey Completed
+type TdigestCreateKey Incomplete
 
 func (c TdigestCreateKey) Compression(compression int64) TdigestCreateCompression {
 	c.cs.s = append(c.cs.s, "COMPRESSION", strconv.FormatInt(compression, 10))
@@ -198,10 +198,10 @@ func (c TdigestCreateKey) Compression(compression int64) TdigestCreateCompressio
 
 func (c TdigestCreateKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestInfo Completed
+type TdigestInfo Incomplete
 
 func (b Builder) TdigestInfo() (c TdigestInfo) {
 	c = TdigestInfo{cs: get(), ks: b.ks}
@@ -219,14 +219,14 @@ func (c TdigestInfo) Key(key string) TdigestInfoKey {
 	return (TdigestInfoKey)(c)
 }
 
-type TdigestInfoKey Completed
+type TdigestInfoKey Incomplete
 
 func (c TdigestInfoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestMax Completed
+type TdigestMax Incomplete
 
 func (b Builder) TdigestMax() (c TdigestMax) {
 	c = TdigestMax{cs: get(), ks: b.ks}
@@ -244,14 +244,14 @@ func (c TdigestMax) Key(key string) TdigestMaxKey {
 	return (TdigestMaxKey)(c)
 }
 
-type TdigestMaxKey Completed
+type TdigestMaxKey Incomplete
 
 func (c TdigestMaxKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestMerge Completed
+type TdigestMerge Incomplete
 
 func (b Builder) TdigestMerge() (c TdigestMerge) {
 	c = TdigestMerge{cs: get(), ks: b.ks}
@@ -269,7 +269,7 @@ func (c TdigestMerge) DestinationKey(destinationKey string) TdigestMergeDestinat
 	return (TdigestMergeDestinationKey)(c)
 }
 
-type TdigestMergeConfigCompression Completed
+type TdigestMergeConfigCompression Incomplete
 
 func (c TdigestMergeConfigCompression) Override() TdigestMergeOverride {
 	c.cs.s = append(c.cs.s, "OVERRIDE")
@@ -278,17 +278,17 @@ func (c TdigestMergeConfigCompression) Override() TdigestMergeOverride {
 
 func (c TdigestMergeConfigCompression) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestMergeDestinationKey Completed
+type TdigestMergeDestinationKey Incomplete
 
 func (c TdigestMergeDestinationKey) Numkeys(numkeys int64) TdigestMergeNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (TdigestMergeNumkeys)(c)
 }
 
-type TdigestMergeNumkeys Completed
+type TdigestMergeNumkeys Incomplete
 
 func (c TdigestMergeNumkeys) SourceKey(sourceKey ...string) TdigestMergeSourceKey {
 	if c.ks&NoSlot == NoSlot {
@@ -305,14 +305,14 @@ func (c TdigestMergeNumkeys) SourceKey(sourceKey ...string) TdigestMergeSourceKe
 	return (TdigestMergeSourceKey)(c)
 }
 
-type TdigestMergeOverride Completed
+type TdigestMergeOverride Incomplete
 
 func (c TdigestMergeOverride) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestMergeSourceKey Completed
+type TdigestMergeSourceKey Incomplete
 
 func (c TdigestMergeSourceKey) SourceKey(sourceKey ...string) TdigestMergeSourceKey {
 	if c.ks&NoSlot == NoSlot {
@@ -341,10 +341,10 @@ func (c TdigestMergeSourceKey) Override() TdigestMergeOverride {
 
 func (c TdigestMergeSourceKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestMin Completed
+type TdigestMin Incomplete
 
 func (b Builder) TdigestMin() (c TdigestMin) {
 	c = TdigestMin{cs: get(), ks: b.ks}
@@ -362,14 +362,14 @@ func (c TdigestMin) Key(key string) TdigestMinKey {
 	return (TdigestMinKey)(c)
 }
 
-type TdigestMinKey Completed
+type TdigestMinKey Incomplete
 
 func (c TdigestMinKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestQuantile Completed
+type TdigestQuantile Incomplete
 
 func (b Builder) TdigestQuantile() (c TdigestQuantile) {
 	c = TdigestQuantile{cs: get(), ks: b.ks}
@@ -387,7 +387,7 @@ func (c TdigestQuantile) Key(key string) TdigestQuantileKey {
 	return (TdigestQuantileKey)(c)
 }
 
-type TdigestQuantileKey Completed
+type TdigestQuantileKey Incomplete
 
 func (c TdigestQuantileKey) Quantile(quantile ...float64) TdigestQuantileQuantile {
 	for _, n := range quantile {
@@ -396,7 +396,7 @@ func (c TdigestQuantileKey) Quantile(quantile ...float64) TdigestQuantileQuantil
 	return (TdigestQuantileQuantile)(c)
 }
 
-type TdigestQuantileQuantile Completed
+type TdigestQuantileQuantile Incomplete
 
 func (c TdigestQuantileQuantile) Quantile(quantile ...float64) TdigestQuantileQuantile {
 	for _, n := range quantile {
@@ -407,10 +407,10 @@ func (c TdigestQuantileQuantile) Quantile(quantile ...float64) TdigestQuantileQu
 
 func (c TdigestQuantileQuantile) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestRank Completed
+type TdigestRank Incomplete
 
 func (b Builder) TdigestRank() (c TdigestRank) {
 	c = TdigestRank{cs: get(), ks: b.ks}
@@ -428,7 +428,7 @@ func (c TdigestRank) Key(key string) TdigestRankKey {
 	return (TdigestRankKey)(c)
 }
 
-type TdigestRankKey Completed
+type TdigestRankKey Incomplete
 
 func (c TdigestRankKey) Value(value ...float64) TdigestRankValue {
 	for _, n := range value {
@@ -437,7 +437,7 @@ func (c TdigestRankKey) Value(value ...float64) TdigestRankValue {
 	return (TdigestRankValue)(c)
 }
 
-type TdigestRankValue Completed
+type TdigestRankValue Incomplete
 
 func (c TdigestRankValue) Value(value ...float64) TdigestRankValue {
 	for _, n := range value {
@@ -448,10 +448,10 @@ func (c TdigestRankValue) Value(value ...float64) TdigestRankValue {
 
 func (c TdigestRankValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestReset Completed
+type TdigestReset Incomplete
 
 func (b Builder) TdigestReset() (c TdigestReset) {
 	c = TdigestReset{cs: get(), ks: b.ks}
@@ -469,14 +469,14 @@ func (c TdigestReset) Key(key string) TdigestResetKey {
 	return (TdigestResetKey)(c)
 }
 
-type TdigestResetKey Completed
+type TdigestResetKey Incomplete
 
 func (c TdigestResetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestRevrank Completed
+type TdigestRevrank Incomplete
 
 func (b Builder) TdigestRevrank() (c TdigestRevrank) {
 	c = TdigestRevrank{cs: get(), ks: b.ks}
@@ -494,7 +494,7 @@ func (c TdigestRevrank) Key(key string) TdigestRevrankKey {
 	return (TdigestRevrankKey)(c)
 }
 
-type TdigestRevrankKey Completed
+type TdigestRevrankKey Incomplete
 
 func (c TdigestRevrankKey) Value(value ...float64) TdigestRevrankValue {
 	for _, n := range value {
@@ -503,7 +503,7 @@ func (c TdigestRevrankKey) Value(value ...float64) TdigestRevrankValue {
 	return (TdigestRevrankValue)(c)
 }
 
-type TdigestRevrankValue Completed
+type TdigestRevrankValue Incomplete
 
 func (c TdigestRevrankValue) Value(value ...float64) TdigestRevrankValue {
 	for _, n := range value {
@@ -514,10 +514,10 @@ func (c TdigestRevrankValue) Value(value ...float64) TdigestRevrankValue {
 
 func (c TdigestRevrankValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestTrimmedMean Completed
+type TdigestTrimmedMean Incomplete
 
 func (b Builder) TdigestTrimmedMean() (c TdigestTrimmedMean) {
 	c = TdigestTrimmedMean{cs: get(), ks: b.ks}
@@ -535,21 +535,21 @@ func (c TdigestTrimmedMean) Key(key string) TdigestTrimmedMeanKey {
 	return (TdigestTrimmedMeanKey)(c)
 }
 
-type TdigestTrimmedMeanHighCutQuantile Completed
+type TdigestTrimmedMeanHighCutQuantile Incomplete
 
 func (c TdigestTrimmedMeanHighCutQuantile) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TdigestTrimmedMeanKey Completed
+type TdigestTrimmedMeanKey Incomplete
 
 func (c TdigestTrimmedMeanKey) LowCutQuantile(lowCutQuantile float64) TdigestTrimmedMeanLowCutQuantile {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(lowCutQuantile, 'f', -1, 64))
 	return (TdigestTrimmedMeanLowCutQuantile)(c)
 }
 
-type TdigestTrimmedMeanLowCutQuantile Completed
+type TdigestTrimmedMeanLowCutQuantile Incomplete
 
 func (c TdigestTrimmedMeanLowCutQuantile) HighCutQuantile(highCutQuantile float64) TdigestTrimmedMeanHighCutQuantile {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(highCutQuantile, 'f', -1, 64))

--- a/internal/cmds/gen_tensor.go
+++ b/internal/cmds/gen_tensor.go
@@ -4,10 +4,10 @@ package cmds
 
 import "strconv"
 
-type AiTensorget Completed
+type AiTensorget Incomplete
 
 func (b Builder) AiTensorget() (c AiTensorget) {
-	c = AiTensorget{cs: get(), ks: b.ks, cf: readonly}
+	c = AiTensorget{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "AI.TENSORGET")
 	return c
 }
@@ -22,38 +22,38 @@ func (c AiTensorget) Key(key string) AiTensorgetKey {
 	return (AiTensorgetKey)(c)
 }
 
-type AiTensorgetFormatBlob Completed
+type AiTensorgetFormatBlob Incomplete
 
 func (c AiTensorgetFormatBlob) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiTensorgetFormatBlob) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiTensorgetFormatValues Completed
+type AiTensorgetFormatValues Incomplete
 
 func (c AiTensorgetFormatValues) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiTensorgetFormatValues) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiTensorgetKey Completed
+type AiTensorgetKey Incomplete
 
 func (c AiTensorgetKey) Meta() AiTensorgetMeta {
 	c.cs.s = append(c.cs.s, "META")
 	return (AiTensorgetMeta)(c)
 }
 
-type AiTensorgetMeta Completed
+type AiTensorgetMeta Incomplete
 
 func (c AiTensorgetMeta) Blob() AiTensorgetFormatBlob {
 	c.cs.s = append(c.cs.s, "BLOB")
@@ -67,15 +67,15 @@ func (c AiTensorgetMeta) Values() AiTensorgetFormatValues {
 
 func (c AiTensorgetMeta) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c AiTensorgetMeta) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiTensorset Completed
+type AiTensorset Incomplete
 
 func (b Builder) AiTensorset() (c AiTensorset) {
 	c = AiTensorset{cs: get(), ks: b.ks}
@@ -93,7 +93,7 @@ func (c AiTensorset) Key(key string) AiTensorsetKey {
 	return (AiTensorsetKey)(c)
 }
 
-type AiTensorsetBlob Completed
+type AiTensorsetBlob Incomplete
 
 func (c AiTensorsetBlob) Values(value ...string) AiTensorsetValues {
 	c.cs.s = append(c.cs.s, "VALUES")
@@ -103,10 +103,10 @@ func (c AiTensorsetBlob) Values(value ...string) AiTensorsetValues {
 
 func (c AiTensorsetBlob) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiTensorsetKey Completed
+type AiTensorsetKey Incomplete
 
 func (c AiTensorsetKey) Float() AiTensorsetTypeFloat {
 	c.cs.s = append(c.cs.s, "FLOAT")
@@ -158,7 +158,7 @@ func (c AiTensorsetKey) Bool() AiTensorsetTypeBool {
 	return (AiTensorsetTypeBool)(c)
 }
 
-type AiTensorsetShape Completed
+type AiTensorsetShape Incomplete
 
 func (c AiTensorsetShape) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -180,10 +180,10 @@ func (c AiTensorsetShape) Values(value ...string) AiTensorsetValues {
 
 func (c AiTensorsetShape) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type AiTensorsetTypeBool Completed
+type AiTensorsetTypeBool Incomplete
 
 func (c AiTensorsetTypeBool) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -192,7 +192,7 @@ func (c AiTensorsetTypeBool) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeDouble Completed
+type AiTensorsetTypeDouble Incomplete
 
 func (c AiTensorsetTypeDouble) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -201,7 +201,7 @@ func (c AiTensorsetTypeDouble) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeFloat Completed
+type AiTensorsetTypeFloat Incomplete
 
 func (c AiTensorsetTypeFloat) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -210,7 +210,7 @@ func (c AiTensorsetTypeFloat) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeInt16 Completed
+type AiTensorsetTypeInt16 Incomplete
 
 func (c AiTensorsetTypeInt16) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -219,7 +219,7 @@ func (c AiTensorsetTypeInt16) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeInt32 Completed
+type AiTensorsetTypeInt32 Incomplete
 
 func (c AiTensorsetTypeInt32) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -228,7 +228,7 @@ func (c AiTensorsetTypeInt32) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeInt64 Completed
+type AiTensorsetTypeInt64 Incomplete
 
 func (c AiTensorsetTypeInt64) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -237,7 +237,7 @@ func (c AiTensorsetTypeInt64) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeInt8 Completed
+type AiTensorsetTypeInt8 Incomplete
 
 func (c AiTensorsetTypeInt8) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -246,7 +246,7 @@ func (c AiTensorsetTypeInt8) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeString Completed
+type AiTensorsetTypeString Incomplete
 
 func (c AiTensorsetTypeString) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -255,7 +255,7 @@ func (c AiTensorsetTypeString) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeUint16 Completed
+type AiTensorsetTypeUint16 Incomplete
 
 func (c AiTensorsetTypeUint16) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -264,7 +264,7 @@ func (c AiTensorsetTypeUint16) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetTypeUint8 Completed
+type AiTensorsetTypeUint8 Incomplete
 
 func (c AiTensorsetTypeUint8) Shape(shape ...int64) AiTensorsetShape {
 	for _, n := range shape {
@@ -273,7 +273,7 @@ func (c AiTensorsetTypeUint8) Shape(shape ...int64) AiTensorsetShape {
 	return (AiTensorsetShape)(c)
 }
 
-type AiTensorsetValues Completed
+type AiTensorsetValues Incomplete
 
 func (c AiTensorsetValues) Values(value ...string) AiTensorsetValues {
 	c.cs.s = append(c.cs.s, "VALUES")
@@ -283,5 +283,5 @@ func (c AiTensorsetValues) Values(value ...string) AiTensorsetValues {
 
 func (c AiTensorsetValues) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_timeseries.go
+++ b/internal/cmds/gen_timeseries.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type TsAdd Completed
+type TsAdd Incomplete
 
 func (b Builder) TsAdd() (c TsAdd) {
 	c = TsAdd{cs: get(), ks: b.ks}
@@ -22,10 +22,10 @@ func (c TsAdd) Key(key string) TsAddKey {
 	return (TsAddKey)(c)
 }
 
-type TsAddChunkSize Completed
+type TsAddChunkSize Incomplete
 
 func (c TsAddChunkSize) OnDuplicateBlock() TsAddOnDuplicateBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "ON_DUPLICATE", "BLOCK")
 	return (TsAddOnDuplicateBlock)(c)
 }
@@ -62,10 +62,10 @@ func (c TsAddChunkSize) Labels() TsAddLabels {
 
 func (c TsAddChunkSize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddEncodingCompressed Completed
+type TsAddEncodingCompressed Incomplete
 
 func (c TsAddEncodingCompressed) ChunkSize(size int64) TsAddChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -73,7 +73,7 @@ func (c TsAddEncodingCompressed) ChunkSize(size int64) TsAddChunkSize {
 }
 
 func (c TsAddEncodingCompressed) OnDuplicateBlock() TsAddOnDuplicateBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "ON_DUPLICATE", "BLOCK")
 	return (TsAddOnDuplicateBlock)(c)
 }
@@ -110,10 +110,10 @@ func (c TsAddEncodingCompressed) Labels() TsAddLabels {
 
 func (c TsAddEncodingCompressed) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddEncodingUncompressed Completed
+type TsAddEncodingUncompressed Incomplete
 
 func (c TsAddEncodingUncompressed) ChunkSize(size int64) TsAddChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -121,7 +121,7 @@ func (c TsAddEncodingUncompressed) ChunkSize(size int64) TsAddChunkSize {
 }
 
 func (c TsAddEncodingUncompressed) OnDuplicateBlock() TsAddOnDuplicateBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "ON_DUPLICATE", "BLOCK")
 	return (TsAddOnDuplicateBlock)(c)
 }
@@ -158,17 +158,17 @@ func (c TsAddEncodingUncompressed) Labels() TsAddLabels {
 
 func (c TsAddEncodingUncompressed) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddKey Completed
+type TsAddKey Incomplete
 
 func (c TsAddKey) Timestamp(timestamp string) TsAddTimestamp {
 	c.cs.s = append(c.cs.s, timestamp)
 	return (TsAddTimestamp)(c)
 }
 
-type TsAddLabels Completed
+type TsAddLabels Incomplete
 
 func (c TsAddLabels) Labels(label string, value string) TsAddLabels {
 	c.cs.s = append(c.cs.s, label, value)
@@ -177,10 +177,10 @@ func (c TsAddLabels) Labels(label string, value string) TsAddLabels {
 
 func (c TsAddLabels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddOnDuplicateBlock Completed
+type TsAddOnDuplicateBlock Incomplete
 
 func (c TsAddOnDuplicateBlock) Labels() TsAddLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -189,10 +189,10 @@ func (c TsAddOnDuplicateBlock) Labels() TsAddLabels {
 
 func (c TsAddOnDuplicateBlock) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddOnDuplicateFirst Completed
+type TsAddOnDuplicateFirst Incomplete
 
 func (c TsAddOnDuplicateFirst) Labels() TsAddLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -201,10 +201,10 @@ func (c TsAddOnDuplicateFirst) Labels() TsAddLabels {
 
 func (c TsAddOnDuplicateFirst) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddOnDuplicateLast Completed
+type TsAddOnDuplicateLast Incomplete
 
 func (c TsAddOnDuplicateLast) Labels() TsAddLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -213,10 +213,10 @@ func (c TsAddOnDuplicateLast) Labels() TsAddLabels {
 
 func (c TsAddOnDuplicateLast) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddOnDuplicateMax Completed
+type TsAddOnDuplicateMax Incomplete
 
 func (c TsAddOnDuplicateMax) Labels() TsAddLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -225,10 +225,10 @@ func (c TsAddOnDuplicateMax) Labels() TsAddLabels {
 
 func (c TsAddOnDuplicateMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddOnDuplicateMin Completed
+type TsAddOnDuplicateMin Incomplete
 
 func (c TsAddOnDuplicateMin) Labels() TsAddLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -237,10 +237,10 @@ func (c TsAddOnDuplicateMin) Labels() TsAddLabels {
 
 func (c TsAddOnDuplicateMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddOnDuplicateSum Completed
+type TsAddOnDuplicateSum Incomplete
 
 func (c TsAddOnDuplicateSum) Labels() TsAddLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -249,10 +249,10 @@ func (c TsAddOnDuplicateSum) Labels() TsAddLabels {
 
 func (c TsAddOnDuplicateSum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddRetention Completed
+type TsAddRetention Incomplete
 
 func (c TsAddRetention) EncodingUncompressed() TsAddEncodingUncompressed {
 	c.cs.s = append(c.cs.s, "ENCODING", "UNCOMPRESSED")
@@ -270,7 +270,7 @@ func (c TsAddRetention) ChunkSize(size int64) TsAddChunkSize {
 }
 
 func (c TsAddRetention) OnDuplicateBlock() TsAddOnDuplicateBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "ON_DUPLICATE", "BLOCK")
 	return (TsAddOnDuplicateBlock)(c)
 }
@@ -307,17 +307,17 @@ func (c TsAddRetention) Labels() TsAddLabels {
 
 func (c TsAddRetention) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAddTimestamp Completed
+type TsAddTimestamp Incomplete
 
 func (c TsAddTimestamp) Value(value float64) TsAddValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
 	return (TsAddValue)(c)
 }
 
-type TsAddValue Completed
+type TsAddValue Incomplete
 
 func (c TsAddValue) Retention(retentionperiod int64) TsAddRetention {
 	c.cs.s = append(c.cs.s, "RETENTION", strconv.FormatInt(retentionperiod, 10))
@@ -340,7 +340,7 @@ func (c TsAddValue) ChunkSize(size int64) TsAddChunkSize {
 }
 
 func (c TsAddValue) OnDuplicateBlock() TsAddOnDuplicateBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "ON_DUPLICATE", "BLOCK")
 	return (TsAddOnDuplicateBlock)(c)
 }
@@ -377,10 +377,10 @@ func (c TsAddValue) Labels() TsAddLabels {
 
 func (c TsAddValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlter Completed
+type TsAlter Incomplete
 
 func (b Builder) TsAlter() (c TsAlter) {
 	c = TsAlter{cs: get(), ks: b.ks}
@@ -398,10 +398,10 @@ func (c TsAlter) Key(key string) TsAlterKey {
 	return (TsAlterKey)(c)
 }
 
-type TsAlterChunkSize Completed
+type TsAlterChunkSize Incomplete
 
 func (c TsAlterChunkSize) DuplicatePolicyBlock() TsAlterDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsAlterDuplicatePolicyBlock)(c)
 }
@@ -438,10 +438,10 @@ func (c TsAlterChunkSize) Labels() TsAlterLabels {
 
 func (c TsAlterChunkSize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterDuplicatePolicyBlock Completed
+type TsAlterDuplicatePolicyBlock Incomplete
 
 func (c TsAlterDuplicatePolicyBlock) Labels() TsAlterLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -450,10 +450,10 @@ func (c TsAlterDuplicatePolicyBlock) Labels() TsAlterLabels {
 
 func (c TsAlterDuplicatePolicyBlock) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterDuplicatePolicyFirst Completed
+type TsAlterDuplicatePolicyFirst Incomplete
 
 func (c TsAlterDuplicatePolicyFirst) Labels() TsAlterLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -462,10 +462,10 @@ func (c TsAlterDuplicatePolicyFirst) Labels() TsAlterLabels {
 
 func (c TsAlterDuplicatePolicyFirst) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterDuplicatePolicyLast Completed
+type TsAlterDuplicatePolicyLast Incomplete
 
 func (c TsAlterDuplicatePolicyLast) Labels() TsAlterLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -474,10 +474,10 @@ func (c TsAlterDuplicatePolicyLast) Labels() TsAlterLabels {
 
 func (c TsAlterDuplicatePolicyLast) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterDuplicatePolicyMax Completed
+type TsAlterDuplicatePolicyMax Incomplete
 
 func (c TsAlterDuplicatePolicyMax) Labels() TsAlterLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -486,10 +486,10 @@ func (c TsAlterDuplicatePolicyMax) Labels() TsAlterLabels {
 
 func (c TsAlterDuplicatePolicyMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterDuplicatePolicyMin Completed
+type TsAlterDuplicatePolicyMin Incomplete
 
 func (c TsAlterDuplicatePolicyMin) Labels() TsAlterLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -498,10 +498,10 @@ func (c TsAlterDuplicatePolicyMin) Labels() TsAlterLabels {
 
 func (c TsAlterDuplicatePolicyMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterDuplicatePolicySum Completed
+type TsAlterDuplicatePolicySum Incomplete
 
 func (c TsAlterDuplicatePolicySum) Labels() TsAlterLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -510,10 +510,10 @@ func (c TsAlterDuplicatePolicySum) Labels() TsAlterLabels {
 
 func (c TsAlterDuplicatePolicySum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterKey Completed
+type TsAlterKey Incomplete
 
 func (c TsAlterKey) Retention(retentionperiod int64) TsAlterRetention {
 	c.cs.s = append(c.cs.s, "RETENTION", strconv.FormatInt(retentionperiod, 10))
@@ -526,7 +526,7 @@ func (c TsAlterKey) ChunkSize(size int64) TsAlterChunkSize {
 }
 
 func (c TsAlterKey) DuplicatePolicyBlock() TsAlterDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsAlterDuplicatePolicyBlock)(c)
 }
@@ -563,10 +563,10 @@ func (c TsAlterKey) Labels() TsAlterLabels {
 
 func (c TsAlterKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterLabels Completed
+type TsAlterLabels Incomplete
 
 func (c TsAlterLabels) Labels(label string, value string) TsAlterLabels {
 	c.cs.s = append(c.cs.s, label, value)
@@ -575,10 +575,10 @@ func (c TsAlterLabels) Labels(label string, value string) TsAlterLabels {
 
 func (c TsAlterLabels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsAlterRetention Completed
+type TsAlterRetention Incomplete
 
 func (c TsAlterRetention) ChunkSize(size int64) TsAlterChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -586,7 +586,7 @@ func (c TsAlterRetention) ChunkSize(size int64) TsAlterChunkSize {
 }
 
 func (c TsAlterRetention) DuplicatePolicyBlock() TsAlterDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsAlterDuplicatePolicyBlock)(c)
 }
@@ -623,10 +623,10 @@ func (c TsAlterRetention) Labels() TsAlterLabels {
 
 func (c TsAlterRetention) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreate Completed
+type TsCreate Incomplete
 
 func (b Builder) TsCreate() (c TsCreate) {
 	c = TsCreate{cs: get(), ks: b.ks}
@@ -644,10 +644,10 @@ func (c TsCreate) Key(key string) TsCreateKey {
 	return (TsCreateKey)(c)
 }
 
-type TsCreateChunkSize Completed
+type TsCreateChunkSize Incomplete
 
 func (c TsCreateChunkSize) DuplicatePolicyBlock() TsCreateDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsCreateDuplicatePolicyBlock)(c)
 }
@@ -684,10 +684,10 @@ func (c TsCreateChunkSize) Labels() TsCreateLabels {
 
 func (c TsCreateChunkSize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateDuplicatePolicyBlock Completed
+type TsCreateDuplicatePolicyBlock Incomplete
 
 func (c TsCreateDuplicatePolicyBlock) Labels() TsCreateLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -696,10 +696,10 @@ func (c TsCreateDuplicatePolicyBlock) Labels() TsCreateLabels {
 
 func (c TsCreateDuplicatePolicyBlock) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateDuplicatePolicyFirst Completed
+type TsCreateDuplicatePolicyFirst Incomplete
 
 func (c TsCreateDuplicatePolicyFirst) Labels() TsCreateLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -708,10 +708,10 @@ func (c TsCreateDuplicatePolicyFirst) Labels() TsCreateLabels {
 
 func (c TsCreateDuplicatePolicyFirst) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateDuplicatePolicyLast Completed
+type TsCreateDuplicatePolicyLast Incomplete
 
 func (c TsCreateDuplicatePolicyLast) Labels() TsCreateLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -720,10 +720,10 @@ func (c TsCreateDuplicatePolicyLast) Labels() TsCreateLabels {
 
 func (c TsCreateDuplicatePolicyLast) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateDuplicatePolicyMax Completed
+type TsCreateDuplicatePolicyMax Incomplete
 
 func (c TsCreateDuplicatePolicyMax) Labels() TsCreateLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -732,10 +732,10 @@ func (c TsCreateDuplicatePolicyMax) Labels() TsCreateLabels {
 
 func (c TsCreateDuplicatePolicyMax) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateDuplicatePolicyMin Completed
+type TsCreateDuplicatePolicyMin Incomplete
 
 func (c TsCreateDuplicatePolicyMin) Labels() TsCreateLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -744,10 +744,10 @@ func (c TsCreateDuplicatePolicyMin) Labels() TsCreateLabels {
 
 func (c TsCreateDuplicatePolicyMin) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateDuplicatePolicySum Completed
+type TsCreateDuplicatePolicySum Incomplete
 
 func (c TsCreateDuplicatePolicySum) Labels() TsCreateLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -756,10 +756,10 @@ func (c TsCreateDuplicatePolicySum) Labels() TsCreateLabels {
 
 func (c TsCreateDuplicatePolicySum) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateEncodingCompressed Completed
+type TsCreateEncodingCompressed Incomplete
 
 func (c TsCreateEncodingCompressed) ChunkSize(size int64) TsCreateChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -767,7 +767,7 @@ func (c TsCreateEncodingCompressed) ChunkSize(size int64) TsCreateChunkSize {
 }
 
 func (c TsCreateEncodingCompressed) DuplicatePolicyBlock() TsCreateDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsCreateDuplicatePolicyBlock)(c)
 }
@@ -804,10 +804,10 @@ func (c TsCreateEncodingCompressed) Labels() TsCreateLabels {
 
 func (c TsCreateEncodingCompressed) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateEncodingUncompressed Completed
+type TsCreateEncodingUncompressed Incomplete
 
 func (c TsCreateEncodingUncompressed) ChunkSize(size int64) TsCreateChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -815,7 +815,7 @@ func (c TsCreateEncodingUncompressed) ChunkSize(size int64) TsCreateChunkSize {
 }
 
 func (c TsCreateEncodingUncompressed) DuplicatePolicyBlock() TsCreateDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsCreateDuplicatePolicyBlock)(c)
 }
@@ -852,10 +852,10 @@ func (c TsCreateEncodingUncompressed) Labels() TsCreateLabels {
 
 func (c TsCreateEncodingUncompressed) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateKey Completed
+type TsCreateKey Incomplete
 
 func (c TsCreateKey) Retention(retentionperiod int64) TsCreateRetention {
 	c.cs.s = append(c.cs.s, "RETENTION", strconv.FormatInt(retentionperiod, 10))
@@ -878,7 +878,7 @@ func (c TsCreateKey) ChunkSize(size int64) TsCreateChunkSize {
 }
 
 func (c TsCreateKey) DuplicatePolicyBlock() TsCreateDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsCreateDuplicatePolicyBlock)(c)
 }
@@ -915,10 +915,10 @@ func (c TsCreateKey) Labels() TsCreateLabels {
 
 func (c TsCreateKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateLabels Completed
+type TsCreateLabels Incomplete
 
 func (c TsCreateLabels) Labels(label string, value string) TsCreateLabels {
 	c.cs.s = append(c.cs.s, label, value)
@@ -927,10 +927,10 @@ func (c TsCreateLabels) Labels(label string, value string) TsCreateLabels {
 
 func (c TsCreateLabels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateRetention Completed
+type TsCreateRetention Incomplete
 
 func (c TsCreateRetention) EncodingUncompressed() TsCreateEncodingUncompressed {
 	c.cs.s = append(c.cs.s, "ENCODING", "UNCOMPRESSED")
@@ -948,7 +948,7 @@ func (c TsCreateRetention) ChunkSize(size int64) TsCreateChunkSize {
 }
 
 func (c TsCreateRetention) DuplicatePolicyBlock() TsCreateDuplicatePolicyBlock {
-	c.cf = blockTag
+	c.cf = int16(blockTag)
 	c.cs.s = append(c.cs.s, "DUPLICATE_POLICY", "BLOCK")
 	return (TsCreateDuplicatePolicyBlock)(c)
 }
@@ -985,10 +985,10 @@ func (c TsCreateRetention) Labels() TsCreateLabels {
 
 func (c TsCreateRetention) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreaterule Completed
+type TsCreaterule Incomplete
 
 func (b Builder) TsCreaterule() (c TsCreaterule) {
 	c = TsCreaterule{cs: get(), ks: b.ks}
@@ -1006,105 +1006,105 @@ func (c TsCreaterule) Sourcekey(sourcekey string) TsCreateruleSourcekey {
 	return (TsCreateruleSourcekey)(c)
 }
 
-type TsCreateruleAggregationAvg Completed
+type TsCreateruleAggregationAvg Incomplete
 
 func (c TsCreateruleAggregationAvg) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationCount Completed
+type TsCreateruleAggregationCount Incomplete
 
 func (c TsCreateruleAggregationCount) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationFirst Completed
+type TsCreateruleAggregationFirst Incomplete
 
 func (c TsCreateruleAggregationFirst) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationLast Completed
+type TsCreateruleAggregationLast Incomplete
 
 func (c TsCreateruleAggregationLast) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationMax Completed
+type TsCreateruleAggregationMax Incomplete
 
 func (c TsCreateruleAggregationMax) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationMin Completed
+type TsCreateruleAggregationMin Incomplete
 
 func (c TsCreateruleAggregationMin) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationRange Completed
+type TsCreateruleAggregationRange Incomplete
 
 func (c TsCreateruleAggregationRange) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationStdP Completed
+type TsCreateruleAggregationStdP Incomplete
 
 func (c TsCreateruleAggregationStdP) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationStdS Completed
+type TsCreateruleAggregationStdS Incomplete
 
 func (c TsCreateruleAggregationStdS) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationSum Completed
+type TsCreateruleAggregationSum Incomplete
 
 func (c TsCreateruleAggregationSum) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationTwa Completed
+type TsCreateruleAggregationTwa Incomplete
 
 func (c TsCreateruleAggregationTwa) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationVarP Completed
+type TsCreateruleAggregationVarP Incomplete
 
 func (c TsCreateruleAggregationVarP) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAggregationVarS Completed
+type TsCreateruleAggregationVarS Incomplete
 
 func (c TsCreateruleAggregationVarS) Bucketduration(bucketduration int64) TsCreateruleBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsCreateruleBucketduration)(c)
 }
 
-type TsCreateruleAligntimestamp Completed
+type TsCreateruleAligntimestamp Incomplete
 
 func (c TsCreateruleAligntimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateruleBucketduration Completed
+type TsCreateruleBucketduration Incomplete
 
 func (c TsCreateruleBucketduration) Aligntimestamp(aligntimestamp int64) TsCreateruleAligntimestamp {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(aligntimestamp, 10))
@@ -1113,10 +1113,10 @@ func (c TsCreateruleBucketduration) Aligntimestamp(aligntimestamp int64) TsCreat
 
 func (c TsCreateruleBucketduration) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsCreateruleDestkey Completed
+type TsCreateruleDestkey Incomplete
 
 func (c TsCreateruleDestkey) AggregationAvg() TsCreateruleAggregationAvg {
 	c.cs.s = append(c.cs.s, "AGGREGATION", "AVG")
@@ -1183,7 +1183,7 @@ func (c TsCreateruleDestkey) AggregationTwa() TsCreateruleAggregationTwa {
 	return (TsCreateruleAggregationTwa)(c)
 }
 
-type TsCreateruleSourcekey Completed
+type TsCreateruleSourcekey Incomplete
 
 func (c TsCreateruleSourcekey) Destkey(destkey string) TsCreateruleDestkey {
 	if c.ks&NoSlot == NoSlot {
@@ -1195,7 +1195,7 @@ func (c TsCreateruleSourcekey) Destkey(destkey string) TsCreateruleDestkey {
 	return (TsCreateruleDestkey)(c)
 }
 
-type TsDecrby Completed
+type TsDecrby Incomplete
 
 func (b Builder) TsDecrby() (c TsDecrby) {
 	c = TsDecrby{cs: get(), ks: b.ks}
@@ -1213,7 +1213,7 @@ func (c TsDecrby) Key(key string) TsDecrbyKey {
 	return (TsDecrbyKey)(c)
 }
 
-type TsDecrbyChunkSize Completed
+type TsDecrbyChunkSize Incomplete
 
 func (c TsDecrbyChunkSize) Labels() TsDecrbyLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -1222,17 +1222,17 @@ func (c TsDecrbyChunkSize) Labels() TsDecrbyLabels {
 
 func (c TsDecrbyChunkSize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDecrbyKey Completed
+type TsDecrbyKey Incomplete
 
 func (c TsDecrbyKey) Value(value float64) TsDecrbyValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
 	return (TsDecrbyValue)(c)
 }
 
-type TsDecrbyLabels Completed
+type TsDecrbyLabels Incomplete
 
 func (c TsDecrbyLabels) Labels(label string, value string) TsDecrbyLabels {
 	c.cs.s = append(c.cs.s, label, value)
@@ -1241,10 +1241,10 @@ func (c TsDecrbyLabels) Labels(label string, value string) TsDecrbyLabels {
 
 func (c TsDecrbyLabels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDecrbyRetention Completed
+type TsDecrbyRetention Incomplete
 
 func (c TsDecrbyRetention) Uncompressed() TsDecrbyUncompressed {
 	c.cs.s = append(c.cs.s, "UNCOMPRESSED")
@@ -1263,10 +1263,10 @@ func (c TsDecrbyRetention) Labels() TsDecrbyLabels {
 
 func (c TsDecrbyRetention) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDecrbyTimestamp Completed
+type TsDecrbyTimestamp Incomplete
 
 func (c TsDecrbyTimestamp) Retention(retentionperiod int64) TsDecrbyRetention {
 	c.cs.s = append(c.cs.s, "RETENTION", strconv.FormatInt(retentionperiod, 10))
@@ -1290,10 +1290,10 @@ func (c TsDecrbyTimestamp) Labels() TsDecrbyLabels {
 
 func (c TsDecrbyTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDecrbyUncompressed Completed
+type TsDecrbyUncompressed Incomplete
 
 func (c TsDecrbyUncompressed) ChunkSize(size int64) TsDecrbyChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -1307,10 +1307,10 @@ func (c TsDecrbyUncompressed) Labels() TsDecrbyLabels {
 
 func (c TsDecrbyUncompressed) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDecrbyValue Completed
+type TsDecrbyValue Incomplete
 
 func (c TsDecrbyValue) Timestamp(timestamp string) TsDecrbyTimestamp {
 	c.cs.s = append(c.cs.s, "TIMESTAMP", timestamp)
@@ -1339,10 +1339,10 @@ func (c TsDecrbyValue) Labels() TsDecrbyLabels {
 
 func (c TsDecrbyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDel Completed
+type TsDel Incomplete
 
 func (b Builder) TsDel() (c TsDel) {
 	c = TsDel{cs: get(), ks: b.ks}
@@ -1360,28 +1360,28 @@ func (c TsDel) Key(key string) TsDelKey {
 	return (TsDelKey)(c)
 }
 
-type TsDelFromTimestamp Completed
+type TsDelFromTimestamp Incomplete
 
 func (c TsDelFromTimestamp) ToTimestamp(toTimestamp int64) TsDelToTimestamp {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(toTimestamp, 10))
 	return (TsDelToTimestamp)(c)
 }
 
-type TsDelKey Completed
+type TsDelKey Incomplete
 
 func (c TsDelKey) FromTimestamp(fromTimestamp int64) TsDelFromTimestamp {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(fromTimestamp, 10))
 	return (TsDelFromTimestamp)(c)
 }
 
-type TsDelToTimestamp Completed
+type TsDelToTimestamp Incomplete
 
 func (c TsDelToTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDeleterule Completed
+type TsDeleterule Incomplete
 
 func (b Builder) TsDeleterule() (c TsDeleterule) {
 	c = TsDeleterule{cs: get(), ks: b.ks}
@@ -1399,14 +1399,14 @@ func (c TsDeleterule) Sourcekey(sourcekey string) TsDeleteruleSourcekey {
 	return (TsDeleteruleSourcekey)(c)
 }
 
-type TsDeleteruleDestkey Completed
+type TsDeleteruleDestkey Incomplete
 
 func (c TsDeleteruleDestkey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsDeleteruleSourcekey Completed
+type TsDeleteruleSourcekey Incomplete
 
 func (c TsDeleteruleSourcekey) Destkey(destkey string) TsDeleteruleDestkey {
 	if c.ks&NoSlot == NoSlot {
@@ -1418,10 +1418,10 @@ func (c TsDeleteruleSourcekey) Destkey(destkey string) TsDeleteruleDestkey {
 	return (TsDeleteruleDestkey)(c)
 }
 
-type TsGet Completed
+type TsGet Incomplete
 
 func (b Builder) TsGet() (c TsGet) {
-	c = TsGet{cs: get(), ks: b.ks, cf: readonly}
+	c = TsGet{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TS.GET")
 	return c
 }
@@ -1436,7 +1436,7 @@ func (c TsGet) Key(key string) TsGetKey {
 	return (TsGetKey)(c)
 }
 
-type TsGetKey Completed
+type TsGetKey Incomplete
 
 func (c TsGetKey) Latest() TsGetLatest {
 	c.cs.s = append(c.cs.s, "LATEST")
@@ -1445,17 +1445,17 @@ func (c TsGetKey) Latest() TsGetLatest {
 
 func (c TsGetKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsGetLatest Completed
+type TsGetLatest Incomplete
 
 func (c TsGetLatest) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsIncrby Completed
+type TsIncrby Incomplete
 
 func (b Builder) TsIncrby() (c TsIncrby) {
 	c = TsIncrby{cs: get(), ks: b.ks}
@@ -1473,7 +1473,7 @@ func (c TsIncrby) Key(key string) TsIncrbyKey {
 	return (TsIncrbyKey)(c)
 }
 
-type TsIncrbyChunkSize Completed
+type TsIncrbyChunkSize Incomplete
 
 func (c TsIncrbyChunkSize) Labels() TsIncrbyLabels {
 	c.cs.s = append(c.cs.s, "LABELS")
@@ -1482,17 +1482,17 @@ func (c TsIncrbyChunkSize) Labels() TsIncrbyLabels {
 
 func (c TsIncrbyChunkSize) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsIncrbyKey Completed
+type TsIncrbyKey Incomplete
 
 func (c TsIncrbyKey) Value(value float64) TsIncrbyValue {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(value, 'f', -1, 64))
 	return (TsIncrbyValue)(c)
 }
 
-type TsIncrbyLabels Completed
+type TsIncrbyLabels Incomplete
 
 func (c TsIncrbyLabels) Labels(label string, value string) TsIncrbyLabels {
 	c.cs.s = append(c.cs.s, label, value)
@@ -1501,10 +1501,10 @@ func (c TsIncrbyLabels) Labels(label string, value string) TsIncrbyLabels {
 
 func (c TsIncrbyLabels) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsIncrbyRetention Completed
+type TsIncrbyRetention Incomplete
 
 func (c TsIncrbyRetention) Uncompressed() TsIncrbyUncompressed {
 	c.cs.s = append(c.cs.s, "UNCOMPRESSED")
@@ -1523,10 +1523,10 @@ func (c TsIncrbyRetention) Labels() TsIncrbyLabels {
 
 func (c TsIncrbyRetention) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsIncrbyTimestamp Completed
+type TsIncrbyTimestamp Incomplete
 
 func (c TsIncrbyTimestamp) Retention(retentionperiod int64) TsIncrbyRetention {
 	c.cs.s = append(c.cs.s, "RETENTION", strconv.FormatInt(retentionperiod, 10))
@@ -1550,10 +1550,10 @@ func (c TsIncrbyTimestamp) Labels() TsIncrbyLabels {
 
 func (c TsIncrbyTimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsIncrbyUncompressed Completed
+type TsIncrbyUncompressed Incomplete
 
 func (c TsIncrbyUncompressed) ChunkSize(size int64) TsIncrbyChunkSize {
 	c.cs.s = append(c.cs.s, "CHUNK_SIZE", strconv.FormatInt(size, 10))
@@ -1567,10 +1567,10 @@ func (c TsIncrbyUncompressed) Labels() TsIncrbyLabels {
 
 func (c TsIncrbyUncompressed) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsIncrbyValue Completed
+type TsIncrbyValue Incomplete
 
 func (c TsIncrbyValue) Timestamp(timestamp string) TsIncrbyTimestamp {
 	c.cs.s = append(c.cs.s, "TIMESTAMP", timestamp)
@@ -1599,13 +1599,13 @@ func (c TsIncrbyValue) Labels() TsIncrbyLabels {
 
 func (c TsIncrbyValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsInfo Completed
+type TsInfo Incomplete
 
 func (b Builder) TsInfo() (c TsInfo) {
-	c = TsInfo{cs: get(), ks: b.ks, cf: readonly}
+	c = TsInfo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TS.INFO")
 	return c
 }
@@ -1620,14 +1620,14 @@ func (c TsInfo) Key(key string) TsInfoKey {
 	return (TsInfoKey)(c)
 }
 
-type TsInfoDebug Completed
+type TsInfoDebug Incomplete
 
 func (c TsInfoDebug) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsInfoKey Completed
+type TsInfoKey Incomplete
 
 func (c TsInfoKey) Debug(debug string) TsInfoDebug {
 	c.cs.s = append(c.cs.s, debug)
@@ -1636,10 +1636,10 @@ func (c TsInfoKey) Debug(debug string) TsInfoDebug {
 
 func (c TsInfoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMadd Completed
+type TsMadd Incomplete
 
 func (b Builder) TsMadd() (c TsMadd) {
 	c = TsMadd{cs: get(), ks: b.ks}
@@ -1651,7 +1651,7 @@ func (c TsMadd) KeyTimestampValue() TsMaddKeyTimestampValue {
 	return (TsMaddKeyTimestampValue)(c)
 }
 
-type TsMaddKeyTimestampValue Completed
+type TsMaddKeyTimestampValue Incomplete
 
 func (c TsMaddKeyTimestampValue) KeyTimestampValue(key string, timestamp int64, value float64) TsMaddKeyTimestampValue {
 	if c.ks&NoSlot == NoSlot {
@@ -1665,10 +1665,10 @@ func (c TsMaddKeyTimestampValue) KeyTimestampValue(key string, timestamp int64, 
 
 func (c TsMaddKeyTimestampValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMget Completed
+type TsMget Incomplete
 
 func (b Builder) TsMget() (c TsMget) {
 	c = TsMget{cs: get(), ks: b.ks}
@@ -1698,7 +1698,7 @@ func (c TsMget) Filter(filter ...string) TsMgetFilter {
 	return (TsMgetFilter)(c)
 }
 
-type TsMgetFilter Completed
+type TsMgetFilter Incomplete
 
 func (c TsMgetFilter) Filter(filter ...string) TsMgetFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -1708,10 +1708,10 @@ func (c TsMgetFilter) Filter(filter ...string) TsMgetFilter {
 
 func (c TsMgetFilter) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMgetLatest Completed
+type TsMgetLatest Incomplete
 
 func (c TsMgetLatest) Withlabels() TsMgetWithlabels {
 	c.cs.s = append(c.cs.s, "WITHLABELS")
@@ -1730,7 +1730,7 @@ func (c TsMgetLatest) Filter(filter ...string) TsMgetFilter {
 	return (TsMgetFilter)(c)
 }
 
-type TsMgetSelectedLabels Completed
+type TsMgetSelectedLabels Incomplete
 
 func (c TsMgetSelectedLabels) Filter(filter ...string) TsMgetFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -1738,7 +1738,7 @@ func (c TsMgetSelectedLabels) Filter(filter ...string) TsMgetFilter {
 	return (TsMgetFilter)(c)
 }
 
-type TsMgetWithlabels Completed
+type TsMgetWithlabels Incomplete
 
 func (c TsMgetWithlabels) Filter(filter ...string) TsMgetFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -1746,7 +1746,7 @@ func (c TsMgetWithlabels) Filter(filter ...string) TsMgetFilter {
 	return (TsMgetFilter)(c)
 }
 
-type TsMrange Completed
+type TsMrange Incomplete
 
 func (b Builder) TsMrange() (c TsMrange) {
 	c = TsMrange{cs: get(), ks: b.ks}
@@ -1759,98 +1759,98 @@ func (c TsMrange) Fromtimestamp(fromtimestamp string) TsMrangeFromtimestamp {
 	return (TsMrangeFromtimestamp)(c)
 }
 
-type TsMrangeAggregationAggregationAvg Completed
+type TsMrangeAggregationAggregationAvg Incomplete
 
 func (c TsMrangeAggregationAggregationAvg) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationCount Completed
+type TsMrangeAggregationAggregationCount Incomplete
 
 func (c TsMrangeAggregationAggregationCount) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationFirst Completed
+type TsMrangeAggregationAggregationFirst Incomplete
 
 func (c TsMrangeAggregationAggregationFirst) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationLast Completed
+type TsMrangeAggregationAggregationLast Incomplete
 
 func (c TsMrangeAggregationAggregationLast) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationMax Completed
+type TsMrangeAggregationAggregationMax Incomplete
 
 func (c TsMrangeAggregationAggregationMax) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationMin Completed
+type TsMrangeAggregationAggregationMin Incomplete
 
 func (c TsMrangeAggregationAggregationMin) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationRange Completed
+type TsMrangeAggregationAggregationRange Incomplete
 
 func (c TsMrangeAggregationAggregationRange) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationStdP Completed
+type TsMrangeAggregationAggregationStdP Incomplete
 
 func (c TsMrangeAggregationAggregationStdP) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationStdS Completed
+type TsMrangeAggregationAggregationStdS Incomplete
 
 func (c TsMrangeAggregationAggregationStdS) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationSum Completed
+type TsMrangeAggregationAggregationSum Incomplete
 
 func (c TsMrangeAggregationAggregationSum) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationTwa Completed
+type TsMrangeAggregationAggregationTwa Incomplete
 
 func (c TsMrangeAggregationAggregationTwa) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationVarP Completed
+type TsMrangeAggregationAggregationVarP Incomplete
 
 func (c TsMrangeAggregationAggregationVarP) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationAggregationVarS Completed
+type TsMrangeAggregationAggregationVarS Incomplete
 
 func (c TsMrangeAggregationAggregationVarS) Bucketduration(bucketduration int64) TsMrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrangeAggregationBucketduration)(c)
 }
 
-type TsMrangeAggregationBucketduration Completed
+type TsMrangeAggregationBucketduration Incomplete
 
 func (c TsMrangeAggregationBucketduration) Buckettimestamp(buckettimestamp string) TsMrangeAggregationBuckettimestamp {
 	c.cs.s = append(c.cs.s, "BUCKETTIMESTAMP", buckettimestamp)
@@ -1868,7 +1868,7 @@ func (c TsMrangeAggregationBucketduration) Filter(filter ...string) TsMrangeFilt
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeAggregationBuckettimestamp Completed
+type TsMrangeAggregationBuckettimestamp Incomplete
 
 func (c TsMrangeAggregationBuckettimestamp) Empty() TsMrangeAggregationEmpty {
 	c.cs.s = append(c.cs.s, "EMPTY")
@@ -1881,7 +1881,7 @@ func (c TsMrangeAggregationBuckettimestamp) Filter(filter ...string) TsMrangeFil
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeAggregationEmpty Completed
+type TsMrangeAggregationEmpty Incomplete
 
 func (c TsMrangeAggregationEmpty) Filter(filter ...string) TsMrangeFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -1889,7 +1889,7 @@ func (c TsMrangeAggregationEmpty) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeAlign Completed
+type TsMrangeAlign Incomplete
 
 func (c TsMrangeAlign) AggregationAvg() TsMrangeAggregationAggregationAvg {
 	c.cs.s = append(c.cs.s, "AGGREGATION", "AVG")
@@ -1962,7 +1962,7 @@ func (c TsMrangeAlign) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeCount Completed
+type TsMrangeCount Incomplete
 
 func (c TsMrangeCount) Align(value string) TsMrangeAlign {
 	c.cs.s = append(c.cs.s, "ALIGN", value)
@@ -2040,7 +2040,7 @@ func (c TsMrangeCount) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeFilter Completed
+type TsMrangeFilter Incomplete
 
 func (c TsMrangeFilter) Filter(filter ...string) TsMrangeFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -2055,10 +2055,10 @@ func (c TsMrangeFilter) Groupby(label string, reduce string, reducer string) TsM
 
 func (c TsMrangeFilter) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMrangeFilterByTs Completed
+type TsMrangeFilterByTs Incomplete
 
 func (c TsMrangeFilterByTs) FilterByTs(timestamp ...int64) TsMrangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -2165,7 +2165,7 @@ func (c TsMrangeFilterByTs) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeFilterByValue Completed
+type TsMrangeFilterByValue Incomplete
 
 func (c TsMrangeFilterByValue) Withlabels() TsMrangeWithlabels {
 	c.cs.s = append(c.cs.s, "WITHLABELS")
@@ -2259,21 +2259,21 @@ func (c TsMrangeFilterByValue) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeFromtimestamp Completed
+type TsMrangeFromtimestamp Incomplete
 
 func (c TsMrangeFromtimestamp) Totimestamp(totimestamp string) TsMrangeTotimestamp {
 	c.cs.s = append(c.cs.s, totimestamp)
 	return (TsMrangeTotimestamp)(c)
 }
 
-type TsMrangeGroupby Completed
+type TsMrangeGroupby Incomplete
 
 func (c TsMrangeGroupby) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMrangeLatest Completed
+type TsMrangeLatest Incomplete
 
 func (c TsMrangeLatest) FilterByTs(timestamp ...int64) TsMrangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -2380,7 +2380,7 @@ func (c TsMrangeLatest) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeSelectedLabels Completed
+type TsMrangeSelectedLabels Incomplete
 
 func (c TsMrangeSelectedLabels) Count(count int64) TsMrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -2463,7 +2463,7 @@ func (c TsMrangeSelectedLabels) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeTotimestamp Completed
+type TsMrangeTotimestamp Incomplete
 
 func (c TsMrangeTotimestamp) Latest() TsMrangeLatest {
 	c.cs.s = append(c.cs.s, "LATEST")
@@ -2575,7 +2575,7 @@ func (c TsMrangeTotimestamp) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrangeWithlabels Completed
+type TsMrangeWithlabels Incomplete
 
 func (c TsMrangeWithlabels) Count(count int64) TsMrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -2658,7 +2658,7 @@ func (c TsMrangeWithlabels) Filter(filter ...string) TsMrangeFilter {
 	return (TsMrangeFilter)(c)
 }
 
-type TsMrevrange Completed
+type TsMrevrange Incomplete
 
 func (b Builder) TsMrevrange() (c TsMrevrange) {
 	c = TsMrevrange{cs: get(), ks: b.ks}
@@ -2671,98 +2671,98 @@ func (c TsMrevrange) Fromtimestamp(fromtimestamp string) TsMrevrangeFromtimestam
 	return (TsMrevrangeFromtimestamp)(c)
 }
 
-type TsMrevrangeAggregationAggregationAvg Completed
+type TsMrevrangeAggregationAggregationAvg Incomplete
 
 func (c TsMrevrangeAggregationAggregationAvg) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationCount Completed
+type TsMrevrangeAggregationAggregationCount Incomplete
 
 func (c TsMrevrangeAggregationAggregationCount) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationFirst Completed
+type TsMrevrangeAggregationAggregationFirst Incomplete
 
 func (c TsMrevrangeAggregationAggregationFirst) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationLast Completed
+type TsMrevrangeAggregationAggregationLast Incomplete
 
 func (c TsMrevrangeAggregationAggregationLast) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationMax Completed
+type TsMrevrangeAggregationAggregationMax Incomplete
 
 func (c TsMrevrangeAggregationAggregationMax) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationMin Completed
+type TsMrevrangeAggregationAggregationMin Incomplete
 
 func (c TsMrevrangeAggregationAggregationMin) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationRange Completed
+type TsMrevrangeAggregationAggregationRange Incomplete
 
 func (c TsMrevrangeAggregationAggregationRange) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationStdP Completed
+type TsMrevrangeAggregationAggregationStdP Incomplete
 
 func (c TsMrevrangeAggregationAggregationStdP) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationStdS Completed
+type TsMrevrangeAggregationAggregationStdS Incomplete
 
 func (c TsMrevrangeAggregationAggregationStdS) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationSum Completed
+type TsMrevrangeAggregationAggregationSum Incomplete
 
 func (c TsMrevrangeAggregationAggregationSum) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationTwa Completed
+type TsMrevrangeAggregationAggregationTwa Incomplete
 
 func (c TsMrevrangeAggregationAggregationTwa) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationVarP Completed
+type TsMrevrangeAggregationAggregationVarP Incomplete
 
 func (c TsMrevrangeAggregationAggregationVarP) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationAggregationVarS Completed
+type TsMrevrangeAggregationAggregationVarS Incomplete
 
 func (c TsMrevrangeAggregationAggregationVarS) Bucketduration(bucketduration int64) TsMrevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsMrevrangeAggregationBucketduration)(c)
 }
 
-type TsMrevrangeAggregationBucketduration Completed
+type TsMrevrangeAggregationBucketduration Incomplete
 
 func (c TsMrevrangeAggregationBucketduration) Buckettimestamp(buckettimestamp string) TsMrevrangeAggregationBuckettimestamp {
 	c.cs.s = append(c.cs.s, "BUCKETTIMESTAMP", buckettimestamp)
@@ -2780,7 +2780,7 @@ func (c TsMrevrangeAggregationBucketduration) Filter(filter ...string) TsMrevran
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeAggregationBuckettimestamp Completed
+type TsMrevrangeAggregationBuckettimestamp Incomplete
 
 func (c TsMrevrangeAggregationBuckettimestamp) Empty() TsMrevrangeAggregationEmpty {
 	c.cs.s = append(c.cs.s, "EMPTY")
@@ -2793,7 +2793,7 @@ func (c TsMrevrangeAggregationBuckettimestamp) Filter(filter ...string) TsMrevra
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeAggregationEmpty Completed
+type TsMrevrangeAggregationEmpty Incomplete
 
 func (c TsMrevrangeAggregationEmpty) Filter(filter ...string) TsMrevrangeFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -2801,7 +2801,7 @@ func (c TsMrevrangeAggregationEmpty) Filter(filter ...string) TsMrevrangeFilter 
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeAlign Completed
+type TsMrevrangeAlign Incomplete
 
 func (c TsMrevrangeAlign) AggregationAvg() TsMrevrangeAggregationAggregationAvg {
 	c.cs.s = append(c.cs.s, "AGGREGATION", "AVG")
@@ -2874,7 +2874,7 @@ func (c TsMrevrangeAlign) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeCount Completed
+type TsMrevrangeCount Incomplete
 
 func (c TsMrevrangeCount) Align(value string) TsMrevrangeAlign {
 	c.cs.s = append(c.cs.s, "ALIGN", value)
@@ -2952,7 +2952,7 @@ func (c TsMrevrangeCount) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeFilter Completed
+type TsMrevrangeFilter Incomplete
 
 func (c TsMrevrangeFilter) Filter(filter ...string) TsMrevrangeFilter {
 	c.cs.s = append(c.cs.s, "FILTER")
@@ -2967,10 +2967,10 @@ func (c TsMrevrangeFilter) Groupby(label string, reduce string, reducer string) 
 
 func (c TsMrevrangeFilter) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMrevrangeFilterByTs Completed
+type TsMrevrangeFilterByTs Incomplete
 
 func (c TsMrevrangeFilterByTs) FilterByTs(timestamp ...int64) TsMrevrangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -3077,7 +3077,7 @@ func (c TsMrevrangeFilterByTs) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeFilterByValue Completed
+type TsMrevrangeFilterByValue Incomplete
 
 func (c TsMrevrangeFilterByValue) Withlabels() TsMrevrangeWithlabels {
 	c.cs.s = append(c.cs.s, "WITHLABELS")
@@ -3171,21 +3171,21 @@ func (c TsMrevrangeFilterByValue) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeFromtimestamp Completed
+type TsMrevrangeFromtimestamp Incomplete
 
 func (c TsMrevrangeFromtimestamp) Totimestamp(totimestamp string) TsMrevrangeTotimestamp {
 	c.cs.s = append(c.cs.s, totimestamp)
 	return (TsMrevrangeTotimestamp)(c)
 }
 
-type TsMrevrangeGroupby Completed
+type TsMrevrangeGroupby Incomplete
 
 func (c TsMrevrangeGroupby) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsMrevrangeLatest Completed
+type TsMrevrangeLatest Incomplete
 
 func (c TsMrevrangeLatest) FilterByTs(timestamp ...int64) TsMrevrangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -3292,7 +3292,7 @@ func (c TsMrevrangeLatest) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeSelectedLabels Completed
+type TsMrevrangeSelectedLabels Incomplete
 
 func (c TsMrevrangeSelectedLabels) Count(count int64) TsMrevrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -3375,7 +3375,7 @@ func (c TsMrevrangeSelectedLabels) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeTotimestamp Completed
+type TsMrevrangeTotimestamp Incomplete
 
 func (c TsMrevrangeTotimestamp) Latest() TsMrevrangeLatest {
 	c.cs.s = append(c.cs.s, "LATEST")
@@ -3487,7 +3487,7 @@ func (c TsMrevrangeTotimestamp) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsMrevrangeWithlabels Completed
+type TsMrevrangeWithlabels Incomplete
 
 func (c TsMrevrangeWithlabels) Count(count int64) TsMrevrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -3570,10 +3570,10 @@ func (c TsMrevrangeWithlabels) Filter(filter ...string) TsMrevrangeFilter {
 	return (TsMrevrangeFilter)(c)
 }
 
-type TsQueryindex Completed
+type TsQueryindex Incomplete
 
 func (b Builder) TsQueryindex() (c TsQueryindex) {
-	c = TsQueryindex{cs: get(), ks: b.ks, cf: readonly}
+	c = TsQueryindex{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TS.QUERYINDEX")
 	return c
 }
@@ -3583,7 +3583,7 @@ func (c TsQueryindex) Filter(filter ...string) TsQueryindexFilter {
 	return (TsQueryindexFilter)(c)
 }
 
-type TsQueryindexFilter Completed
+type TsQueryindexFilter Incomplete
 
 func (c TsQueryindexFilter) Filter(filter ...string) TsQueryindexFilter {
 	c.cs.s = append(c.cs.s, filter...)
@@ -3592,13 +3592,13 @@ func (c TsQueryindexFilter) Filter(filter ...string) TsQueryindexFilter {
 
 func (c TsQueryindexFilter) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRange Completed
+type TsRange Incomplete
 
 func (b Builder) TsRange() (c TsRange) {
-	c = TsRange{cs: get(), ks: b.ks, cf: readonly}
+	c = TsRange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TS.RANGE")
 	return c
 }
@@ -3613,98 +3613,98 @@ func (c TsRange) Key(key string) TsRangeKey {
 	return (TsRangeKey)(c)
 }
 
-type TsRangeAggregationAggregationAvg Completed
+type TsRangeAggregationAggregationAvg Incomplete
 
 func (c TsRangeAggregationAggregationAvg) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationCount Completed
+type TsRangeAggregationAggregationCount Incomplete
 
 func (c TsRangeAggregationAggregationCount) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationFirst Completed
+type TsRangeAggregationAggregationFirst Incomplete
 
 func (c TsRangeAggregationAggregationFirst) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationLast Completed
+type TsRangeAggregationAggregationLast Incomplete
 
 func (c TsRangeAggregationAggregationLast) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationMax Completed
+type TsRangeAggregationAggregationMax Incomplete
 
 func (c TsRangeAggregationAggregationMax) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationMin Completed
+type TsRangeAggregationAggregationMin Incomplete
 
 func (c TsRangeAggregationAggregationMin) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationRange Completed
+type TsRangeAggregationAggregationRange Incomplete
 
 func (c TsRangeAggregationAggregationRange) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationStdP Completed
+type TsRangeAggregationAggregationStdP Incomplete
 
 func (c TsRangeAggregationAggregationStdP) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationStdS Completed
+type TsRangeAggregationAggregationStdS Incomplete
 
 func (c TsRangeAggregationAggregationStdS) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationSum Completed
+type TsRangeAggregationAggregationSum Incomplete
 
 func (c TsRangeAggregationAggregationSum) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationTwa Completed
+type TsRangeAggregationAggregationTwa Incomplete
 
 func (c TsRangeAggregationAggregationTwa) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationVarP Completed
+type TsRangeAggregationAggregationVarP Incomplete
 
 func (c TsRangeAggregationAggregationVarP) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationAggregationVarS Completed
+type TsRangeAggregationAggregationVarS Incomplete
 
 func (c TsRangeAggregationAggregationVarS) Bucketduration(bucketduration int64) TsRangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRangeAggregationBucketduration)(c)
 }
 
-type TsRangeAggregationBucketduration Completed
+type TsRangeAggregationBucketduration Incomplete
 
 func (c TsRangeAggregationBucketduration) Buckettimestamp(buckettimestamp string) TsRangeAggregationBuckettimestamp {
 	c.cs.s = append(c.cs.s, "BUCKETTIMESTAMP", buckettimestamp)
@@ -3718,10 +3718,10 @@ func (c TsRangeAggregationBucketduration) Empty() TsRangeAggregationEmpty {
 
 func (c TsRangeAggregationBucketduration) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeAggregationBuckettimestamp Completed
+type TsRangeAggregationBuckettimestamp Incomplete
 
 func (c TsRangeAggregationBuckettimestamp) Empty() TsRangeAggregationEmpty {
 	c.cs.s = append(c.cs.s, "EMPTY")
@@ -3730,17 +3730,17 @@ func (c TsRangeAggregationBuckettimestamp) Empty() TsRangeAggregationEmpty {
 
 func (c TsRangeAggregationBuckettimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeAggregationEmpty Completed
+type TsRangeAggregationEmpty Incomplete
 
 func (c TsRangeAggregationEmpty) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeAlign Completed
+type TsRangeAlign Incomplete
 
 func (c TsRangeAlign) AggregationAvg() TsRangeAggregationAggregationAvg {
 	c.cs.s = append(c.cs.s, "AGGREGATION", "AVG")
@@ -3809,10 +3809,10 @@ func (c TsRangeAlign) AggregationTwa() TsRangeAggregationAggregationTwa {
 
 func (c TsRangeAlign) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeCount Completed
+type TsRangeCount Incomplete
 
 func (c TsRangeCount) Align(value string) TsRangeAlign {
 	c.cs.s = append(c.cs.s, "ALIGN", value)
@@ -3886,10 +3886,10 @@ func (c TsRangeCount) AggregationTwa() TsRangeAggregationAggregationTwa {
 
 func (c TsRangeCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeFilterByTs Completed
+type TsRangeFilterByTs Incomplete
 
 func (c TsRangeFilterByTs) FilterByTs(timestamp ...int64) TsRangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -3981,10 +3981,10 @@ func (c TsRangeFilterByTs) AggregationTwa() TsRangeAggregationAggregationTwa {
 
 func (c TsRangeFilterByTs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeFilterByValue Completed
+type TsRangeFilterByValue Incomplete
 
 func (c TsRangeFilterByValue) Count(count int64) TsRangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -4063,24 +4063,24 @@ func (c TsRangeFilterByValue) AggregationTwa() TsRangeAggregationAggregationTwa 
 
 func (c TsRangeFilterByValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeFromtimestamp Completed
+type TsRangeFromtimestamp Incomplete
 
 func (c TsRangeFromtimestamp) Totimestamp(totimestamp string) TsRangeTotimestamp {
 	c.cs.s = append(c.cs.s, totimestamp)
 	return (TsRangeTotimestamp)(c)
 }
 
-type TsRangeKey Completed
+type TsRangeKey Incomplete
 
 func (c TsRangeKey) Fromtimestamp(fromtimestamp string) TsRangeFromtimestamp {
 	c.cs.s = append(c.cs.s, fromtimestamp)
 	return (TsRangeFromtimestamp)(c)
 }
 
-type TsRangeLatest Completed
+type TsRangeLatest Incomplete
 
 func (c TsRangeLatest) FilterByTs(timestamp ...int64) TsRangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -4172,10 +4172,10 @@ func (c TsRangeLatest) AggregationTwa() TsRangeAggregationAggregationTwa {
 
 func (c TsRangeLatest) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRangeTotimestamp Completed
+type TsRangeTotimestamp Incomplete
 
 func (c TsRangeTotimestamp) Latest() TsRangeLatest {
 	c.cs.s = append(c.cs.s, "LATEST")
@@ -4272,13 +4272,13 @@ func (c TsRangeTotimestamp) AggregationTwa() TsRangeAggregationAggregationTwa {
 
 func (c TsRangeTotimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrange Completed
+type TsRevrange Incomplete
 
 func (b Builder) TsRevrange() (c TsRevrange) {
-	c = TsRevrange{cs: get(), ks: b.ks, cf: readonly}
+	c = TsRevrange{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TS.REVRANGE")
 	return c
 }
@@ -4293,98 +4293,98 @@ func (c TsRevrange) Key(key string) TsRevrangeKey {
 	return (TsRevrangeKey)(c)
 }
 
-type TsRevrangeAggregationAggregationAvg Completed
+type TsRevrangeAggregationAggregationAvg Incomplete
 
 func (c TsRevrangeAggregationAggregationAvg) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationCount Completed
+type TsRevrangeAggregationAggregationCount Incomplete
 
 func (c TsRevrangeAggregationAggregationCount) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationFirst Completed
+type TsRevrangeAggregationAggregationFirst Incomplete
 
 func (c TsRevrangeAggregationAggregationFirst) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationLast Completed
+type TsRevrangeAggregationAggregationLast Incomplete
 
 func (c TsRevrangeAggregationAggregationLast) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationMax Completed
+type TsRevrangeAggregationAggregationMax Incomplete
 
 func (c TsRevrangeAggregationAggregationMax) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationMin Completed
+type TsRevrangeAggregationAggregationMin Incomplete
 
 func (c TsRevrangeAggregationAggregationMin) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationRange Completed
+type TsRevrangeAggregationAggregationRange Incomplete
 
 func (c TsRevrangeAggregationAggregationRange) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationStdP Completed
+type TsRevrangeAggregationAggregationStdP Incomplete
 
 func (c TsRevrangeAggregationAggregationStdP) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationStdS Completed
+type TsRevrangeAggregationAggregationStdS Incomplete
 
 func (c TsRevrangeAggregationAggregationStdS) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationSum Completed
+type TsRevrangeAggregationAggregationSum Incomplete
 
 func (c TsRevrangeAggregationAggregationSum) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationTwa Completed
+type TsRevrangeAggregationAggregationTwa Incomplete
 
 func (c TsRevrangeAggregationAggregationTwa) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationVarP Completed
+type TsRevrangeAggregationAggregationVarP Incomplete
 
 func (c TsRevrangeAggregationAggregationVarP) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationAggregationVarS Completed
+type TsRevrangeAggregationAggregationVarS Incomplete
 
 func (c TsRevrangeAggregationAggregationVarS) Bucketduration(bucketduration int64) TsRevrangeAggregationBucketduration {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(bucketduration, 10))
 	return (TsRevrangeAggregationBucketduration)(c)
 }
 
-type TsRevrangeAggregationBucketduration Completed
+type TsRevrangeAggregationBucketduration Incomplete
 
 func (c TsRevrangeAggregationBucketduration) Buckettimestamp(buckettimestamp string) TsRevrangeAggregationBuckettimestamp {
 	c.cs.s = append(c.cs.s, "BUCKETTIMESTAMP", buckettimestamp)
@@ -4398,10 +4398,10 @@ func (c TsRevrangeAggregationBucketduration) Empty() TsRevrangeAggregationEmpty 
 
 func (c TsRevrangeAggregationBucketduration) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeAggregationBuckettimestamp Completed
+type TsRevrangeAggregationBuckettimestamp Incomplete
 
 func (c TsRevrangeAggregationBuckettimestamp) Empty() TsRevrangeAggregationEmpty {
 	c.cs.s = append(c.cs.s, "EMPTY")
@@ -4410,17 +4410,17 @@ func (c TsRevrangeAggregationBuckettimestamp) Empty() TsRevrangeAggregationEmpty
 
 func (c TsRevrangeAggregationBuckettimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeAggregationEmpty Completed
+type TsRevrangeAggregationEmpty Incomplete
 
 func (c TsRevrangeAggregationEmpty) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeAlign Completed
+type TsRevrangeAlign Incomplete
 
 func (c TsRevrangeAlign) AggregationAvg() TsRevrangeAggregationAggregationAvg {
 	c.cs.s = append(c.cs.s, "AGGREGATION", "AVG")
@@ -4489,10 +4489,10 @@ func (c TsRevrangeAlign) AggregationTwa() TsRevrangeAggregationAggregationTwa {
 
 func (c TsRevrangeAlign) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeCount Completed
+type TsRevrangeCount Incomplete
 
 func (c TsRevrangeCount) Align(value string) TsRevrangeAlign {
 	c.cs.s = append(c.cs.s, "ALIGN", value)
@@ -4566,10 +4566,10 @@ func (c TsRevrangeCount) AggregationTwa() TsRevrangeAggregationAggregationTwa {
 
 func (c TsRevrangeCount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeFilterByTs Completed
+type TsRevrangeFilterByTs Incomplete
 
 func (c TsRevrangeFilterByTs) FilterByTs(timestamp ...int64) TsRevrangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -4661,10 +4661,10 @@ func (c TsRevrangeFilterByTs) AggregationTwa() TsRevrangeAggregationAggregationT
 
 func (c TsRevrangeFilterByTs) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeFilterByValue Completed
+type TsRevrangeFilterByValue Incomplete
 
 func (c TsRevrangeFilterByValue) Count(count int64) TsRevrangeCount {
 	c.cs.s = append(c.cs.s, "COUNT", strconv.FormatInt(count, 10))
@@ -4743,24 +4743,24 @@ func (c TsRevrangeFilterByValue) AggregationTwa() TsRevrangeAggregationAggregati
 
 func (c TsRevrangeFilterByValue) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeFromtimestamp Completed
+type TsRevrangeFromtimestamp Incomplete
 
 func (c TsRevrangeFromtimestamp) Totimestamp(totimestamp string) TsRevrangeTotimestamp {
 	c.cs.s = append(c.cs.s, totimestamp)
 	return (TsRevrangeTotimestamp)(c)
 }
 
-type TsRevrangeKey Completed
+type TsRevrangeKey Incomplete
 
 func (c TsRevrangeKey) Fromtimestamp(fromtimestamp string) TsRevrangeFromtimestamp {
 	c.cs.s = append(c.cs.s, fromtimestamp)
 	return (TsRevrangeFromtimestamp)(c)
 }
 
-type TsRevrangeLatest Completed
+type TsRevrangeLatest Incomplete
 
 func (c TsRevrangeLatest) FilterByTs(timestamp ...int64) TsRevrangeFilterByTs {
 	c.cs.s = append(c.cs.s, "FILTER_BY_TS")
@@ -4852,10 +4852,10 @@ func (c TsRevrangeLatest) AggregationTwa() TsRevrangeAggregationAggregationTwa {
 
 func (c TsRevrangeLatest) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TsRevrangeTotimestamp Completed
+type TsRevrangeTotimestamp Incomplete
 
 func (c TsRevrangeTotimestamp) Latest() TsRevrangeLatest {
 	c.cs.s = append(c.cs.s, "LATEST")
@@ -4952,5 +4952,5 @@ func (c TsRevrangeTotimestamp) AggregationTwa() TsRevrangeAggregationAggregation
 
 func (c TsRevrangeTotimestamp) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_topk.go
+++ b/internal/cmds/gen_topk.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type TopkAdd Completed
+type TopkAdd Incomplete
 
 func (b Builder) TopkAdd() (c TopkAdd) {
 	c = TopkAdd{cs: get(), ks: b.ks}
@@ -22,7 +22,7 @@ func (c TopkAdd) Key(key string) TopkAddKey {
 	return (TopkAddKey)(c)
 }
 
-type TopkAddItems Completed
+type TopkAddItems Incomplete
 
 func (c TopkAddItems) Items(items ...string) TopkAddItems {
 	c.cs.s = append(c.cs.s, items...)
@@ -31,17 +31,17 @@ func (c TopkAddItems) Items(items ...string) TopkAddItems {
 
 func (c TopkAddItems) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkAddKey Completed
+type TopkAddKey Incomplete
 
 func (c TopkAddKey) Items(items ...string) TopkAddItems {
 	c.cs.s = append(c.cs.s, items...)
 	return (TopkAddItems)(c)
 }
 
-type TopkCount Completed
+type TopkCount Incomplete
 
 func (b Builder) TopkCount() (c TopkCount) {
 	c = TopkCount{cs: get(), ks: b.ks}
@@ -59,7 +59,7 @@ func (c TopkCount) Key(key string) TopkCountKey {
 	return (TopkCountKey)(c)
 }
 
-type TopkCountItem Completed
+type TopkCountItem Incomplete
 
 func (c TopkCountItem) Item(item ...string) TopkCountItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -68,17 +68,17 @@ func (c TopkCountItem) Item(item ...string) TopkCountItem {
 
 func (c TopkCountItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkCountKey Completed
+type TopkCountKey Incomplete
 
 func (c TopkCountKey) Item(item ...string) TopkCountItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (TopkCountItem)(c)
 }
 
-type TopkIncrby Completed
+type TopkIncrby Incomplete
 
 func (b Builder) TopkIncrby() (c TopkIncrby) {
 	c = TopkIncrby{cs: get(), ks: b.ks}
@@ -96,7 +96,7 @@ func (c TopkIncrby) Key(key string) TopkIncrbyKey {
 	return (TopkIncrbyKey)(c)
 }
 
-type TopkIncrbyItemsIncrement Completed
+type TopkIncrbyItemsIncrement Incomplete
 
 func (c TopkIncrbyItemsIncrement) Item(item string) TopkIncrbyItemsItem {
 	c.cs.s = append(c.cs.s, item)
@@ -105,27 +105,27 @@ func (c TopkIncrbyItemsIncrement) Item(item string) TopkIncrbyItemsItem {
 
 func (c TopkIncrbyItemsIncrement) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkIncrbyItemsItem Completed
+type TopkIncrbyItemsItem Incomplete
 
 func (c TopkIncrbyItemsItem) Increment(increment int64) TopkIncrbyItemsIncrement {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(increment, 10))
 	return (TopkIncrbyItemsIncrement)(c)
 }
 
-type TopkIncrbyKey Completed
+type TopkIncrbyKey Incomplete
 
 func (c TopkIncrbyKey) Item(item string) TopkIncrbyItemsItem {
 	c.cs.s = append(c.cs.s, item)
 	return (TopkIncrbyItemsItem)(c)
 }
 
-type TopkInfo Completed
+type TopkInfo Incomplete
 
 func (b Builder) TopkInfo() (c TopkInfo) {
-	c = TopkInfo{cs: get(), ks: b.ks, cf: readonly}
+	c = TopkInfo{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TOPK.INFO")
 	return c
 }
@@ -140,22 +140,22 @@ func (c TopkInfo) Key(key string) TopkInfoKey {
 	return (TopkInfoKey)(c)
 }
 
-type TopkInfoKey Completed
+type TopkInfoKey Incomplete
 
 func (c TopkInfoKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c TopkInfoKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkList Completed
+type TopkList Incomplete
 
 func (b Builder) TopkList() (c TopkList) {
-	c = TopkList{cs: get(), ks: b.ks, cf: readonly}
+	c = TopkList{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TOPK.LIST")
 	return c
 }
@@ -170,7 +170,7 @@ func (c TopkList) Key(key string) TopkListKey {
 	return (TopkListKey)(c)
 }
 
-type TopkListKey Completed
+type TopkListKey Incomplete
 
 func (c TopkListKey) Withcount() TopkListWithcount {
 	c.cs.s = append(c.cs.s, "WITHCOUNT")
@@ -179,30 +179,30 @@ func (c TopkListKey) Withcount() TopkListWithcount {
 
 func (c TopkListKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c TopkListKey) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkListWithcount Completed
+type TopkListWithcount Incomplete
 
 func (c TopkListWithcount) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c TopkListWithcount) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkQuery Completed
+type TopkQuery Incomplete
 
 func (b Builder) TopkQuery() (c TopkQuery) {
-	c = TopkQuery{cs: get(), ks: b.ks, cf: readonly}
+	c = TopkQuery{cs: get(), ks: b.ks, cf: int16(readonly)}
 	c.cs.s = append(c.cs.s, "TOPK.QUERY")
 	return c
 }
@@ -217,7 +217,7 @@ func (c TopkQuery) Key(key string) TopkQueryKey {
 	return (TopkQueryKey)(c)
 }
 
-type TopkQueryItem Completed
+type TopkQueryItem Incomplete
 
 func (c TopkQueryItem) Item(item ...string) TopkQueryItem {
 	c.cs.s = append(c.cs.s, item...)
@@ -226,22 +226,22 @@ func (c TopkQueryItem) Item(item ...string) TopkQueryItem {
 
 func (c TopkQueryItem) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
 func (c TopkQueryItem) Cache() Cacheable {
 	c.cs.Build()
-	return Cacheable(c)
+	return Cacheable{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkQueryKey Completed
+type TopkQueryKey Incomplete
 
 func (c TopkQueryKey) Item(item ...string) TopkQueryItem {
 	c.cs.s = append(c.cs.s, item...)
 	return (TopkQueryItem)(c)
 }
 
-type TopkReserve Completed
+type TopkReserve Incomplete
 
 func (b Builder) TopkReserve() (c TopkReserve) {
 	c = TopkReserve{cs: get(), ks: b.ks}
@@ -259,35 +259,35 @@ func (c TopkReserve) Key(key string) TopkReserveKey {
 	return (TopkReserveKey)(c)
 }
 
-type TopkReserveKey Completed
+type TopkReserveKey Incomplete
 
 func (c TopkReserveKey) Topk(topk int64) TopkReserveTopk {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(topk, 10))
 	return (TopkReserveTopk)(c)
 }
 
-type TopkReserveParamsDecay Completed
+type TopkReserveParamsDecay Incomplete
 
 func (c TopkReserveParamsDecay) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TopkReserveParamsDepth Completed
+type TopkReserveParamsDepth Incomplete
 
 func (c TopkReserveParamsDepth) Decay(decay float64) TopkReserveParamsDecay {
 	c.cs.s = append(c.cs.s, strconv.FormatFloat(decay, 'f', -1, 64))
 	return (TopkReserveParamsDecay)(c)
 }
 
-type TopkReserveParamsWidth Completed
+type TopkReserveParamsWidth Incomplete
 
 func (c TopkReserveParamsWidth) Depth(depth int64) TopkReserveParamsDepth {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(depth, 10))
 	return (TopkReserveParamsDepth)(c)
 }
 
-type TopkReserveTopk Completed
+type TopkReserveTopk Incomplete
 
 func (c TopkReserveTopk) Width(width int64) TopkReserveParamsWidth {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(width, 10))
@@ -296,5 +296,5 @@ func (c TopkReserveTopk) Width(width int64) TopkReserveParamsWidth {
 
 func (c TopkReserveTopk) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_transactions.go
+++ b/internal/cmds/gen_transactions.go
@@ -2,7 +2,7 @@
 
 package cmds
 
-type Discard Completed
+type Discard Incomplete
 
 func (b Builder) Discard() (c Discard) {
 	c = Discard{cs: get(), ks: b.ks}
@@ -12,10 +12,10 @@ func (b Builder) Discard() (c Discard) {
 
 func (c Discard) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Exec Completed
+type Exec Incomplete
 
 func (b Builder) Exec() (c Exec) {
 	c = Exec{cs: get(), ks: b.ks}
@@ -25,10 +25,10 @@ func (b Builder) Exec() (c Exec) {
 
 func (c Exec) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Multi Completed
+type Multi Incomplete
 
 func (b Builder) Multi() (c Multi) {
 	c = Multi{cs: get(), ks: b.ks}
@@ -38,10 +38,10 @@ func (b Builder) Multi() (c Multi) {
 
 func (c Multi) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Unwatch Completed
+type Unwatch Incomplete
 
 func (b Builder) Unwatch() (c Unwatch) {
 	c = Unwatch{cs: get(), ks: b.ks}
@@ -51,10 +51,10 @@ func (b Builder) Unwatch() (c Unwatch) {
 
 func (c Unwatch) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Watch Completed
+type Watch Incomplete
 
 func (b Builder) Watch() (c Watch) {
 	c = Watch{cs: get(), ks: b.ks}
@@ -77,7 +77,7 @@ func (c Watch) Key(key ...string) WatchKey {
 	return (WatchKey)(c)
 }
 
-type WatchKey Completed
+type WatchKey Incomplete
 
 func (c WatchKey) Key(key ...string) WatchKey {
 	if c.ks&NoSlot == NoSlot {
@@ -96,5 +96,5 @@ func (c WatchKey) Key(key ...string) WatchKey {
 
 func (c WatchKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }

--- a/internal/cmds/gen_triggers_and_functions.go
+++ b/internal/cmds/gen_triggers_and_functions.go
@@ -4,7 +4,7 @@ package cmds
 
 import "strconv"
 
-type Tfcall Completed
+type Tfcall Incomplete
 
 func (b Builder) Tfcall() (c Tfcall) {
 	c = Tfcall{cs: get(), ks: b.ks}
@@ -17,7 +17,7 @@ func (c Tfcall) LibraryFunction(libraryFunction string) TfcallLibraryFunction {
 	return (TfcallLibraryFunction)(c)
 }
 
-type TfcallArg Completed
+type TfcallArg Incomplete
 
 func (c TfcallArg) Arg(arg ...string) TfcallArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -26,10 +26,10 @@ func (c TfcallArg) Arg(arg ...string) TfcallArg {
 
 func (c TfcallArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfcallKey Completed
+type TfcallKey Incomplete
 
 func (c TfcallKey) Key(key ...string) TfcallKey {
 	if c.ks&NoSlot == NoSlot {
@@ -53,17 +53,17 @@ func (c TfcallKey) Arg(arg ...string) TfcallArg {
 
 func (c TfcallKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfcallLibraryFunction Completed
+type TfcallLibraryFunction Incomplete
 
 func (c TfcallLibraryFunction) Numkeys(numkeys int64) TfcallNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (TfcallNumkeys)(c)
 }
 
-type TfcallNumkeys Completed
+type TfcallNumkeys Incomplete
 
 func (c TfcallNumkeys) Key(key ...string) TfcallKey {
 	if c.ks&NoSlot == NoSlot {
@@ -87,10 +87,10 @@ func (c TfcallNumkeys) Arg(arg ...string) TfcallArg {
 
 func (c TfcallNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type Tfcallasync Completed
+type Tfcallasync Incomplete
 
 func (b Builder) Tfcallasync() (c Tfcallasync) {
 	c = Tfcallasync{cs: get(), ks: b.ks}
@@ -103,7 +103,7 @@ func (c Tfcallasync) LibraryFunction(libraryFunction string) TfcallasyncLibraryF
 	return (TfcallasyncLibraryFunction)(c)
 }
 
-type TfcallasyncArg Completed
+type TfcallasyncArg Incomplete
 
 func (c TfcallasyncArg) Arg(arg ...string) TfcallasyncArg {
 	c.cs.s = append(c.cs.s, arg...)
@@ -112,10 +112,10 @@ func (c TfcallasyncArg) Arg(arg ...string) TfcallasyncArg {
 
 func (c TfcallasyncArg) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfcallasyncKey Completed
+type TfcallasyncKey Incomplete
 
 func (c TfcallasyncKey) Key(key ...string) TfcallasyncKey {
 	if c.ks&NoSlot == NoSlot {
@@ -139,17 +139,17 @@ func (c TfcallasyncKey) Arg(arg ...string) TfcallasyncArg {
 
 func (c TfcallasyncKey) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfcallasyncLibraryFunction Completed
+type TfcallasyncLibraryFunction Incomplete
 
 func (c TfcallasyncLibraryFunction) Numkeys(numkeys int64) TfcallasyncNumkeys {
 	c.cs.s = append(c.cs.s, strconv.FormatInt(numkeys, 10))
 	return (TfcallasyncNumkeys)(c)
 }
 
-type TfcallasyncNumkeys Completed
+type TfcallasyncNumkeys Incomplete
 
 func (c TfcallasyncNumkeys) Key(key ...string) TfcallasyncKey {
 	if c.ks&NoSlot == NoSlot {
@@ -173,10 +173,10 @@ func (c TfcallasyncNumkeys) Arg(arg ...string) TfcallasyncArg {
 
 func (c TfcallasyncNumkeys) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionDelete Completed
+type TfunctionDelete Incomplete
 
 func (b Builder) TfunctionDelete() (c TfunctionDelete) {
 	c = TfunctionDelete{cs: get(), ks: b.ks}
@@ -189,14 +189,14 @@ func (c TfunctionDelete) LibraryName(libraryName string) TfunctionDeleteLibraryN
 	return (TfunctionDeleteLibraryName)(c)
 }
 
-type TfunctionDeleteLibraryName Completed
+type TfunctionDeleteLibraryName Incomplete
 
 func (c TfunctionDeleteLibraryName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionList Completed
+type TfunctionList Incomplete
 
 func (b Builder) TfunctionList() (c TfunctionList) {
 	c = TfunctionList{cs: get(), ks: b.ks}
@@ -226,10 +226,10 @@ func (c TfunctionList) V() TfunctionListV {
 
 func (c TfunctionList) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionListLibraryName Completed
+type TfunctionListLibraryName Incomplete
 
 func (c TfunctionListLibraryName) Withcode() TfunctionListWithcode {
 	c.cs.s = append(c.cs.s, "WITHCODE")
@@ -248,17 +248,17 @@ func (c TfunctionListLibraryName) V() TfunctionListV {
 
 func (c TfunctionListLibraryName) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionListV Completed
+type TfunctionListV Incomplete
 
 func (c TfunctionListV) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionListVerbose Completed
+type TfunctionListVerbose Incomplete
 
 func (c TfunctionListVerbose) V() TfunctionListV {
 	c.cs.s = append(c.cs.s, "V")
@@ -267,10 +267,10 @@ func (c TfunctionListVerbose) V() TfunctionListV {
 
 func (c TfunctionListVerbose) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionListWithcode Completed
+type TfunctionListWithcode Incomplete
 
 func (c TfunctionListWithcode) Verbose() TfunctionListVerbose {
 	c.cs.s = append(c.cs.s, "VERBOSE")
@@ -284,10 +284,10 @@ func (c TfunctionListWithcode) V() TfunctionListV {
 
 func (c TfunctionListWithcode) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionLoad Completed
+type TfunctionLoad Incomplete
 
 func (b Builder) TfunctionLoad() (c TfunctionLoad) {
 	c = TfunctionLoad{cs: get(), ks: b.ks}
@@ -310,21 +310,21 @@ func (c TfunctionLoad) LibraryCode(libraryCode string) TfunctionLoadLibraryCode 
 	return (TfunctionLoadLibraryCode)(c)
 }
 
-type TfunctionLoadConfig Completed
+type TfunctionLoadConfig Incomplete
 
 func (c TfunctionLoadConfig) LibraryCode(libraryCode string) TfunctionLoadLibraryCode {
 	c.cs.s = append(c.cs.s, libraryCode)
 	return (TfunctionLoadLibraryCode)(c)
 }
 
-type TfunctionLoadLibraryCode Completed
+type TfunctionLoadLibraryCode Incomplete
 
 func (c TfunctionLoadLibraryCode) Build() Completed {
 	c.cs.Build()
-	return Completed(c)
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
-type TfunctionLoadReplace Completed
+type TfunctionLoadReplace Incomplete
 
 func (c TfunctionLoadReplace) Config(config string) TfunctionLoadConfig {
 	c.cs.s = append(c.cs.s, config)


### PR DESCRIPTION
This prevents the Go language server from auto-casting commands to `rueidis.Completed` by Introducing the `rueidis.Incomplete` as the intermediate struct of the command builder and fixes https://github.com/redis/rueidis/issues/58.