### PR TITLE
feat: streaming read with DoStream() and DoMultiStream()

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,27 @@ script := rueidis.NewLuaScript("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}")
 list, err := script.Exec(ctx, client, []string{"k1", "k2"}, []string{"a1", "a2"}).ToArray()
 ```
 
+## Streaming Read
+
+`client.DoStream()` and `client.DoMultiStream()` can be used to send large redis responses to an `io.Writer`
+without allocating the full responses in memory. They work by first sending commands to a dedicated connection acquired from a pool,
+then directly copying the response values to the given `io.Writer`, and finally recycling the connection.
+
+```go
+s := client.DoMultiStream(ctx, client.B().Get().Key("a{slot1}").Build(), client.B().Get().Key("b{slot1}").Build())
+for s.HasNext() {
+    n, err := s.WriteTo(io.Discard)
+    // ...
+}
+```
+
+Note that these two methods will occupy connections until all responses are written to the given `io.Writer`.
+This can take a long time and hurt performance. Use the normal `Do()` and `DoMulti()` instead unless you want to avoid
+allocating memory for large redis response.
+
+Also note that these two methods only work with `string`, `integer`, and `float` redis responses. And `DoMultiStream` currently
+does not support pipelining keys across multiple slots when connecting to a redis cluster.
+
 ## Memory Consumption Consideration
 
 Each underlying connection in rueidis allocates a ring buffer for pipelining.

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package rueidis
 
 import (
 	"context"
-	"io"
 	"sync/atomic"
 	"time"
 
@@ -53,10 +52,10 @@ retry:
 	return resp
 }
 
-func (c *singleClient) DoReader(ctx context.Context, cmd Completed) (r io.Reader, err error) {
-	r, err = c.conn.(*mux).doReader(ctx, cmd)
+func (c *singleClient) DoStream(ctx context.Context, cmd Completed) Stream {
+	s := c.conn.(*mux).doStream(ctx, cmd)
 	cmds.PutCompleted(cmd)
-	return
+	return s
 }
 
 func (c *singleClient) DoMulti(ctx context.Context, multi ...Completed) (resps []RedisResult) {

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package rueidis
 
 import (
 	"context"
+	"io"
 	"sync/atomic"
 	"time"
 
@@ -50,6 +51,12 @@ retry:
 		cmds.PutCompleted(cmd)
 	}
 	return resp
+}
+
+func (c *singleClient) DoReader(ctx context.Context, cmd Completed) (r io.Reader, err error) {
+	r, err = c.conn.(*mux).doReader(ctx, cmd)
+	cmds.PutCompleted(cmd)
+	return
 }
 
 func (c *singleClient) DoMulti(ctx context.Context, multi ...Completed) (resps []RedisResult) {

--- a/client.go
+++ b/client.go
@@ -58,6 +58,14 @@ func (c *singleClient) DoStream(ctx context.Context, cmd Completed) Stream {
 	return s
 }
 
+func (c *singleClient) DoMultiStream(ctx context.Context, multi ...Completed) Stream {
+	s := c.conn.(*mux).doMultiStream(ctx, multi...)
+	for _, cmd := range multi {
+		cmds.PutCompleted(cmd)
+	}
+	return s
+}
+
 func (c *singleClient) DoMulti(ctx context.Context, multi ...Completed) (resps []RedisResult) {
 	if len(multi) == 0 {
 		return nil

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package rueidis
 
 import (
 	"context"
+	"io"
 	"sync/atomic"
 	"time"
 
@@ -53,13 +54,16 @@ retry:
 }
 
 func (c *singleClient) DoStream(ctx context.Context, cmd Completed) RedisResultStream {
-	s := c.conn.(*mux).doStream(ctx, cmd)
+	s := c.conn.DoStream(ctx, cmd)
 	cmds.PutCompleted(cmd)
 	return s
 }
 
-func (c *singleClient) DoMultiStream(ctx context.Context, multi ...Completed) RedisResultStream {
-	s := c.conn.(*mux).doMultiStream(ctx, multi...)
+func (c *singleClient) DoMultiStream(ctx context.Context, multi ...Completed) MultiRedisResultStream {
+	if len(multi) == 0 {
+		return RedisResultStream{e: io.EOF}
+	}
+	s := c.conn.DoMultiStream(ctx, multi...)
 	for _, cmd := range multi {
 		cmds.PutCompleted(cmd)
 	}

--- a/client.go
+++ b/client.go
@@ -52,13 +52,13 @@ retry:
 	return resp
 }
 
-func (c *singleClient) DoStream(ctx context.Context, cmd Completed) Stream {
+func (c *singleClient) DoStream(ctx context.Context, cmd Completed) RedisResultStream {
 	s := c.conn.(*mux).doStream(ctx, cmd)
 	cmds.PutCompleted(cmd)
 	return s
 }
 
-func (c *singleClient) DoMultiStream(ctx context.Context, multi ...Completed) Stream {
+func (c *singleClient) DoMultiStream(ctx context.Context, multi ...Completed) RedisResultStream {
 	s := c.conn.(*mux).doMultiStream(ctx, multi...)
 	for _, cmd := range multi {
 		cmds.PutCompleted(cmd)

--- a/client_test.go
+++ b/client_test.go
@@ -12,20 +12,22 @@ import (
 )
 
 type mockConn struct {
-	DoFn           func(cmd Completed) RedisResult
-	DoCacheFn      func(cmd Cacheable, ttl time.Duration) RedisResult
-	DoMultiFn      func(multi ...Completed) *redisresults
-	DoMultiCacheFn func(multi ...CacheableTTL) *redisresults
-	ReceiveFn      func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error
-	InfoFn         func() map[string]RedisMessage
-	VersionFn      func() int
-	ErrorFn        func() error
-	CloseFn        func()
-	DialFn         func() error
-	AcquireFn      func() wire
-	StoreFn        func(w wire)
-	OverrideFn     func(c conn)
-	AddrFn         func() string
+	DoFn            func(cmd Completed) RedisResult
+	DoCacheFn       func(cmd Cacheable, ttl time.Duration) RedisResult
+	DoMultiFn       func(multi ...Completed) *redisresults
+	DoMultiCacheFn  func(multi ...CacheableTTL) *redisresults
+	ReceiveFn       func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error
+	DoStreamFn      func(ctx context.Context, cmd Completed) RedisResultStream
+	DoMultiStreamFn func(ctx context.Context, cmd ...Completed) MultiRedisResultStream
+	InfoFn          func() map[string]RedisMessage
+	VersionFn       func() int
+	ErrorFn         func() error
+	CloseFn         func()
+	DialFn          func() error
+	AcquireFn       func() wire
+	StoreFn         func(w wire)
+	OverrideFn      func(c conn)
+	AddrFn          func() string
 
 	DoOverride      map[string]func(cmd Completed) RedisResult
 	DoCacheOverride map[string]func(cmd Cacheable, ttl time.Duration) RedisResult
@@ -118,6 +120,20 @@ func (m *mockConn) Receive(ctx context.Context, subscribe Completed, hdl func(me
 		return m.ReceiveFn(ctx, subscribe, hdl)
 	}
 	return nil
+}
+
+func (m *mockConn) DoStream(ctx context.Context, cmd Completed) RedisResultStream {
+	if m.DoStreamFn != nil {
+		return m.DoStreamFn(ctx, cmd)
+	}
+	return RedisResultStream{}
+}
+
+func (m *mockConn) DoMultiStream(ctx context.Context, cmd ...Completed) MultiRedisResultStream {
+	if m.DoMultiStreamFn != nil {
+		return m.DoMultiStreamFn(ctx, cmd...)
+	}
+	return MultiRedisResultStream{}
 }
 
 func (m *mockConn) CleanSubscriptions() {
@@ -774,7 +790,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			newErrResult(ErrClosing),
 			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
 		)
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			if v, err := cc.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -788,8 +804,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(newErrResult(ErrClosing))
-		m.AcquireFn = func() wire { return m }
 		m.ErrorFn = func() error { return ErrClosing }
+		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.Do(context.Background(), c.B().Get().Key("Do").Build()).Error()
 		}); ret != ErrClosing {
@@ -800,7 +816,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(newErrResult(ErrClosing))
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -813,7 +829,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate Do Write NoRetry", func(t *testing.T) {
 		c, m := setup()
 		m.DoFn = makeDoFn(newErrResult(ErrClosing))
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.Do(context.Background(), c.B().Set().Key("Do").Value("Do").Build()).Error()
 		}); ret != ErrClosing {
@@ -827,7 +843,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 			[]RedisResult{newErrResult(ErrClosing)},
 			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
 		)
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			if v, err := cc.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -841,8 +857,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn([]RedisResult{newErrResult(ErrClosing)})
-		m.AcquireFn = func() wire { return m }
 		m.ErrorFn = func() error { return ErrClosing }
+		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].Error()
 		}); ret != ErrClosing {
@@ -853,7 +869,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti ReadOnly NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn([]RedisResult{newErrResult(ErrClosing)})
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -866,7 +882,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Dedicate Delegate DoMulti Write NoRetry", func(t *testing.T) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn([]RedisResult{newErrResult(ErrClosing)})
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.DoMulti(context.Background(), c.B().Set().Key("Do").Value("Do").Build())[0].Error()
 		}); ret != ErrClosing {
@@ -877,7 +893,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Receive Retry", func(t *testing.T) {
 		c, m := setup()
 		m.ReceiveFn = makeReceiveFn(ErrClosing, nil)
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{ReceiveFn: m.ReceiveFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			if err := cc.Receive(context.Background(), c.B().Subscribe().Channel("Do").Build(), nil); err != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -891,8 +907,8 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Receive NoRetry - broken", func(t *testing.T) {
 		c, m := setup()
 		m.ReceiveFn = makeReceiveFn(ErrClosing)
-		m.AcquireFn = func() wire { return m }
 		m.ErrorFn = func() error { return ErrClosing }
+		m.AcquireFn = func() wire { return &mockWire{ReceiveFn: m.ReceiveFn, ErrorFn: m.ErrorFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
 			return cc.Receive(context.Background(), c.B().Subscribe().Channel("Do").Build(), nil)
 		}); ret != ErrClosing {
@@ -903,7 +919,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 	t.Run("Delegate Receive NoRetry - ctx done", func(t *testing.T) {
 		c, m := setup()
 		m.ReceiveFn = makeReceiveFn(ErrClosing)
-		m.AcquireFn = func() wire { return m }
+		m.AcquireFn = func() wire { return &mockWire{ReceiveFn: m.ReceiveFn} }
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		if ret := c.Dedicated(func(cc DedicatedClient) error {

--- a/cluster.go
+++ b/cluster.go
@@ -1019,8 +1019,12 @@ func (c *clusterClient) DoMultiStream(ctx context.Context, multi ...Completed) M
 	slot := multi[0].Slot()
 	repl := c.toReplica(multi[0])
 	for i := 1; i < len(multi); i++ {
-		if slot != multi[i].Slot() {
-			panic("DoMultiStream across multiple slots is not supported")
+		if s := multi[i].Slot(); s != cmds.InitSlot {
+			if slot == cmds.InitSlot {
+				slot = s
+			} else if slot != s {
+				panic("DoMultiStream across multiple slots is not supported")
+			}
 		}
 		repl = repl && c.toReplica(multi[i])
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -3,6 +3,7 @@ package rueidis
 import (
 	"context"
 	"errors"
+	"io"
 	"math/rand"
 	"net"
 	"runtime"
@@ -999,6 +1000,39 @@ ret:
 		cmds.PutCompleted(subscribe)
 	}
 	return err
+}
+
+func (c *clusterClient) DoStream(ctx context.Context, cmd Completed) RedisResultStream {
+	cc, err := c.pick(ctx, cmd.Slot(), c.toReplica(cmd))
+	if err != nil {
+		return RedisResultStream{e: err}
+	}
+	ret := cc.DoStream(ctx, cmd)
+	cmds.PutCompleted(cmd)
+	return ret
+}
+
+func (c *clusterClient) DoMultiStream(ctx context.Context, multi ...Completed) MultiRedisResultStream {
+	if len(multi) == 0 {
+		return RedisResultStream{e: io.EOF}
+	}
+	slot := multi[0].Slot()
+	repl := c.toReplica(multi[0])
+	for i := 1; i < len(multi); i++ {
+		if slot != multi[i].Slot() {
+			panic("DoMultiStream across multiple slots is not supported")
+		}
+		repl = repl && c.toReplica(multi[i])
+	}
+	cc, err := c.pick(ctx, slot, repl)
+	if err != nil {
+		return RedisResultStream{e: err}
+	}
+	ret := cc.DoMultiStream(ctx, multi...)
+	for _, cmd := range multi {
+		cmds.PutCompleted(cmd)
+	}
+	return ret
 }
 
 func (c *clusterClient) Dedicated(fn func(DedicatedClient) error) (err error) {

--- a/lua_test.go
+++ b/lua_test.go
@@ -231,6 +231,14 @@ func (c *client) DoMulti(ctx context.Context, cmd ...Completed) (resp []RedisRes
 	return nil
 }
 
+func (c *client) DoStream(ctx context.Context, cmd Completed) (resp RedisResultStream) {
+	return RedisResultStream{}
+}
+
+func (c *client) DoMultiStream(ctx context.Context, cmd ...Completed) (resp MultiRedisResultStream) {
+	return MultiRedisResultStream{}
+}
+
 func (c *client) DoMultiCache(ctx context.Context, cmd ...CacheableTTL) (resp []RedisResult) {
 	if c.DoMultiCacheFn != nil {
 		return c.DoMultiCacheFn(ctx, cmd...)

--- a/mock/client.go
+++ b/mock/client.go
@@ -115,6 +115,20 @@ func (mr *ClientMockRecorder) Do(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*Client)(nil).Do), arg0, arg1)
 }
 
+// DoStream mocks base method.
+func (m *Client) DoStream(arg0 context.Context, arg1 rueidis.Completed) rueidis.RedisResultStream {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoStream", arg0, arg1)
+	ret0, _ := ret[0].(rueidis.RedisResultStream)
+	return ret0
+}
+
+// DoStream indicates an expected call of DoStream.
+func (mr *ClientMockRecorder) DoStream(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoStream", reflect.TypeOf((*Client)(nil).DoStream), arg0, arg1)
+}
+
 // DoCache mocks base method.
 func (m *Client) DoCache(arg0 context.Context, arg1 rueidis.Cacheable, arg2 time.Duration) rueidis.RedisResult {
 	m.ctrl.T.Helper()
@@ -146,6 +160,25 @@ func (mr *ClientMockRecorder) DoMulti(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoMulti", reflect.TypeOf((*Client)(nil).DoMulti), varargs...)
+}
+
+// DoMultiStream mocks base method.
+func (m *Client) DoMultiStream(arg0 context.Context, arg1 ...rueidis.Completed) rueidis.MultiRedisResultStream {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DoMultiStream", varargs...)
+	ret0, _ := ret[0].(rueidis.MultiRedisResultStream)
+	return ret0
+}
+
+// DoMultiStream indicates an expected call of DoMultiStream.
+func (mr *ClientMockRecorder) DoMultiStream(arg0 any, arg1 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoMultiStream", reflect.TypeOf((*Client)(nil).DoMultiStream), varargs...)
 }
 
 // DoMultiCache mocks base method.

--- a/mock/client_test.go
+++ b/mock/client_test.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -54,6 +55,20 @@ func TestNewClient(t *testing.T) {
 			if err := resp.Error(); !rueidis.IsRedisNil(err) {
 				t.Fatalf("unexpected err %v", err)
 			}
+		}
+	}
+	{
+		client.EXPECT().DoStream(ctx, Match("GET", "e")).Return(RedisResultStream(RedisNil()))
+		s := client.DoStream(ctx, client.B().Get().Key("e").Build())
+		if _, err := s.WriteTo(io.Discard); !rueidis.IsRedisNil(err) {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	{
+		client.EXPECT().DoMultiStream(ctx, Match("GET", "e"), Match("GET", "f")).Return(MultiRedisResultStream(RedisNil()))
+		s := client.DoMultiStream(ctx, client.B().Get().Key("e").Build(), client.B().Get().Key("f").Build())
+		if _, err := s.WriteTo(io.Discard); !rueidis.IsRedisNil(err) {
+			t.Fatalf("unexpected err %v", err)
 		}
 	}
 	{

--- a/mock/result.go
+++ b/mock/result.go
@@ -1,7 +1,14 @@
 package mock
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
 	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/redis/rueidis"
@@ -19,6 +26,11 @@ func ErrorResult(err error) rueidis.RedisResult {
 
 func RedisString(v string) rueidis.RedisMessage {
 	m := message{typ: '+', string: v}
+	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
+}
+
+func RedisBlobString(v string) rueidis.RedisMessage {
+	m := message{typ: '$', string: v}
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
@@ -65,14 +77,111 @@ func RedisMap(kv map[string]rueidis.RedisMessage) rueidis.RedisMessage {
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
+func serialize(m message, buf *bytes.Buffer) {
+	switch m.typ {
+	case '$', '!', '=':
+		buf.WriteString(fmt.Sprintf("%s%d\r\n%s\r\n", string(m.typ), len(m.string), m.string))
+	case '+', '-', ',', '(':
+		buf.WriteString(fmt.Sprintf("%s%s\r\n", string(m.typ), m.string))
+	case ':', '#':
+		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), m.integer))
+	case '_':
+		buf.WriteString(fmt.Sprintf("%s\r\n", string(m.typ)))
+	case '*':
+		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), len(m.values)))
+		for _, v := range m.values {
+			pv := *(*message)(unsafe.Pointer(&v))
+			serialize(pv, buf)
+		}
+	case '%':
+		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), len(m.values)/2))
+		for _, v := range m.values {
+			pv := *(*message)(unsafe.Pointer(&v))
+			serialize(pv, buf)
+		}
+	}
+}
+
+func RedisResultStreamError(err error) rueidis.RedisResultStream {
+	s := stream{e: err}
+	return *(*rueidis.RedisResultStream)(unsafe.Pointer(&s))
+}
+
+func RedisResultStream(ms ...rueidis.RedisMessage) rueidis.RedisResultStream {
+	buf := bytes.NewBuffer(nil)
+	for _, m := range ms {
+		pm := *(*message)(unsafe.Pointer(&m))
+		serialize(pm, buf)
+	}
+	s := stream{n: len(ms), p: &pool{size: 1, cond: sync.NewCond(&sync.Mutex{})}, w: &pipe{r: bufio.NewReader(buf)}}
+	return *(*rueidis.RedisResultStream)(unsafe.Pointer(&s))
+}
+
+func MultiRedisResultStream(ms ...rueidis.RedisMessage) rueidis.MultiRedisResultStream {
+	return RedisResultStream(ms...)
+}
+
+func MultiRedisResultStreamError(err error) rueidis.RedisResultStream {
+	return RedisResultStreamError(err)
+}
+
 type message struct {
 	attrs   *rueidis.RedisMessage
 	string  string
 	values  []rueidis.RedisMessage
 	integer int64
 	typ     byte
+	ttl     [7]byte
 }
+
 type result struct {
 	err error
 	val rueidis.RedisMessage
+}
+
+type pool struct {
+	dead any
+	cond *sync.Cond
+	make func() any
+	list []any
+	size int
+	down bool
+}
+
+type pipe struct {
+	conn            net.Conn
+	error           atomic.Value
+	clhks           atomic.Value // closed hook, invoked after the conn is closed
+	pshks           atomic.Value // pubsub hook, registered by the SetPubSubHooks
+	queue           any
+	cache           rueidis.CacheStore
+	r               *bufio.Reader
+	w               *bufio.Writer
+	close           chan struct{}
+	onInvalidations func([]rueidis.RedisMessage)
+	r2psFn          func() (p *pipe, err error) // func to build pipe for resp2 pubsub
+	r2pipe          *pipe                       // internal pipe for resp2 pubsub only
+	ssubs           *any                        // pubsub smessage subscriptions
+	nsubs           *any                        // pubsub  message subscriptions
+	psubs           *any                        // pubsub pmessage subscriptions
+	info            map[string]rueidis.RedisMessage
+	timeout         time.Duration
+	pinggap         time.Duration
+	maxFlushDelay   time.Duration
+	once            sync.Once
+	r2mu            sync.Mutex
+	version         int32
+	_               [10]int32
+	blcksig         int32
+	state           int32
+	waits           int32
+	recvs           int32
+	r2ps            bool // identify this pipe is used for resp2 pubsub or not
+}
+
+type stream struct {
+	p *pool
+	w *pipe
+	e error
+	n int
 }

--- a/mux.go
+++ b/mux.go
@@ -383,6 +383,7 @@ func (m *mux) Close() {
 		}
 	}
 	m.dpool.Close()
+	m.spool.Close()
 }
 
 func (m *mux) Addr() string {

--- a/mux.go
+++ b/mux.go
@@ -70,7 +70,8 @@ type mux struct {
 	init   wire
 	dead   wire
 	clhks  atomic.Value
-	pool   *pool
+	dpool  *pool
+	spool  *pool
 	wireFn wireFn
 	dst    string
 	wire   []atomic.Value
@@ -81,19 +82,23 @@ type mux struct {
 
 func makeMux(dst string, option *ClientOption, dialFn dialFn) *mux {
 	dead := deadFn()
-	return newMux(dst, option, (*pipe)(nil), dead, func() (w wire) {
-		w, err := newPipe(func() (net.Conn, error) {
-			return dialFn(dst, option)
-		}, option)
-		if err != nil {
-			dead.error.Store(&errs{error: err})
-			w = dead
+	connFn := func() (net.Conn, error) {
+		return dialFn(dst, option)
+	}
+	wireFn := func(pipeFn pipeFn) func() wire {
+		return func() (w wire) {
+			w, err := pipeFn(connFn, option)
+			if err != nil {
+				dead.error.Store(&errs{error: err})
+				w = dead
+			}
+			return w
 		}
-		return w
-	})
+	}
+	return newMux(dst, option, (*pipe)(nil), dead, wireFn(newPipe), wireFn(newPipeNoBg))
 }
 
-func newMux(dst string, option *ClientOption, init, dead wire, wireFn wireFn) *mux {
+func newMux(dst string, option *ClientOption, init, dead wire, wireFn wireFn, wireNoBgFn wireFn) *mux {
 	var multiplex int
 	if option.PipelineMultiplex >= 0 {
 		multiplex = 1 << option.PipelineMultiplex
@@ -110,7 +115,8 @@ func newMux(dst string, option *ClientOption, init, dead wire, wireFn wireFn) *m
 	for i := 0; i < len(m.wire); i++ {
 		m.wire[i].Store(init)
 	}
-	m.pool = newPool(option.BlockingPoolSize, dead, wireFn)
+	m.dpool = newPool(option.BlockingPoolSize, dead, wireFn)
+	m.spool = newPool(option.BlockingPoolSize, dead, wireNoBgFn)
 	return m
 }
 
@@ -262,17 +268,17 @@ block:
 }
 
 func (m *mux) blocking(ctx context.Context, cmd Completed) (resp RedisResult) {
-	wire := m.pool.Acquire()
+	wire := m.dpool.Acquire()
 	resp = wire.Do(ctx, cmd)
 	if resp.NonRedisError() != nil { // abort the wire if blocking command return early (ex. context.DeadlineExceeded)
 		wire.Close()
 	}
-	m.pool.Store(wire)
+	m.dpool.Store(wire)
 	return resp
 }
 
 func (m *mux) blockingMulti(ctx context.Context, cmd []Completed) (resp *redisresults) {
-	wire := m.pool.Acquire()
+	wire := m.dpool.Acquire()
 	resp = wire.DoMulti(ctx, cmd...)
 	for _, res := range resp.s {
 		if res.NonRedisError() != nil { // abort the wire if blocking command return early (ex. context.DeadlineExceeded)
@@ -280,7 +286,7 @@ func (m *mux) blockingMulti(ctx context.Context, cmd []Completed) (resp *redisre
 			break
 		}
 	}
-	m.pool.Store(wire)
+	m.dpool.Store(wire)
 	return resp
 }
 
@@ -388,13 +394,13 @@ func (m *mux) Receive(ctx context.Context, subscribe Completed, fn func(message 
 }
 
 func (m *mux) Acquire() wire {
-	return m.pool.Acquire()
+	return m.dpool.Acquire()
 }
 
 func (m *mux) Store(w wire) {
 	w.SetPubSubHooks(PubSubHooks{})
 	w.CleanSubscriptions()
-	m.pool.Store(w)
+	m.dpool.Store(w)
 }
 
 func (m *mux) Close() {
@@ -403,7 +409,7 @@ func (m *mux) Close() {
 			prev.Close()
 		}
 	}
-	m.pool.Close()
+	m.dpool.Close()
 }
 
 func (m *mux) Addr() string {

--- a/mux.go
+++ b/mux.go
@@ -203,8 +203,8 @@ func (m *mux) Error() error {
 	return m.pipe(0).Error()
 }
 
-type Stream struct {
-	m *mux
+type RedisResultStream struct {
+	p *pool
 	w *pipe
 	e error
 	n int
@@ -228,16 +228,16 @@ func (s *Stream) To(w io.Writer) (n int64, err error) {
 	return n, err
 }
 
-func (m *mux) doStream(ctx context.Context, cmd Completed) Stream {
-	wire := m.pool.Acquire()
+func (m *mux) doStream(ctx context.Context, cmd Completed) RedisResultStream {
+	wire := m.spool.Acquire()
 	err := wire.(*pipe).doStream(ctx, cmd)
-	return Stream{m: m, w: wire.(*pipe), e: err, n: 1}
+	return RedisResultStream{p: m.spool, w: wire.(*pipe), e: err, n: 1}
 }
 
-func (m *mux) doMultiStream(ctx context.Context, multi ...Completed) Stream {
-	wire := m.pool.Acquire()
+func (m *mux) doMultiStream(ctx context.Context, multi ...Completed) RedisResultStream {
+	wire := m.spool.Acquire()
 	err := wire.(*pipe).doMultiStream(ctx, multi...)
-	return Stream{m: m, w: wire.(*pipe), e: err, n: len(multi)}
+	return RedisResultStream{p: m.spool, w: wire.(*pipe), e: err, n: len(multi)}
 }
 
 func (m *mux) Do(ctx context.Context, cmd Completed) (resp RedisResult) {

--- a/mux.go
+++ b/mux.go
@@ -2,6 +2,7 @@ package rueidis
 
 import (
 	"context"
+	"io"
 	"math/rand"
 	"net"
 	"runtime"
@@ -199,6 +200,13 @@ func (m *mux) Version() int {
 
 func (m *mux) Error() error {
 	return m.pipe(0).Error()
+}
+
+func (m *mux) doReader(ctx context.Context, cmd Completed) (io.Reader, error) {
+	wire := m.pool.Acquire()
+	return wire.(*pipe).doReader(ctx, func() {
+		m.pool.Store(wire)
+	}, cmd)
 }
 
 func (m *mux) Do(ctx context.Context, cmd Completed) (resp RedisResult) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -28,6 +28,8 @@ func setupMuxWithOption(wires []*mockWire, option *ClientOption) (conn *mux, che
 			defer mu.Unlock()
 			count++
 			return wires[count]
+		}, func() wire {
+			return &mockWire{}
 		}), func(t *testing.T) {
 			if count != len(wires)-1 {
 				t.Fatalf("there is %d remaining unused wires", len(wires)-count-1)
@@ -128,6 +130,8 @@ func TestMuxDialSuppress(t *testing.T) {
 	m := newMux("", &ClientOption{}, (*mockWire)(nil), (*mockWire)(nil), func() wire {
 		atomic.AddInt64(&wires, 1)
 		<-blocking
+		return &mockWire{}
+	}, func() wire {
 		return &mockWire{}
 	})
 	for i := 0; i < 1000; i++ {

--- a/pipe.go
+++ b/pipe.go
@@ -1004,14 +1004,20 @@ type RedisResultStream struct {
 	n int
 }
 
+// HasNext can be used in a for loop condition to check if a further WriteTo call is needed.
 func (s *RedisResultStream) HasNext() bool {
-	return s.n != 0
+	return s.n > 0 && s.e == nil
 }
 
+// Error returns the error happened when sending commands to redis or reading response from redis.
+// Usually a user is not required to use this function because the error is also reported by the WriteTo.
 func (s *RedisResultStream) Error() error {
 	return s.e
 }
 
+// WriteTo reads a redis response from redis and then write it to the given writer.
+// This function is not thread safe and should be called sequentially to read multiple responses.
+// An io.EOF error will be reported if all responses are read.
 func (s *RedisResultStream) WriteTo(w io.Writer) (n int64, err error) {
 	if err = s.e; err == nil && s.n > 0 {
 		var clean bool

--- a/pipe.go
+++ b/pipe.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"regexp"
@@ -985,31 +984,26 @@ abort:
 	return resp
 }
 
-func (p *pipe) doReader(ctx context.Context, done func(), cmd Completed) (io.Reader, error) {
+func (p *pipe) doReader(ctx context.Context, cmd Completed) error {
 	if cmd.NoReply() {
 		panic("NoReply is not supported")
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return err
 	}
 	cmds.CompletedCS(cmd).Verify()
 
 	state := atomic.LoadInt32(&p.state)
 
 	if state == 1 {
-		panic("DoReader with auto pipelining is a bug")
+		panic("DoStream with auto pipelining is a bug")
 	}
 
 	if state == 0 {
 		atomic.AddInt32(&p.blcksig, 1)
 		waits := atomic.AddInt32(&p.waits, 1)
-		donef := func() {
-			atomic.AddInt32(&p.blcksig, -1)
-			atomic.AddInt32(&p.waits, -1)
-			done()
-		}
 		if waits != 1 {
-			panic("DoReader with racing is a bug")
+			panic("DoStream with racing is a bug")
 		}
 		dl, ok := ctx.Deadline()
 		if ok {
@@ -1027,12 +1021,13 @@ func (p *pipe) doReader(ctx context.Context, done func(), cmd Completed) (io.Rea
 			p.error.CompareAndSwap(nil, &errs{error: err})
 			p.conn.Close()
 			p.background() // start the background worker to clean up goroutines
-			donef()
-			return nil, err
+			atomic.AddInt32(&p.blcksig, -1)
+			atomic.AddInt32(&p.waits, -1)
+			return err
 		}
-		return nextStringReader(p.r, donef)
+		return nil
 	}
-	return nil, p.Error()
+	return p.Error()
 }
 
 func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp RedisResult) {

--- a/rueidis.go
+++ b/rueidis.go
@@ -193,6 +193,7 @@ type SentinelOption struct {
 type StreamClient interface {
 	B() Builder
 	DoStream(ctx context.Context, cmd Completed) Stream
+	DoMultiStream(ctx context.Context, multi ...Completed) Stream
 	Close()
 }
 

--- a/rueidis.go
+++ b/rueidis.go
@@ -192,8 +192,8 @@ type SentinelOption struct {
 
 type StreamClient interface {
 	B() Builder
-	DoStream(ctx context.Context, cmd Completed) Stream
-	DoMultiStream(ctx context.Context, multi ...Completed) Stream
+	DoStream(ctx context.Context, cmd Completed) RedisResultStream
+	DoMultiStream(ctx context.Context, multi ...Completed) RedisResultStream
 	Close()
 }
 

--- a/rueidis.go
+++ b/rueidis.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"math"
 	"math/rand"
 	"net"
@@ -188,6 +189,12 @@ type SentinelOption struct {
 	Username   string
 	Password   string
 	ClientName string
+}
+
+type StreamClient interface {
+	B() Builder
+	DoReader(ctx context.Context, cmd Completed) (r io.Reader, err error)
+	Close()
 }
 
 // Client is the redis client interface for both single redis instance and redis cluster. It should be created from the NewClient()

--- a/rueidis.go
+++ b/rueidis.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"io"
 	"math"
 	"math/rand"
 	"net"
@@ -193,7 +192,7 @@ type SentinelOption struct {
 
 type StreamClient interface {
 	B() Builder
-	DoReader(ctx context.Context, cmd Completed) (r io.Reader, err error)
+	DoStream(ctx context.Context, cmd Completed) Stream
 	Close()
 }
 

--- a/rueidis.go
+++ b/rueidis.go
@@ -190,13 +190,6 @@ type SentinelOption struct {
 	ClientName string
 }
 
-type StreamClient interface {
-	B() Builder
-	DoStream(ctx context.Context, cmd Completed) RedisResultStream
-	DoMultiStream(ctx context.Context, multi ...Completed) RedisResultStream
-	Close()
-}
-
 // Client is the redis client interface for both single redis instance and redis cluster. It should be created from the NewClient()
 type Client interface {
 	CoreClient
@@ -216,6 +209,9 @@ type Client interface {
 	// DoMultiCache is similar to DoCache, but works with multiple cacheable commands across different slots.
 	// It will first group commands by slots and will send only cache missed commands to redis.
 	DoMultiCache(ctx context.Context, multi ...CacheableTTL) (resp []RedisResult)
+
+	DoStream(ctx context.Context, cmd Completed) RedisResultStream
+	DoMultiStream(ctx context.Context, multi ...Completed) MultiRedisResultStream
 
 	// Dedicated acquire a connection from the blocking connection pool, no one else can use the connection
 	// during Dedicated. The main usage of Dedicated is CAS operation, which is WATCH + MULTI + EXEC.

--- a/rueidishook/hook.go
+++ b/rueidishook/hook.go
@@ -16,6 +16,8 @@ type Hook interface {
 	DoCache(client rueidis.Client, ctx context.Context, cmd rueidis.Cacheable, ttl time.Duration) (resp rueidis.RedisResult)
 	DoMultiCache(client rueidis.Client, ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult)
 	Receive(client rueidis.Client, ctx context.Context, subscribe rueidis.Completed, fn func(msg rueidis.PubSubMessage)) (err error)
+	DoStream(client rueidis.Client, ctx context.Context, cmd rueidis.Completed) rueidis.RedisResultStream
+	DoMultiStream(client rueidis.Client, ctx context.Context, multi ...rueidis.Completed) rueidis.MultiRedisResultStream
 }
 
 // WithHook wraps rueidis.Client with Hook and allows user to intercept rueidis.Client
@@ -46,6 +48,14 @@ func (c *hookclient) DoCache(ctx context.Context, cmd rueidis.Cacheable, ttl tim
 
 func (c *hookclient) DoMultiCache(ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
 	return c.hook.DoMultiCache(c.client, ctx, multi...)
+}
+
+func (c *hookclient) DoStream(ctx context.Context, cmd rueidis.Completed) rueidis.RedisResultStream {
+	return c.hook.DoStream(c.client, ctx, cmd)
+}
+
+func (c *hookclient) DoMultiStream(ctx context.Context, multi ...rueidis.Completed) rueidis.MultiRedisResultStream {
+	return c.hook.DoMultiStream(c.client, ctx, multi...)
 }
 
 func (c *hookclient) Dedicated(fn func(rueidis.DedicatedClient) error) (err error) {
@@ -118,6 +128,13 @@ func (e *extended) DoCache(ctx context.Context, cmd rueidis.Cacheable, ttl time.
 
 func (e *extended) DoMultiCache(ctx context.Context, multi ...rueidis.CacheableTTL) (resp []rueidis.RedisResult) {
 	panic("DoMultiCache() is not allowed with rueidis.DedicatedClient")
+}
+func (c *extended) DoStream(ctx context.Context, cmd rueidis.Completed) rueidis.RedisResultStream {
+	panic("DoStream() is not allowed with rueidis.DedicatedClient")
+}
+
+func (c *extended) DoMultiStream(ctx context.Context, multi ...rueidis.Completed) rueidis.MultiRedisResultStream {
+	panic("DoMultiStream() is not allowed with rueidis.DedicatedClient")
 }
 
 func (e *extended) Dedicated(fn func(rueidis.DedicatedClient) error) (err error) {

--- a/rueidishook/hook_test.go
+++ b/rueidishook/hook_test.go
@@ -33,6 +33,14 @@ func (h *hook) Receive(client rueidis.Client, ctx context.Context, subscribe rue
 	return client.Receive(ctx, subscribe, fn)
 }
 
+func (h *hook) DoStream(client rueidis.Client, ctx context.Context, cmd rueidis.Completed) rueidis.RedisResultStream {
+	return client.DoStream(ctx, cmd)
+}
+
+func (h *hook) DoMultiStream(client rueidis.Client, ctx context.Context, multi ...rueidis.Completed) rueidis.MultiRedisResultStream {
+	return client.DoMultiStream(ctx, multi...)
+}
+
 type wronghook struct {
 	DoFn func(client rueidis.Client)
 }
@@ -55,6 +63,14 @@ func (w *wronghook) DoMultiCache(client rueidis.Client, ctx context.Context, mul
 }
 
 func (w *wronghook) Receive(client rueidis.Client, ctx context.Context, subscribe rueidis.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
+	panic("implement me")
+}
+
+func (w *wronghook) DoStream(client rueidis.Client, ctx context.Context, cmd rueidis.Completed) rueidis.RedisResultStream {
+	panic("implement me")
+}
+
+func (w *wronghook) DoMultiStream(client rueidis.Client, ctx context.Context, multi ...rueidis.Completed) rueidis.MultiRedisResultStream {
 	panic("implement me")
 }
 

--- a/rueidisotel/trace.go
+++ b/rueidisotel/trace.go
@@ -99,6 +99,20 @@ func (o *otelclient) DoMulti(ctx context.Context, multi ...rueidis.Completed) (r
 	return
 }
 
+func (o *otelclient) DoStream(ctx context.Context, cmd rueidis.Completed) (resp rueidis.RedisResultStream) {
+	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()), o.tAttrs)
+	resp = o.client.DoStream(ctx, cmd)
+	o.end(span, resp.Error())
+	return
+}
+
+func (o *otelclient) DoMultiStream(ctx context.Context, multi ...rueidis.Completed) (resp rueidis.MultiRedisResultStream) {
+	ctx, span := o.start(ctx, multiFirst(multi), multiSum(multi), o.tAttrs)
+	resp = o.client.DoMultiStream(ctx, multi...)
+	o.end(span, resp.Error())
+	return
+}
+
 func (o *otelclient) DoCache(ctx context.Context, cmd rueidis.Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
 	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()), o.tAttrs)
 	resp = o.client.DoCache(ctx, cmd, ttl)

--- a/rueidisotel/trace_test.go
+++ b/rueidisotel/trace_test.go
@@ -93,6 +93,12 @@ func testWithClient(t *testing.T, client rueidis.Client, exp *tracetest.InMemory
 	client.DoMulti(ctx, client.B().Set().Key("key").Value("val").Build(), client.B().Set().Key("key").Value("val").Build())
 	validateTrace(t, exp, "SET SET", codes.Ok)
 
+	client.DoStream(ctx, client.B().Set().Key("key").Value("val").Build())
+	validateTrace(t, exp, "SET", codes.Ok)
+
+	client.DoMultiStream(ctx, client.B().Set().Key("key").Value("val").Build(), client.B().Set().Key("key").Value("val").Build())
+	validateTrace(t, exp, "SET SET", codes.Ok)
+
 	// first DoCache
 	client.DoCache(ctx, client.B().Get().Key("key").Cache(), time.Minute)
 	validateTrace(t, exp, "GET", codes.Ok)


### PR DESCRIPTION
This is a draft of #450.

Initial benchmark result with redjet v0.5.0:

```
▶ go test -bench . -benchtime=3s
goos: darwin
goarch: arm64
pkg: rueidis-benchmark/redjet
Benchmark/single/rueidis/payload1B-10         	  697377	      5117 ns/op	       0 B/op	       0 allocs/op
Benchmark/single/rueidis/payload1K-10         	  626092	      5241 ns/op	       0 B/op	       0 allocs/op
Benchmark/single/rueidis/payload1M-10         	   19602	    181655 ns/op	       1 B/op	       0 allocs/op
Benchmark/single/redjet/payload1B-10          	  657787	      5283 ns/op	     256 B/op	       4 allocs/op
Benchmark/single/redjet/payload1K-10          	  632977	      5408 ns/op	     256 B/op	       4 allocs/op
Benchmark/single/redjet/payload1M-10          	   17818	    201544 ns/op	     291 B/op	       5 allocs/op
Benchmark/pipe20/rueidis/payload1B-10         	  328735	     10990 ns/op	       0 B/op	       0 allocs/op
Benchmark/pipe20/rueidis/payload1K-10         	  276231	     12719 ns/op	       0 B/op	       0 allocs/op
Benchmark/pipe20/rueidis/payload1M-10         	     607	   5568295 ns/op	      46 B/op	       0 allocs/op
Benchmark/pipe20/redjet/payload1B-10          	  328198	     10975 ns/op	     560 B/op	      23 allocs/op
Benchmark/pipe20/redjet/payload1K-10          	  274506	     12821 ns/op	     560 B/op	      23 allocs/op
Benchmark/pipe20/redjet/payload1M-10          	     618	   5762557 ns/op	    1424 B/op	      43 allocs/op
PASS
```

Code:
```go
package bench

