### PR TITLE
OTEL tweaks

### DIFF
--- a/rueidisotel/metrics.go
+++ b/rueidisotel/metrics.go
@@ -14,14 +14,8 @@ import (
 )
 
 var (
-	DefaultHistogramBuckets = []float64{
+	defaultHistogramBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10,
-	}
-	DefaultDialFn = func(dst string, dialer *net.Dialer, cfg *tls.Config) (conn net.Conn, err error) {
-		if cfg != nil {
-			return tls.DialWithDialer(dialer, "tcp", dst, cfg)
-		}
-		return dialer.Dial("tcp", dst)
 	}
 )
 
@@ -47,7 +41,7 @@ func NewClient(clientOption rueidis.ClientOption, opts ...Option) (rueidis.Clien
 	oclient := newClient(opts...)
 
 	if clientOption.DialFn == nil {
-		clientOption.DialFn = DefaultDialFn
+		clientOption.DialFn = defaultDialFn
 	}
 
 	attempt, err := oclient.meter.Int64Counter("rueidis_dial_attempt")
@@ -96,7 +90,7 @@ func newClient(opts ...Option) *otelclient {
 		opt(cli)
 	}
 	if cli.histogramOption.Buckets == nil {
-		cli.histogramOption.Buckets = DefaultHistogramBuckets
+		cli.histogramOption.Buckets = defaultHistogramBuckets
 	}
 	if cli.meterProvider == nil {
 		cli.meterProvider = otel.GetMeterProvider() // Default to global MeterProvider
@@ -156,4 +150,11 @@ func (t *connTracker) Close() error {
 	}
 
 	return t.Conn.Close()
+}
+
+func defaultDialFn(dst string, dialer *net.Dialer, cfg *tls.Config) (conn net.Conn, err error) {
+	if cfg != nil {
+		return tls.DialWithDialer(dialer, "tcp", dst, cfg)
+	}
+	return dialer.Dial("tcp", dst)
 }

--- a/rueidisotel/metrics.go
+++ b/rueidisotel/metrics.go
@@ -136,7 +136,8 @@ func trackDialing(
 			return nil, err
 		}
 
-		dialLatency.Record(ctx, time.Since(start).Seconds())
+		// Use floating point division for higher precision (instead of Seconds method).
+		dialLatency.Record(ctx, float64(time.Since(start))/float64(time.Second))
 		success.Add(ctx, 1)
 		conns.Add(ctx, 1)
 

--- a/rueidisotel/trace.go
+++ b/rueidisotel/trace.go
@@ -23,7 +23,10 @@ var _ rueidis.Client = (*otelclient)(nil)
 
 // WithClient creates a new rueidis.Client with OpenTelemetry tracing enabled.
 func WithClient(client rueidis.Client, opts ...Option) rueidis.Client {
-	cli := newClient(opts...)
+	cli, err := newClient(opts...)
+	if err != nil {
+		panic(err)
+	}
 	cli.client = client
 	return cli
 }

--- a/rueidisotel/trace.go
+++ b/rueidisotel/trace.go
@@ -22,6 +22,8 @@ var (
 var _ rueidis.Client = (*otelclient)(nil)
 
 // WithClient creates a new rueidis.Client with OpenTelemetry tracing enabled.
+//
+// Deprecated: use NewClient() instead.
 func WithClient(client rueidis.Client, opts ...Option) rueidis.Client {
 	cli, err := newClient(opts...)
 	if err != nil {


### PR DESCRIPTION
**First commit**: it's good to avoid mutable public fields because they encourage poor user behavior. It's possible to configure the histogram buckets via options, no need to make the default value mutable.

**Second commit**: it's better to fail early if OTEL library returned an error rather than discard an error, store `nil` in the field and then panic with NPE later. There will be no way to find out why the field was `nil` because the error was discarded. Also, it'd be better if `WithClient()` just returned an error.

**Third commit**: `Second()` does something weird instead of just division. It loses precision that way. OpenTelementry libraries just use division, e.g. https://github.com/open-telemetry/opentelemetry-go-contrib/blob/8e44cea6d4fe181343500b6cb680bd501b3d24aa/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go#L343-L344

Overall I think it's not the best choice to have both `WithClient()` and `NewClient()`. Why not have a single function and let the user configure if they want metrics, traces, both, and with what options. If we want to keep two functions, names are really not clear. They should be `WithTracing()` and `WithMetrics()` or something like that.

But IMO it's better to have a single function. If someone doesn't want e.g. metrics, they can provide a NOOP `MeterProvider`. Same with tracing - there is a NOOP `TracerProvider`.