### PR TITLE
feat: avoid using QUIT command

### DIFF
--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -33,12 +33,7 @@ var (
 	RoleCmd = Completed{
 		cs: newCommandSlice([]string{"ROLE"}),
 	}
-	// QuitCmd is predefined QUIT
-	// We shouldn't use this because its deprecated
-	// https://github.com/redis/rueidis/issues/377
-	QuitCmd = Completed{
-		cs: newCommandSlice([]string{"QUIT"}),
-	}
+
 	// UnsubscribeCmd is predefined UNSUBSCRIBE
 	UnsubscribeCmd = Completed{
 		cs: newCommandSlice([]string{"UNSUBSCRIBE"}),

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -34,6 +34,8 @@ var (
 		cs: newCommandSlice([]string{"ROLE"}),
 	}
 	// QuitCmd is predefined QUIT
+	// We shouldn't use this because its deprecated
+	// https://github.com/redis/rueidis/issues/377
 	QuitCmd = Completed{
 		cs: newCommandSlice([]string{"QUIT"}),
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -80,7 +80,7 @@ func TestNewMux(t *testing.T) {
 			ReplyString("OK")
 		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 			ReplyError("UNKNOWN COMMAND")
-		mock.Expect("QUIT").ReplyString("OK")
+		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 	}()
 	m := makeMux("", &ClientOption{}, func(dst string, opt *ClientOption) (net.Conn, error) {

--- a/pipe.go
+++ b/pipe.go
@@ -332,7 +332,7 @@ func (p *pipe) _background() {
 		atomic.CompareAndSwapInt32(&p.state, 2, 3) // make write goroutine to exit
 		atomic.AddInt32(&p.waits, 1)
 		go func() {
-			<-p.queue.PutOne(cmds.QuitCmd)
+			<-p.queue.PutOne(cmds.PingCmd)
 			atomic.AddInt32(&p.waits, -1)
 		}()
 	}
@@ -421,7 +421,7 @@ func (p *pipe) _backgroundWrite() (err error) {
 			err = writeCmd(p.w, cmd.Commands())
 		}
 		if err != nil {
-			if err != ErrClosing { // ignore ErrClosing to allow final QUIT command to be sent
+			if err != ErrClosing { // ignore ErrClosing to allow final PING command to be sent
 				return
 			}
 			runtime.Gosched()
@@ -1304,7 +1304,7 @@ func (p *pipe) Close() {
 			p.background()
 		}
 		if block == 1 && (stopping1 || stopping2) { // make sure there is no block cmd
-			<-p.queue.PutOne(cmds.QuitCmd)
+			<-p.queue.PutOne(cmds.PingCmd)
 		}
 	}
 	atomic.AddInt32(&p.waits, -1)

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -160,7 +160,7 @@ func setup(t *testing.T, option ClientOption) (*pipe, *redisMock, func(), func()
 		t.Fatalf("pipe setup failed, unexpected version: %v", p.Version())
 	}
 	return p, mock, func() {
-			go func() { mock.Expect("QUIT").ReplyString("OK") }()
+			go func() { mock.Expect("PING").ReplyString("OK") }()
 			p.Close()
 			mock.Close()
 			for atomic.LoadInt32(&p.state) != 4 {
@@ -219,7 +219,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -255,7 +255,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -289,7 +289,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -327,7 +327,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -356,7 +356,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -393,7 +393,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -430,7 +430,7 @@ func TestNewPipe(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pipe setup failed: %v", err)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -447,7 +447,7 @@ func TestNewPipe(t *testing.T) {
 	t.Run("Auth Credentials Function Error", func(t *testing.T) {
 		n1, n2 := net.Pipe()
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		_, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{
 			SelectDB: 1,
 			AuthCredentialsFn: func(context AuthCredentialsContext) (AuthCredentials, error) {
@@ -476,7 +476,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyError("ERR unknown subcommand or wrong number of arguments for 'TRACKING'. Try CLIENT HELP")
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 				ReplyError("UNKNOWN COMMAND")
-			mock.Expect("QUIT").ReplyString("OK")
+			mock.Expect("PING").ReplyString("OK")
 		}()
 		if _, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{}); !errors.Is(err, ErrNoCache) {
 			t.Fatalf("unexpected err: %v", err)
@@ -495,7 +495,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 				ReplyString("OK")
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 				ReplyError("UNKNOWN COMMAND")
-			mock.Expect("QUIT").ReplyString("OK")
+			mock.Expect("PING").ReplyString("OK")
 		}()
 		if _, err := newPipe(func() (net.Conn, error) { return n1, nil }, &ClientOption{}); !errors.Is(err, ErrNoCache) {
 			t.Fatalf("unexpected err: %v", err)
@@ -527,7 +527,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 		if p.version >= 6 {
 			t.Fatalf("unexpected p.version: %v", p.version)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -564,7 +564,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 		if p.version >= 6 {
 			t.Fatalf("unexpected p.version: %v", p.version)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -602,7 +602,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 		if p.version >= 6 {
 			t.Fatalf("unexpected p.version: %v", p.version)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -644,7 +644,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 		if p.version >= 6 {
 			t.Fatalf("unexpected p.version: %v", p.version)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -686,7 +686,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 		if p.version >= 6 {
 			t.Fatalf("unexpected p.version: %v", p.version)
 		}
-		go func() { mock.Expect("QUIT").ReplyString("OK") }()
+		go func() { mock.Expect("PING").ReplyString("OK") }()
 		p.Close()
 		mock.Close()
 		n1.Close()
@@ -3141,7 +3141,7 @@ func TestCloseAndWaitPendingCMDs(t *testing.T) {
 		}
 		r.ReplyString("b")
 	}
-	mock.Expect("QUIT").ReplyString("OK")
+	mock.Expect("PING").ReplyString("OK")
 	mock.Close()
 	wg.Wait()
 }

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -2054,7 +2054,6 @@ func TestDisableClientSideCaching(t *testing.T) {
 			Expect("GET", "c").
 			ReplyString("2").
 			ReplyString("3")
-
 	}()
 
 	v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
@@ -2616,7 +2615,7 @@ func TestPubSub(t *testing.T) {
 	})
 
 	t.Run("PubSub Unexpected Subscribe", func(t *testing.T) {
-		var shouldPanic = func(push string) (pass bool) {
+		shouldPanic := func(push string) (pass bool) {
 			defer func() { pass = recover() == protocolbug }()
 
 			p, mock, _, _ := setup(t, ClientOption{})
@@ -2646,7 +2645,7 @@ func TestPubSub(t *testing.T) {
 	})
 
 	t.Run("PubSub MULTI/EXEC Subscribe", func(t *testing.T) {
-		var shouldPanic = func(cmd Completed) (pass bool) {
+		shouldPanic := func(cmd Completed) (pass bool) {
 			defer func() { pass = recover() == multiexecsub }()
 
 			p, mock, _, _ := setup(t, ClientOption{})
@@ -3692,7 +3691,6 @@ func TestBlockingCommandNoDeadline(t *testing.T) {
 			close(wait)
 			time.Sleep(2 * timeout)
 			mock.Expect("READ").Expect("BLOCK").ReplyString("OK").ReplyString("READ").ReplyString("OK")
-
 		}()
 		<-wait
 		if val, err := p.DoMulti(context.Background(),
@@ -3805,5 +3803,4 @@ func TestNoHelloRegex(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/ring_test.go
+++ b/ring_test.go
@@ -117,9 +117,9 @@ func TestRing(t *testing.T) {
 		if one, _, ch := ring.NextWriteCmd(); ch == nil {
 			go func() {
 				time.Sleep(time.Millisecond * 100)
-				ring.PutOne(cmds.QuitCmd)
+				ring.PutOne(cmds.PingCmd)
 			}()
-			if one, _, ch = ring.WaitForWrite(); ch != nil && one.Commands()[0] == cmds.QuitCmd.Commands()[0] {
+			if one, _, ch = ring.WaitForWrite(); ch != nil && one.Commands()[0] == cmds.PingCmd.Commands()[0] {
 				return
 			}
 		}
@@ -131,9 +131,9 @@ func TestRing(t *testing.T) {
 		if _, multi, ch := ring.NextWriteCmd(); ch == nil {
 			go func() {
 				time.Sleep(time.Millisecond * 100)
-				ring.PutMulti([]Completed{cmds.QuitCmd}, nil)
+				ring.PutMulti([]Completed{cmds.PingCmd}, nil)
 			}()
-			if _, multi, ch = ring.WaitForWrite(); ch != nil && multi[0].Commands()[0] == cmds.QuitCmd.Commands()[0] {
+			if _, multi, ch = ring.WaitForWrite(); ch != nil && multi[0].Commands()[0] == cmds.PingCmd.Commands()[0] {
 				return
 			}
 		}

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -113,7 +113,7 @@ func TestNewClusterClientError(t *testing.T) {
 		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "other error"})
-		mock.Expect("QUIT").ReplyString("OK")
+		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)
 	}()
@@ -143,7 +143,7 @@ func TestFallBackSingleClient(t *testing.T) {
 		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "ERR This instance has cluster support disabled"})
-		mock.Expect("QUIT").ReplyString("OK")
+		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)
 	}()
@@ -177,7 +177,7 @@ func TestForceSingleClient(t *testing.T) {
 		}
 		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 			ReplyError("UNKNOWN COMMAND")
-		mock.Expect("QUIT").ReplyString("OK")
+		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)
 	}()
@@ -258,7 +258,7 @@ func TestTLSClient(t *testing.T) {
 		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LIB_NAME, "LIB-VER", LIB_VER).
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "ERR This instance has cluster support disabled"})
-		mock.Expect("QUIT").ReplyString("OK")
+		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)
 	}()


### PR DESCRIPTION
This PR resolves #377.

From the suggestion in the documentation in Redis [QUIT (deprecated)](https://redis.io/commands/quit/)

> Note: Clients should not use this command. Instead,
> clients should simply close the connection when they're not used anymore.
> Terminating a connection on the client side is preferable,
> as it eliminates TIME_WAIT lingering sockets on the server side.

We should close the connection by ourselves,
so I changed to last command from QUIT to PING to wait for other pending commands to be completed.