### PR TITLE
Check for too big option.PipelineMultiplex value

### DIFF
--- a/rueidis.go
+++ b/rueidis.go
@@ -30,6 +30,8 @@ const (
 	DefaultReadBuffer = 1 << 19
 	// DefaultWriteBuffer is the default value of bufio.NewWriterSize for each connection, which is 0.5MiB
 	DefaultWriteBuffer = 1 << 19
+	// MaxPipelineMultiplex is the maximum meaningful value for ClientOption.PipelineMultiplex
+	MaxPipelineMultiplex = 8
 )
 
 var (
@@ -46,6 +48,8 @@ var (
 	// ErrReplicaOnlyNotSupported means ReplicaOnly flag is not supported by
 	// current client
 	ErrReplicaOnlyNotSupported = errors.New("ReplicaOnly is not supported for single client")
+	// ErrWrongPipelineMultiplex means wrong value for ClientOption.PipelineMultiplex
+	ErrWrongPipelineMultiplex = errors.New("ClientOption.PipelineMultiplex must not be bigger than MaxPipelineMultiplex")
 )
 
 // ClientOption should be passed to NewClient to construct a Client
@@ -313,6 +317,9 @@ func NewClient(option ClientOption) (client Client, err error) {
 		rand.Shuffle(len(option.InitAddress), func(i, j int) {
 			option.InitAddress[i], option.InitAddress[j] = option.InitAddress[j], option.InitAddress[i]
 		})
+	}
+	if option.PipelineMultiplex > MaxPipelineMultiplex {
+		return nil, ErrWrongPipelineMultiplex
 	}
 	if option.Sentinel.MasterSet != "" {
 		option.PipelineMultiplex = singleClientMultiplex(option.PipelineMultiplex)


### PR DESCRIPTION
If we use `ClientOption.PipelineMultiplex` in the wrong way (too big), we will get a panic inside rueidis:

https://go.dev/play/p/QE8VYHE6hJX
```
package main

func foo(v int) int {
	return 1 << v
}

func main() {
	println(foo(0), foo(2), foo(50), foo(70), foo(100), foo(200))
}

>> 1 4 1125899906842624 0 0 0
```

In this case, we will get [zero for multiplex value](https://github.com/redis/rueidis/blob/a85dd76338d31ff6e92e55d698dd536e5ea6f10a/mux.go#L97) and zero-sized `wire`, `mu`, `sc` slices. Which will lead to panic [here](https://github.com/redis/rueidis/blob/a85dd76338d31ff6e92e55d698dd536e5ea6f10a/mux.go#L142) for example.

```
goroutine 59 [running]:
github.com/redis/rueidis.(*mux)._pipe(0x0?, 0x0?)
        /home/X/go/pkg/mod/github.com/redis/rueidis@v1.0.25/mux.go:142 +0x71e
github.com/redis/rueidis.(*mux).Dial(0x0?)
        /home/X/go/pkg/mod/github.com/redis/rueidis@v1.0.25/mux.go:188 +0x1b
github.com/redis/rueidis.(*clusterClient).init.func1({0xc00010f640, 0x19}, {0x17ce2d0, 0xc00001b180})
        /home/X/go/pkg/mod/github.com/redis/rueidis@v1.0.25/cluster.go:134 +0x48
created by github.com/redis/rueidis.(*clusterClient).init
        /home/X/go/pkg/mod/github.com/redis/rueidis@v1.0.25/cluster.go:133 +0x9d
```
