### PR TITLE
fix: do not ignore error of `url.Parse`

### DIFF
--- a/url.go
+++ b/url.go
@@ -18,7 +18,10 @@ import (
 // redis://<user>:<password>@<host>:<port>?addr=<host2>:<port2>&addr=<host3>:<port3>
 // unix://<user>:<password>@</path/to/redis.sock>?db=<db_number>
 func ParseURL(str string) (opt ClientOption, err error) {
-	u, _ := url.Parse(str)
+	u, err := url.Parse(str)
+	if err != nil {
+		return opt, err
+	}
 	parseAddr := func(hostport string) (host string, addr string) {
 		host, port, _ := net.SplitHostPort(hostport)
 		if host == "" {

--- a/url_test.go
+++ b/url_test.go
@@ -6,6 +6,9 @@ import (
 )
 
 func TestParseURL(t *testing.T) {
+	if opt, err := ParseURL("re dis://"); err == nil {
+		t.Fatalf("unexpected %v %v", opt, err)
+	}
 	if opt, err := ParseURL(""); !strings.HasPrefix(err.Error(), "redis: invalid URL scheme") {
 		t.Fatalf("unexpected %v %v", opt, err)
 	}


### PR DESCRIPTION
If the error is ignored, there will be a nil pinter dereference panic when accessing `u.Scheme`.