### PR TITLE
Add Normalized Vector Tests for `TestVectorString32`/`64`

### DIFF
--- a/binary_test.go
+++ b/binary_test.go
@@ -30,12 +30,16 @@ func TestJSONPanic(t *testing.T) {
 	JSON(a)
 }
 
+
 func TestVectorString32(t *testing.T) {
 	for _, test := range [][]float32{
 		{},
 		{0, 0, 0, 0},
 		{9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
 		{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
+		{.9, .9, .9, .9, .9, .9, .9, .9, .9, .9, .9},
+		{-.1, -.1, -.1, -.1, -.1, -.1, -.1, -.1, -.1, -.1},
+		{.1, -.1, .1, -.1, .1, -.1, .1, -.1, .1, -.1},
 	} {
 		if !reflect.DeepEqual(test, ToVector32(VectorString32(test))) {
 			t.Fatalf("fail to convert %v", test)
@@ -49,6 +53,9 @@ func TestVectorString64(t *testing.T) {
 		{0, 0, 0, 0},
 		{9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
 		{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
+		{.9, .9, .9, .9, .9, .9, .9, .9, .9, .9, .9},
+		{-.1, -.1, -.1, -.1, -.1, -.1, -.1, -.1, -.1, -.1},
+		{.1, -.1, .1, -.1, .1, -.1, .1, -.1, .1, -.1},
 	} {
 		if !reflect.DeepEqual(test, ToVector64(VectorString64(test))) {
 			t.Fatalf("fail to convert %v", test)


### PR DESCRIPTION
Running into some issues parsing vector embeddings in a project. They vectors are normalized and was wondering if that was the issue after looking at the tests for the function. Looks like it is not but adding these tests for better coverage.