### PR TITLE
Refactor: add baseCmd to go-redis adaptor commands

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -2560,7 +2560,8 @@ func (c *Compat) EvalShaRO(ctx context.Context, sha1 string, keys []string, args
 
 func (c *Compat) ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd {
 	var mu sync.Mutex
-	ret := &BoolSliceCmd{val: make([]bool, len(hashes))}
+	ret := &BoolSliceCmd{}
+	ret.val = make([]bool, len(hashes))
 	for i := range hashes {
 		ret.val[i] = true
 	}


### PR DESCRIPTION
This PR add `baseCmd` to `go-redis` adaptor commands.
Note that there are some Commands that can't use `baseCmd` due to incompatible method
signature for `(*Command).SetVal`, `(*Command).Val`, `(*Command).Result`.

 e.g. `KeyValuesCmd`, `ZSliceWithKeyCmd`, `XAutoClaimCmd`, `XAutoClaimJustIDCmd`.