### PR TITLE
fix: rueidis.ParseURL() cannot parse unix address

### DIFF
--- a/url.go
+++ b/url.go
@@ -57,12 +57,14 @@ func ParseURL(str string) (opt ClientOption, err error) {
 		opt.Username = u.User.Username()
 		opt.Password, _ = u.User.Password()
 	}
-	if ps := strings.Split(u.Path, "/"); len(ps) == 2 {
-		if opt.SelectDB, err = strconv.Atoi(ps[1]); err != nil {
-			return opt, fmt.Errorf("redis: invalid database number: %q", ps[1])
+	if u.Scheme != "unix" {
+		if ps := strings.Split(u.Path, "/"); len(ps) == 2 {
+			if opt.SelectDB, err = strconv.Atoi(ps[1]); err != nil {
+				return opt, fmt.Errorf("redis: invalid database number: %q", ps[1])
+			}
+		} else if len(ps) > 2 {
+			return opt, fmt.Errorf("redis: invalid URL path: %s", u.Path)
 		}
-	} else if len(ps) > 2 {
-		return opt, fmt.Errorf("redis: invalid URL path: %s", u.Path)
 	}
 	q := u.Query()
 	if q.Has("db") {

--- a/url_test.go
+++ b/url_test.go
@@ -66,6 +66,9 @@ func TestParseURL(t *testing.T) {
 	if opt, err := ParseURL("rediss://myhost:6379"); err != nil || opt.TLSConfig.ServerName != "myhost" {
 		t.Fatalf("unexpected %v %v", opt, err)
 	}
+	if opt, err := ParseURL("unix:///path/to/redis.sock?db=1"); opt.DialFn == nil || opt.InitAddress[0] != "/path/to/redis.sock" || opt.SelectDB != 1 {
+		t.Fatalf("unexpected %v %v", opt, err)
+	}
 }
 
 func TestMustParseURL(t *testing.T) {


### PR DESCRIPTION
A simple fix for #424. And a simple test as well.