### PR TITLE
Add option for an AUTH credential function

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -152,6 +152,14 @@ func _newPipe(connFn func() (net.Conn, error), option *ClientOption, r2ps bool) 
 	p.pshks.Store(emptypshks)
 	p.clhks.Store(emptyclhks)
 
+	if option.AuthCredentialsFn != nil {
+		username, password, err := option.AuthCredentialsFn()
+		if err == nil {
+			option.Username = username
+			option.Password = password
+		}
+	}
+
 	helloCmd := []string{"HELLO", "3"}
 	if option.Password != "" && option.Username == "" {
 		helloCmd = append(helloCmd, "AUTH", "default", option.Password)

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -294,6 +294,41 @@ func TestNewPipe(t *testing.T) {
 		n1.Close()
 		n2.Close()
 	})
+	t.Run("Auth with Credentials Function", func(t *testing.T) {
+		n1, n2 := net.Pipe()
+		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
+		go func() {
+			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
+				Reply(RedisMessage{
+					typ: '%',
+					values: []RedisMessage{
+						{typ: '+', string: "proto"},
+						{typ: ':', integer: 3},
+					},
+				})
+			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
+				ReplyString("OK")
+			mock.Expect("SELECT", "1").
+				ReplyString("OK")
+			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
+				ReplyError("UNKNOWN COMMAND")
+		}()
+		p, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
+			SelectDB: 1,
+			AuthCredentialsFn: func() (username string, password string, err error) {
+				return "ua", "pa", nil
+			},
+			ClientName: "cn",
+		})
+		if err != nil {
+			t.Fatalf("pipe setup failed: %v", err)
+		}
+		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		p.Close()
+		mock.Close()
+		n1.Close()
+		n2.Close()
+	})
 	t.Run("With ClientSideTrackingOptions", func(t *testing.T) {
 		n1, n2 := net.Pipe()
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}

--- a/rueidis.go
+++ b/rueidis.go
@@ -79,7 +79,7 @@ type ClientOption struct {
 
 	// AuthCredentialsFn allows for setting the AUTH username and password dynamically on each connection attempt to
 	// support rotating credentials
-	AuthCredentialsFn func() (username string, password string, err error)
+	AuthCredentialsFn func(AuthCredentialsContext) (AuthCredentials, error)
 
 	// ClientSetInfo will assign various info attributes to the current connection
 	ClientSetInfo []string
@@ -266,6 +266,17 @@ func CT(cmd Cacheable, ttl time.Duration) CacheableTTL {
 type CacheableTTL struct {
 	Cmd Cacheable
 	TTL time.Duration
+}
+
+// AuthCredentialsContext is the parameter container of AuthCredentialsFn
+type AuthCredentialsContext struct {
+	Address net.Addr
+}
+
+// AuthCredentials is the output of AuthCredentialsFn
+type AuthCredentials struct {
+	Username string
+	Password string
 }
 
 // NewClient uses ClientOption to initialize the Client for both cluster client and single client.

--- a/rueidis.go
+++ b/rueidis.go
@@ -77,6 +77,10 @@ type ClientOption struct {
 	Password   string
 	ClientName string
 
+	// AuthCredentialsFn allows for setting the AUTH username and password dynamically on each connection attempt to
+	// support rotating credentials
+	AuthCredentialsFn func() (username string, password string, err error)
+
 	// ClientSetInfo will assign various info attributes to the current connection
 	ClientSetInfo []string
 


### PR DESCRIPTION
We are developing an implementation of short-lived token authentication for Redis which requires that the password associated with the Redis authentication change as new tokens are generated to replace expired tokens. I'm proposing support for this within Rueidis in the form of configurable auth credential function which allows for setting a new password on each dial as needed.