import (
	"context"
	"io"
	"strings"
	"testing"

	"github.com/coder/redjet"
	"github.com/redis/rueidis"
)

func Benchmark(b *testing.B) {
	tests := [][2]string{
		{"payload1B", strings.Repeat("x", 1)},
		{"payload1K", strings.Repeat("x", 1024)},
		{"payload1M", strings.Repeat("x", 1024*1024)},
	}

	rj := redjet.New("127.0.0.1:6379")
	defer rj.Close()

	ru, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6379"}})
	if err != nil {
		panic(err)
	}
	defer ru.Close()

	for _, t := range tests {
		if err := ru.Do(context.Background(), ru.B().Set().Key(t[0]).Value(t[1]).Build()).Error(); err != nil {
			panic(err)
		}
	}

	b.Run("single", func(b *testing.B) {
		b.Run("rueidis", func(b *testing.B) {
			for _, t := range tests {
				b.Run(t[0], func(b *testing.B) {
					b.ResetTimer()
					b.ReportAllocs()
					b.RunParallel(func(pb *testing.PB) {
						for pb.Next() {
							s := ru.DoStream(context.Background(), ru.B().Get().Key(t[0]).Build())
							n, err := s.WriteTo(io.Discard)
							if err != nil {
								panic(err)
							}
							if n != int64(len(t[1])) {
								panic("wrong")
							}
						}
					})
				})
			}
		})

		b.Run("redjet", func(b *testing.B) {
			for _, t := range tests {
				b.Run(t[0], func(b *testing.B) {
					b.ResetTimer()
					b.ReportAllocs()
					b.RunParallel(func(pb *testing.PB) {
						for pb.Next() {
							n, err := rj.Command(context.Background(), "GET", t[0]).WriteTo(io.Discard)
							if err != nil {
								panic(err)
							}
							if n != int64(len(t[1])) {
								panic("wrong")
							}
						}
					})
				})
			}
		})
	})

	b.Run("pipe20", func(b *testing.B) {
		b.Run("rueidis", func(b *testing.B) {
			for _, t := range tests {
				b.Run(t[0], func(b *testing.B) {
					b.ResetTimer()
					b.ReportAllocs()
					b.RunParallel(func(pb *testing.PB) {
						cmds := make(rueidis.Commands, 20)
						for n := range cmds {
							cmds[n] = ru.B().Get().Key(t[0]).Build().Pin()
						}
						for pb.Next() {
							s := ru.DoMultiStream(context.Background(), cmds...)
							for range cmds {
								n, err := s.WriteTo(io.Discard)
								if err != nil {
									panic(err)
								}
								if n != int64(len(t[1])) {
									panic("wrong")
								}
							}
						}
					})
				})
			}
		})

		b.Run("redjet", func(b *testing.B) {
			for _, t := range tests {
				b.Run(t[0], func(b *testing.B) {
					b.ResetTimer()
					b.ReportAllocs()
					b.RunParallel(func(pb *testing.PB) {
						for pb.Next() {
							var p *redjet.Pipeline
							for n := 0; n < 20; n++ {
								p = rj.Pipeline(context.Background(), p, "GET", t[0])
							}
							for p.Next() {
								n, err := p.WriteTo(io.Discard)
								if err != nil {
									panic(err)
								}
								if n != int64(len(t[1])) {
									panic("wrong")
								}
							}
							p.Close()
						}
					})
				})
			}
		})
	})
}
```