### PR TITLE
refactor: move ginkgo/v2 dependency to its submodule

### DIFF
--- a/rueidiscompat/go.mod
+++ b/rueidiscompat/go.mod
@@ -1,10 +1,13 @@
-module github.com/redis/rueidis
+module github.com/redis/rueidis/rueidiscompat
 
 go 1.20
 
+replace github.com/redis/rueidis => ../
+
 require (
+	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
-	golang.org/x/sys v0.14.0
+	github.com/redis/rueidis v1.0.28
 )
 
 require (
@@ -12,11 +15,9 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.12.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Fixes #466 