### PR TITLE
improvement: set shorter deadline between context deadline and conn deadline

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -1062,6 +1062,10 @@ func (p *pipe) DoStream(ctx context.Context, pool *pool, cmd Completed) RedisRes
 		}
 		dl, ok := ctx.Deadline()
 		if ok {
+			defaultDeadline := time.Now().Add(p.timeout)
+			if dl.After(defaultDeadline) {
+				dl = defaultDeadline
+			}
 			p.conn.SetDeadline(dl)
 		} else if p.timeout > 0 && !cmd.IsBlock() {
 			p.conn.SetDeadline(time.Now().Add(p.timeout))
@@ -1106,6 +1110,10 @@ func (p *pipe) DoMultiStream(ctx context.Context, pool *pool, multi ...Completed
 		}
 		dl, ok := ctx.Deadline()
 		if ok {
+			defaultDeadline := time.Now().Add(p.timeout)
+			if dl.After(defaultDeadline) {
+				dl = defaultDeadline
+			}
 			p.conn.SetDeadline(dl)
 		} else if p.timeout > 0 {
 			for _, cmd := range multi {
@@ -1138,6 +1146,10 @@ func (p *pipe) DoMultiStream(ctx context.Context, pool *pool, multi ...Completed
 
 func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp RedisResult) {
 	if dlOk {
+		defaultDeadline := time.Now().Add(p.timeout)
+		if dl.After(defaultDeadline) {
+			dl = defaultDeadline
+		}
 		p.conn.SetDeadline(dl)
 	} else if p.timeout > 0 && !cmd.IsBlock() {
 		p.conn.SetDeadline(time.Now().Add(p.timeout))
@@ -1163,6 +1175,10 @@ func (p *pipe) syncDo(dl time.Time, dlOk bool, cmd Completed) (resp RedisResult)
 
 func (p *pipe) syncDoMulti(dl time.Time, dlOk bool, resp []RedisResult, multi []Completed) {
 	if dlOk {
+		defaultDeadline := time.Now().Add(p.timeout)
+		if dl.After(defaultDeadline) {
+			dl = defaultDeadline
+		}
 		p.conn.SetDeadline(dl)
 	} else if p.timeout > 0 {
 		for _, cmd := range multi {


### PR DESCRIPTION
previous discussion: https://github.com/redis/rueidis/discussions/468

set shorter deadline between `context.Context`and `ConnWriteTimeout`