### PR TITLE
Add support for 'REPLICAOF NO ONE'

### DIFF
--- a/internal/cmds/gen_server.go
+++ b/internal/cmds/gen_server.go
@@ -1342,6 +1342,11 @@ func (c ReplicaofHost) Port(port int64) ReplicaofPort {
 	return (ReplicaofPort)(c)
 }
 
+func (c Replicaof) NoOne() ReplicaofPort {
+	c.cs.s = append(c.cs.s, "NO ONE")
+	return (ReplicaofPort)(c)
+}
+
 type ReplicaofPort Incomplete
 
 func (c ReplicaofPort) Build() Completed {

--- a/internal/cmds/gen_server_test.go
+++ b/internal/cmds/gen_server_test.go
@@ -96,6 +96,7 @@ func server0(s Builder) {
 	s.Monitor().Build()
 	s.Psync().Replicationid("1").Offset(1).Build()
 	s.Replicaof().Host("1").Port(1).Build()
+	s.Replicaof().NoOne().Build()
 	s.Role().Build()
 	s.Save().Build()
 	s.Shutdown().Nosave().Now().Force().Abort().Build()


### PR DESCRIPTION
The `REPLICAOF` command supports the arguments `NO ONE` ([link to documentation](https://redis.io/commands/replicaof/)) to stop replication. This doesn't seem to be supported by the current command builder, so this PR adds support for this one special case which breaks from the standard types for `host` and `port`.

Let me know if I'm missing an existing way to do this, or if there's a cleaner implementation.