### PR TITLE
Add servername and min tls version to tls config

### DIFF
--- a/url.go
+++ b/url.go
@@ -25,7 +25,9 @@ func ParseURL(str string) (opt ClientOption, err error) {
 		}
 		opt.InitAddress = []string{strings.TrimSpace(u.Path)}
 	case "rediss":
-		opt.TLSConfig = &tls.Config{}
+		opt.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	case "redis":
 	default:
 		return opt, fmt.Errorf("redis: invalid URL scheme: %s", u.Scheme)
@@ -42,6 +44,9 @@ func ParseURL(str string) (opt ClientOption, err error) {
 			port = "6379"
 		}
 		opt.InitAddress = []string{net.JoinHostPort(host, port)}
+		if opt.TLSConfig != nil {
+			opt.TLSConfig.ServerName = host
+		}
 	}
 	if u.User != nil {
 		opt.Username = u.User.Username()

--- a/url_test.go
+++ b/url_test.go
@@ -57,6 +57,9 @@ func TestParseURL(t *testing.T) {
 	if opt, err := ParseURL("redis://?master_set=0"); opt.Sentinel.MasterSet != "0" {
 		t.Fatalf("unexpected %v %v", opt, err)
 	}
+	if opt, err := ParseURL("rediss://myhost:6379"); err != nil || opt.TLSConfig.ServerName != "myhost" {
+		t.Fatalf("unexpected %v %v", opt, err)
+	}
 }
 
 func TestMustParseURL(t *testing.T) {


### PR DESCRIPTION
This change sets the TLS server name to the url host and it also sets the minimum TLS version to use. This keeps the compatibility with go-redis url parsing and how it handles TLS configs
I added a unit test to assert that the server name is set correctly in the TLS config. The existing unit test on line 12 should cover the fact that 'redis://' urls are not affected by this change