### PR TITLE
feat: add counting bloom filter

### DIFF
--- a/rueidisprob/README.md
+++ b/rueidisprob/README.md
@@ -57,3 +57,80 @@ func main() {
 	fmt.Println(exists) // true
 }
 ```
+
+### Counting Bloom Filter
+
+It is a variation of the standard Bloom filter that adds a counting mechanism to each element.
+This allows for the filter to count the number of times an element has been added to the filter.
+And it allows for the removal of elements from the filter.
+
+Example:
+
+```go
+
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/redis/rueidis"
+    "github.com/redis/rueidis/rueidisprob"
+)
+
+func main() {
+    client, err := rueidis.NewClient(rueidis.ClientOption{
+        InitAddress: []string{"localhost:6379"},
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    cbf, err := rueidisprob.NewCountingBloomFilter(client, "counting_bloom_filter", 1000, 0.01)
+
+    err = cbf.Add(context.Background(), "hello")
+    if err != nil {
+        panic(err)
+    }
+
+    err = cbf.Add(context.Background(), "world")
+    if err != nil {
+        panic(err)
+    }
+
+    exists, err := cbf.Exists(context.Background(), "hello")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(exists) // true
+
+    exists, err = cbf.Exists(context.Background(), "world")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(exists) // true
+
+    count, err := cbf.Count(context.Background())
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(count) // 2
+
+    err = cbf.Remove(context.Background(), "hello")
+    if err != nil {
+        panic(err)
+    }
+
+    exists, err = cbf.Exists(context.Background(), "hello")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(exists) // false
+
+    count, err = cbf.Count(context.Background())
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(count) // 1
+}
+```

--- a/rueidisprob/bloomfilter.go
+++ b/rueidisprob/bloomfilter.go
@@ -15,7 +15,7 @@ const (
 )
 
 const (
-	addMultiScript = `
+	bloomFilterAddMultiScript = `
 local hashIterations = tonumber(ARGV[1])
 local numElements = tonumber(#ARGV) - 1
 local filterKey = KEYS[1]
@@ -48,7 +48,7 @@ end
 return redis.call('INCRBY', counterKey, counter)
 `
 
-	existsMultiScript = `
+	bloomFilterExistsMultiScript = `
 local hashIterations = tonumber(ARGV[1])
 local numElements = tonumber(#ARGV) - 1
 local filterKey = KEYS[1]
@@ -79,7 +79,7 @@ end
 return result
 `
 
-	resetScript = `
+	bloomFilterResetScript = `
 local filterKey = KEYS[1]
 local counterKey = KEYS[2]
 
@@ -89,7 +89,7 @@ redis.call('SET', counterKey, 0)
 return 1
 `
 
-	deleteScript = `
+	bloomFilterDeleteScript = `
 local filterKey = KEYS[1]
 local counterKey = KEYS[2]
 
@@ -179,14 +179,14 @@ func NewBloomFilter(
 		return nil, ErrFalsePositiveRateGreaterThanOne
 	}
 
-	size := numberOfBits(expectedNumberOfItems, falsePositiveRate)
+	size := numberOfBloomFilterBits(expectedNumberOfItems, falsePositiveRate)
 	if size == 0 {
 		return nil, ErrBitsSizeZero
 	}
 	if size > maxSize {
 		return nil, ErrBitsSizeTooLarge
 	}
-	hashIterations := numberOfHashFunctions(size, expectedNumberOfItems)
+	hashIterations := numberOfBloomFilterHashFunctions(size, expectedNumberOfItems)
 
 	// NOTE: https://redis.io/docs/reference/cluster-spec/#hash-tags
 	bfName := "{" + name + "}"
@@ -198,18 +198,18 @@ func NewBloomFilter(
 		hashIterations:      hashIterations,
 		hashIterationString: strconv.FormatUint(uint64(hashIterations), 10),
 		size:                size,
-		addMultiScript:      rueidis.NewLuaScript(addMultiScript),
+		addMultiScript:      rueidis.NewLuaScript(bloomFilterAddMultiScript),
 		addMultiKeys:        []string{bfName, counterName},
-		existsMultiScript:   rueidis.NewLuaScript(existsMultiScript),
+		existsMultiScript:   rueidis.NewLuaScript(bloomFilterExistsMultiScript),
 		existsMultiKeys:     []string{bfName},
 	}, nil
 }
 
-func numberOfBits(n uint, r float64) uint {
+func numberOfBloomFilterBits(n uint, r float64) uint {
 	return uint(math.Ceil(-float64(n) * math.Log(r) / math.Pow(math.Log(2), 2)))
 }
 
-func numberOfHashFunctions(s uint, n uint) uint {
+func numberOfBloomFilterHashFunctions(s uint, n uint) uint {
 	return uint(math.Round(float64(s) / float64(n) * math.Log(2)))
 }
 
@@ -300,7 +300,7 @@ func (c *bloomFilter) Reset(ctx context.Context) error {
 		ctx,
 		c.client.B().
 			Eval().
-			Script(resetScript).
+			Script(bloomFilterResetScript).
 			Numkeys(2).
 			Key(c.name, c.counter).
 			Build(),
@@ -317,7 +317,7 @@ func (c *bloomFilter) Delete(ctx context.Context) error {
 		ctx,
 		c.client.B().
 			Eval().
-			Script(deleteScript).
+			Script(bloomFilterDeleteScript).
 			Numkeys(2).
 			Key(c.name, c.counter).
 			Build(),

--- a/rueidisprob/bloomfilter.go
+++ b/rueidisprob/bloomfilter.go
@@ -229,11 +229,7 @@ func (c *bloomFilter) AddMulti(ctx context.Context, keys []string) error {
 	args = append(args, indexes...)
 
 	resp := c.addMultiScript.Exec(ctx, c.client, c.addMultiKeys, args)
-	if resp.Error() != nil {
-		return resp.Error()
-	}
-
-	return nil
+	return resp.Error()
 }
 
 func (c *bloomFilter) indexes(keys []string) []string {
@@ -305,11 +301,7 @@ func (c *bloomFilter) Reset(ctx context.Context) error {
 			Key(c.name, c.counter).
 			Build(),
 	)
-	if resp.Error() != nil {
-		return resp.Error()
-	}
-
-	return nil
+	return resp.Error()
 }
 
 func (c *bloomFilter) Delete(ctx context.Context) error {
@@ -322,11 +314,7 @@ func (c *bloomFilter) Delete(ctx context.Context) error {
 			Key(c.name, c.counter).
 			Build(),
 	)
-	if resp.Error() != nil {
-		return resp.Error()
-	}
-
-	return nil
+	return resp.Error()
 }
 
 func (c *bloomFilter) Count(ctx context.Context) (uint, error) {

--- a/rueidisprob/countingbloomfilter.go
+++ b/rueidisprob/countingbloomfilter.go
@@ -291,14 +291,12 @@ func (f *countingBloomFilter) ExistsMulti(ctx context.Context, keys []string) ([
 	args = append(args, indexes...)
 
 	resp := f.existsMultiScript.Exec(ctx, f.client, f.existsMultiKeys, args)
-	if resp.Error() != nil {
-		return nil, resp.Error()
-	}
 
 	arr, err := resp.AsBoolSlice()
 	if err != nil {
 		return nil, err
 	}
+
 	return arr, nil
 }
 
@@ -358,16 +356,12 @@ func (f *countingBloomFilter) Count(ctx context.Context) (uint, error) {
 			Key(f.counter).
 			Build(),
 	)
-	if resp.Error() != nil {
-		if rueidis.IsRedisNil(resp.Error()) {
+	count, err := resp.AsUint64()
+	if err != nil {
+		if rueidis.IsRedisNil(err) {
 			return 0, nil
 		}
 
-		return 0, resp.Error()
-	}
-
-	count, err := resp.AsUint64()
-	if err != nil {
 		return 0, err
 	}
 

--- a/rueidisprob/countingbloomfilter.go
+++ b/rueidisprob/countingbloomfilter.go
@@ -1,0 +1,385 @@
+package rueidisprob
+
+import (
+	"context"
+	"errors"
+	"github.com/redis/rueidis"
+	"strconv"
+)
+
+var (
+	ErrEmptyCountingBloomFilterName                          = errors.New("name cannot be empty")
+	ErrCountingBloomFilterFalsePositiveRateLessThanEqualZero = errors.New("false positive rate cannot be less than or equal to zero")
+	ErrCountingBloomFilterFalsePositiveRateGreaterThanOne    = errors.New("false positive rate cannot be greater than 1")
+	ErrCountingBloomFilterBitsSizeZero                       = errors.New("bits size cannot be zero")
+)
+
+const (
+	countingBloomFilterAddMultiScript = `
+local itemCount = tonumber(ARGV[1])
+local numElements = tonumber(#ARGV) - 1
+local filterKey = KEYS[1]
+local counterKey = KEYS[2]
+
+for i=2, numElements+1 do
+    redis.call('HINCRBY', filterKey, ARGV[i], 1)
+end
+
+return redis.call('INCRBY', counterKey, itemCount)
+`
+
+	countingBloomFilterExistsMultiScript = `
+local hashIterations = tonumber(ARGV[1])
+local numElements = tonumber(#ARGV) - 1
+local filterKey = KEYS[1]
+
+local hmgetArgs = {}
+for i=2, numElements+1 do
+    table.insert(hmgetArgs, ARGV[i])
+end
+
+local counts = redis.call('HMGET', filterKey, unpack(hmgetArgs))
+
+local result = {}
+local isExist = true
+for i=1, #counts do
+    if (not counts[i]) or (tonumber(counts[i]) == 0) then
+        isExist = false
+    end
+
+    if (i % hashIterations == 0) then
+		table.insert(result, isExist)
+        isExist = true
+    end
+end
+
+return result
+`
+
+	countingBloomFilterRemoveMultiScript = `
+local function MergeTables(t1, t2)
+	for i=1, #t2 do
+		table.insert(t1, t2[i])
+	end
+
+	return t1
+end
+
+local hashIterations = tonumber(ARGV[1])
+local numElements = tonumber(#ARGV) - 1
+local filterKey = KEYS[1]
+local counterKey = KEYS[2]
+
+local hmgetArgs = {}
+for i=2, numElements+1 do
+    table.insert(hmgetArgs, ARGV[i])
+end
+
+local counts = redis.call('HMGET', filterKey, unpack(hmgetArgs))
+
+local existingItemIndexes = {}
+local temp = {}
+local deleteItemCount = 0
+local isExistingItem = true
+for i=1, #counts do
+	table.insert(temp, ARGV[i+1])
+
+    if (not counts[i]) or (tonumber(counts[i]) == 0)  then
+        isExistingItem = false
+    end
+
+    if (i % hashIterations == 0) then
+        if isExistingItem then
+            deleteItemCount = deleteItemCount - 1
+			
+			existingItemIndexes = MergeTables(existingItemIndexes, temp)
+        end
+
+		temp = {}
+        isExistingItem = true
+    end
+end
+
+for i=1, #existingItemIndexes do
+    redis.call('HINCRBY', filterKey, existingItemIndexes[i], -1)
+end
+
+return redis.call('INCRBY', counterKey, deleteItemCount)
+`
+
+	countingBloomFilterDeleteScript = `
+local filterKey = KEYS[1]
+local counterKey = KEYS[2]
+
+redis.call('DEL', filterKey)
+redis.call('DEL', counterKey)
+
+return 1
+`
+)
+
+// CountingBloomFilter based on Hashes.
+// CountingBloomFilter uses 128-bit murmur3 hash function.
+type CountingBloomFilter interface {
+	// Add adds an item to the Counting Bloom Filter.
+	Add(ctx context.Context, key string) error
+
+	// AddMulti adds one or more items to the Counting Bloom Filter.
+	// If there are duplicate keys, they are deduplicated.
+	// NOTE: If keys are too many, it can block the Redis server for a long time.
+	AddMulti(ctx context.Context, keys []string) error
+
+	// Exists checks if an item is in the Counting Bloom Filter.
+	Exists(ctx context.Context, key string) (bool, error)
+
+	// ExistsMulti checks if one or more items are in the Counting Bloom Filter.
+	// Returns a slice of bool values where each bool indicates
+	// whether the corresponding key was found.
+	// NOTE: If keys are too many, it can block the Redis server for a long time.
+	ExistsMulti(ctx context.Context, keys []string) ([]bool, error)
+
+	// Remove removes an item from the Counting Bloom Filter.
+	Remove(ctx context.Context, key string) error
+
+	// RemoveMulti removes one or more items from the Counting Bloom Filter.
+	// If there are duplicate keys, they are deduplicated.
+	// NOTE: If keys are too many, it can block the Redis server for a long time.
+	RemoveMulti(ctx context.Context, keys []string) error
+
+	// Delete deletes the Counting Bloom Filter.
+	Delete(ctx context.Context) error
+
+	// Count returns count of items in Counting Bloom Filter.
+	Count(ctx context.Context) (uint, error)
+}
+
+type countingBloomFilter struct {
+	client rueidis.Client
+
+	// name is the name of the Counting Bloom Filter.
+	// It is used as a key in the Redis.
+	name string
+
+	// counter is the name of the counter.
+	counter string
+
+	// hashIterations is the number of hash functions to use.
+	hashIterations      uint
+	hashIterationString string
+
+	// size is the number of bits to use.
+	size uint
+
+	addMultiScript *rueidis.Lua
+	addMultiKeys   []string
+
+	existsMultiScript *rueidis.Lua
+	existsMultiKeys   []string
+
+	removeMultiScript *rueidis.Lua
+	removeMultiKeys   []string
+}
+
+// NewCountingBloomFilter creates a new Counting Bloom Filter.
+// NOTE: 'name:cbf:c' is used as a counter key in the Redis and
+// 'name:cbf' is used as a filter key in the Redis
+// to keep track of the number of items in the Counting Bloom Filter for Count method.
+func NewCountingBloomFilter(
+	client rueidis.Client,
+	name string,
+	expectedNumberOfItems uint,
+	falsePositiveRate float64,
+) (CountingBloomFilter, error) {
+	if len(name) == 0 {
+		return nil, ErrEmptyCountingBloomFilterName
+	}
+
+	if falsePositiveRate <= 0 {
+		return nil, ErrCountingBloomFilterFalsePositiveRateLessThanEqualZero
+	}
+	if falsePositiveRate >= 1 {
+		return nil, ErrCountingBloomFilterFalsePositiveRateGreaterThanOne
+	}
+
+	size := numberOfBloomFilterBits(expectedNumberOfItems, falsePositiveRate)
+	if size == 0 {
+		return nil, ErrCountingBloomFilterBitsSizeZero
+	}
+	hashIterations := numberOfBloomFilterHashFunctions(size, expectedNumberOfItems)
+
+	// NOTE: https://redis.io/docs/reference/cluster-spec/#hash-tags
+	baseName := "{" + name + "}"
+	bfName := baseName + ":cbf"
+	counterName := bfName + ":c"
+	return &countingBloomFilter{
+		client:              client,
+		name:                bfName,
+		counter:             counterName,
+		hashIterations:      hashIterations,
+		hashIterationString: strconv.FormatUint(uint64(hashIterations), 10),
+		size:                size,
+		addMultiScript:      rueidis.NewLuaScript(countingBloomFilterAddMultiScript),
+		addMultiKeys:        []string{bfName, counterName},
+		existsMultiScript:   rueidis.NewLuaScript(countingBloomFilterExistsMultiScript),
+		existsMultiKeys:     []string{bfName},
+		removeMultiScript:   rueidis.NewLuaScript(countingBloomFilterRemoveMultiScript),
+		removeMultiKeys:     []string{bfName, counterName},
+	}, nil
+}
+
+func (f *countingBloomFilter) Add(ctx context.Context, key string) error {
+	return f.AddMulti(ctx, []string{key})
+}
+
+func (f *countingBloomFilter) AddMulti(ctx context.Context, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	deduplicatedKeys := make([]string, 0, len(keys))
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if _, ok := keySet[key]; !ok {
+			keySet[key] = struct{}{}
+			deduplicatedKeys = append(deduplicatedKeys, key)
+		}
+	}
+
+	indexes := f.indexes(deduplicatedKeys)
+
+	args := make([]string, 0, len(indexes)+1)
+	args = append(args, strconv.Itoa(len(deduplicatedKeys)))
+	args = append(args, indexes...)
+
+	resp := f.addMultiScript.Exec(ctx, f.client, f.addMultiKeys, args)
+	if resp.Error() != nil {
+		return resp.Error()
+	}
+
+	return nil
+}
+
+func (f *countingBloomFilter) indexes(keys []string) []string {
+	allIndexes := make([]string, 0, len(keys)*int(f.hashIterations))
+	size := uint64(f.size)
+	for _, key := range keys {
+		h1, h2 := hash([]byte(key))
+		for i := uint(0); i < f.hashIterations; i++ {
+			allIndexes = append(allIndexes, strconv.FormatUint(index(h1, h2, i, size), 10))
+		}
+	}
+	return allIndexes
+}
+
+func (f *countingBloomFilter) Exists(ctx context.Context, key string) (bool, error) {
+	exists, err := f.ExistsMulti(ctx, []string{key})
+	if err != nil {
+		return false, err
+	}
+
+	return exists[0], nil
+}
+
+func (f *countingBloomFilter) ExistsMulti(ctx context.Context, keys []string) ([]bool, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	deduplicatedKeys := make([]string, 0, len(keys))
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if _, ok := keySet[key]; !ok {
+			keySet[key] = struct{}{}
+			deduplicatedKeys = append(deduplicatedKeys, key)
+		}
+	}
+
+	indexes := f.indexes(keys)
+
+	args := make([]string, 0, len(indexes)+1)
+	args = append(args, f.hashIterationString)
+	args = append(args, indexes...)
+
+	resp := f.existsMultiScript.Exec(ctx, f.client, f.existsMultiKeys, args)
+	if resp.Error() != nil {
+		return nil, resp.Error()
+	}
+
+	arr, err := resp.AsBoolSlice()
+	if err != nil {
+		return nil, err
+	}
+	return arr, nil
+}
+
+func (f *countingBloomFilter) Remove(ctx context.Context, key string) error {
+	return f.RemoveMulti(ctx, []string{key})
+}
+
+func (f *countingBloomFilter) RemoveMulti(ctx context.Context, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	deduplicatedKeys := make([]string, 0, len(keys))
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if _, ok := keySet[key]; !ok {
+			keySet[key] = struct{}{}
+			deduplicatedKeys = append(deduplicatedKeys, key)
+		}
+	}
+
+	indexes := f.indexes(deduplicatedKeys)
+	args := make([]string, 0, len(indexes)+1)
+	args = append(args, f.hashIterationString)
+	args = append(args, indexes...)
+
+	resp := f.removeMultiScript.Exec(ctx, f.client, f.removeMultiKeys, args)
+	if resp.Error() != nil {
+		return resp.Error()
+	}
+
+	return nil
+}
+
+func (f *countingBloomFilter) Delete(ctx context.Context) error {
+	resp := f.client.Do(
+		ctx,
+		f.client.B().
+			Eval().
+			Script(countingBloomFilterDeleteScript).
+			Numkeys(2).
+			Key(f.name, f.counter).
+			Build(),
+	)
+	if resp.Error() != nil {
+		return resp.Error()
+	}
+
+	return nil
+}
+
+func (f *countingBloomFilter) Count(ctx context.Context) (uint, error) {
+	resp := f.client.Do(
+		ctx,
+		f.client.B().
+			Get().
+			Key(f.counter).
+			Build(),
+	)
+	if resp.Error() != nil {
+		if rueidis.IsRedisNil(resp.Error()) {
+			return 0, nil
+		}
+
+		return 0, resp.Error()
+	}
+
+	count, err := resp.AsUint64()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint(count), nil
+}

--- a/rueidisprob/countingbloomfilter.go
+++ b/rueidisprob/countingbloomfilter.go
@@ -219,11 +219,7 @@ func (f *countingBloomFilter) AddMulti(ctx context.Context, keys []string) error
 	args = append(args, indexes...)
 
 	resp := f.addMultiScript.Exec(ctx, f.client, f.addMultiKeys, args)
-	if resp.Error() != nil {
-		return resp.Error()
-	}
-
-	return nil
+	return resp.Error()
 }
 
 func (f *countingBloomFilter) indexes(keys []string) []string {
@@ -320,11 +316,7 @@ func (f *countingBloomFilter) RemoveMulti(ctx context.Context, keys []string) er
 	args = append(args, indexes...)
 
 	resp := f.removeMultiScript.Exec(ctx, f.client, f.removeMultiKeys, args)
-	if resp.Error() != nil {
-		return resp.Error()
-	}
-
-	return nil
+	return resp.Error()
 }
 
 func (f *countingBloomFilter) Delete(ctx context.Context) error {
@@ -337,11 +329,7 @@ func (f *countingBloomFilter) Delete(ctx context.Context) error {
 			Key(f.name, f.counter).
 			Build(),
 	)
-	if resp.Error() != nil {
-		return resp.Error()
-	}
-
-	return nil
+	return resp.Error()
 }
 
 func (f *countingBloomFilter) ItemMinCount(ctx context.Context, key string) (uint, error) {

--- a/rueidisprob/countingbloomfilter.go
+++ b/rueidisprob/countingbloomfilter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/redis/rueidis"
+	"math"
 	"strconv"
 )
 
@@ -26,34 +27,6 @@ for i=2, numElements+1 do
 end
 
 return redis.call('INCRBY', counterKey, itemCount)
-`
-
-	countingBloomFilterExistsMultiScript = `
-local hashIterations = tonumber(ARGV[1])
-local numElements = tonumber(#ARGV) - 1
-local filterKey = KEYS[1]
-
-local hmgetArgs = {}
-for i=2, numElements+1 do
-    table.insert(hmgetArgs, ARGV[i])
-end
-
-local counts = redis.call('HMGET', filterKey, unpack(hmgetArgs))
-
-local result = {}
-local isExist = true
-for i=1, #counts do
-    if (not counts[i]) or (tonumber(counts[i]) == 0) then
-        isExist = false
-    end
-
-    if (i % hashIterations == 0) then
-		table.insert(result, isExist)
-        isExist = true
-    end
-end
-
-return result
 `
 
 	countingBloomFilterRemoveMultiScript = `
@@ -134,7 +107,6 @@ type CountingBloomFilter interface {
 	// ExistsMulti checks if one or more items are in the Counting Bloom Filter.
 	// Returns a slice of bool values where each bool indicates
 	// whether the corresponding key was found.
-	// NOTE: If keys are too many, it can block the Redis server for a long time.
 	ExistsMulti(ctx context.Context, keys []string) ([]bool, error)
 
 	// Remove removes an item from the Counting Bloom Filter.
@@ -147,6 +119,16 @@ type CountingBloomFilter interface {
 
 	// Delete deletes the Counting Bloom Filter.
 	Delete(ctx context.Context) error
+
+	// ItemMinCount returns the minimum count of item in the Counting Bloom Filter.
+	// If the item is not in the Counting Bloom Filter, it returns a zero value.
+	// Minimum count is not always accurate because of the hash collisions.
+	ItemMinCount(ctx context.Context, key string) (uint, error)
+
+	// ItemMinCountMulti returns the minimum count of items in the Counting Bloom Filter.
+	// If the item is not in the Counting Bloom Filter, it returns a zero value.
+	// Minimum count is not always accurate because of the hash collisions.
+	ItemMinCountMulti(ctx context.Context, keys []string) ([]uint, error)
 
 	// Count returns count of items in Counting Bloom Filter.
 	Count(ctx context.Context) (uint, error)
@@ -171,9 +153,6 @@ type countingBloomFilter struct {
 
 	addMultiScript *rueidis.Lua
 	addMultiKeys   []string
-
-	existsMultiScript *rueidis.Lua
-	existsMultiKeys   []string
 
 	removeMultiScript *rueidis.Lua
 	removeMultiKeys   []string
@@ -219,8 +198,6 @@ func NewCountingBloomFilter(
 		size:                size,
 		addMultiScript:      rueidis.NewLuaScript(countingBloomFilterAddMultiScript),
 		addMultiKeys:        []string{bfName, counterName},
-		existsMultiScript:   rueidis.NewLuaScript(countingBloomFilterExistsMultiScript),
-		existsMultiKeys:     []string{bfName},
 		removeMultiScript:   rueidis.NewLuaScript(countingBloomFilterRemoveMultiScript),
 		removeMultiKeys:     []string{bfName, counterName},
 	}, nil
@@ -275,29 +252,48 @@ func (f *countingBloomFilter) ExistsMulti(ctx context.Context, keys []string) ([
 		return nil, nil
 	}
 
-	deduplicatedKeys := make([]string, 0, len(keys))
-	keySet := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		if _, ok := keySet[key]; !ok {
-			keySet[key] = struct{}{}
-			deduplicatedKeys = append(deduplicatedKeys, key)
-		}
-	}
-
 	indexes := f.indexes(keys)
 
-	args := make([]string, 0, len(indexes)+1)
-	args = append(args, f.hashIterationString)
-	args = append(args, indexes...)
+	resp := f.client.Do(
+		ctx,
+		f.client.B().
+			Hmget().
+			Key(f.name).
+			Field(indexes...).
+			Build(),
+	)
+	if resp.Error() != nil {
+		return nil, resp.Error()
+	}
 
-	resp := f.existsMultiScript.Exec(ctx, f.client, f.existsMultiKeys, args)
-
-	arr, err := resp.AsBoolSlice()
+	messages, err := resp.ToArray()
 	if err != nil {
 		return nil, err
 	}
 
-	return arr, nil
+	result := make([]bool, 0, len(keys))
+	isExist := true
+	for i, message := range messages {
+		cnt, err := message.AsUint64()
+		if err != nil {
+			if !rueidis.IsRedisNil(err) {
+				return nil, err
+			}
+
+			isExist = false
+		}
+
+		if cnt == 0 {
+			isExist = false
+		}
+
+		if (i+1)%int(f.hashIterations) == 0 {
+			result = append(result, isExist)
+			isExist = true
+		}
+	}
+
+	return result, nil
 }
 
 func (f *countingBloomFilter) Remove(ctx context.Context, key string) error {
@@ -346,6 +342,64 @@ func (f *countingBloomFilter) Delete(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (f *countingBloomFilter) ItemMinCount(ctx context.Context, key string) (uint, error) {
+	counts, err := f.ItemMinCountMulti(ctx, []string{key})
+	if err != nil {
+		return 0, err
+	}
+
+	return counts[0], nil
+}
+
+func (f *countingBloomFilter) ItemMinCountMulti(ctx context.Context, keys []string) ([]uint, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	indexes := f.indexes(keys)
+
+	resp := f.client.Do(
+		ctx,
+		f.client.B().
+			Hmget().
+			Key(f.name).
+			Field(indexes...).
+			Build(),
+	)
+	if resp.Error() != nil {
+		return nil, resp.Error()
+	}
+
+	messages, err := resp.ToArray()
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make([]uint, 0, len(messages))
+	minCount := uint64(math.MaxUint64)
+	for i, message := range messages {
+		cnt, err := message.AsUint64()
+		if err != nil {
+			if !rueidis.IsRedisNil(err) {
+				return nil, err
+			}
+
+			minCount = 0
+		}
+
+		if cnt < minCount {
+			minCount = cnt
+		}
+
+		if (i+1)%int(f.hashIterations) == 0 {
+			counts = append(counts, uint(minCount))
+			minCount = uint64(math.MaxUint64)
+		}
+	}
+
+	return counts, nil
 }
 
 func (f *countingBloomFilter) Count(ctx context.Context) (uint, error) {

--- a/rueidisprob/countingbloomfilter_test.go
+++ b/rueidisprob/countingbloomfilter_test.go
@@ -1,0 +1,1621 @@
+package rueidisprob
+
+import (
+	"context"
+	"errors"
+	"github.com/redis/rueidis"
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+func TestNewCountingBloomFilter(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if bf == nil {
+		t.Error("Bloom filter is nil")
+	}
+	if bf.(*countingBloomFilter).client == nil {
+		t.Error("Client is nil")
+	}
+	if bf.(*countingBloomFilter).name != "{test}:cbf" {
+		t.Error("Name is not {test}:cbf")
+	}
+	if bf.(*countingBloomFilter).counter != "{test}:cbf:c" {
+		t.Error("Counter is not test:cbf:c")
+	}
+	if bf.(*countingBloomFilter).hashIterations != 4 {
+		t.Error("Hash iterations is not 4")
+	}
+	if bf.(*countingBloomFilter).client != client {
+		t.Error("Client is not equal")
+	}
+}
+
+func TestNewCountingBloomFilterError(t *testing.T) {
+	t.Run("EmptyName", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		_, err = NewCountingBloomFilter(client, "", 100, 0.05)
+		if !errors.Is(err, ErrEmptyCountingBloomFilterName) {
+			t.Error("Error is not ErrEmptyName")
+		}
+	})
+
+	t.Run("NegativeFalsePositiveRate", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		_, err = NewCountingBloomFilter(client, "test", 100, -0.01)
+		if !errors.Is(err, ErrCountingBloomFilterFalsePositiveRateLessThanEqualZero) {
+			t.Error("Error is not ErrFalsePositiveRateNegative")
+		}
+	})
+
+	t.Run("GreaterThanOneFalsePositiveRate", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		_, err = NewCountingBloomFilter(client, "test", 100, 1.01)
+		if !errors.Is(err, ErrCountingBloomFilterFalsePositiveRateGreaterThanOne) {
+			t.Error("Error is not ErrFalsePositiveRateGreaterThanOne")
+		}
+	})
+
+	t.Run("BitsSizeZero", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		_, err = NewCountingBloomFilter(client, "test", 0, 0.01)
+		if !errors.Is(err, ErrCountingBloomFilterBitsSizeZero) {
+			t.Error("Error is not ErrBitsSizeZero")
+		}
+	})
+}
+
+func TestCountingBloomFilterAdd(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = bf.Add(context.Background(), "1")
+	if err != nil {
+		t.Error(err)
+	}
+
+	exists, err := bf.Exists(context.Background(), "1")
+	if err != nil {
+		t.Error(err)
+	}
+	if !exists {
+		t.Error("Key test does not exist")
+	}
+
+	count, err := bf.Count(context.Background())
+	if err != nil {
+		t.Error(err)
+	}
+	if count != 1 {
+		t.Error("Count is not 1")
+	}
+}
+
+func TestCountingBloomFilterAddError(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = bf.Add(ctx, "1")
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Error is not context.Canceled")
+	}
+}
+
+func TestCountingBloomFilterAddMulti(t *testing.T) {
+	t.Run("add multiple items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		keys := []string{"1", "2", "3"}
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+
+		for _, key := range keys {
+			exists, err := bf.Exists(context.Background(), key)
+			if err != nil {
+				t.Error(err)
+			}
+			if !exists {
+				t.Errorf("Key %s does not exist", key)
+			}
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 3 {
+			t.Error("Count is not 3")
+		}
+	})
+
+	t.Run("add empty items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.AddMulti(context.Background(), []string{})
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 0 {
+			t.Error("Count is not 0")
+		}
+	})
+
+	t.Run("add already exists items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Add(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		exist, err := bf.Exists(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		if !exist {
+			t.Error("Key 1 does not exist")
+		}
+
+		err = bf.AddMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+
+		for _, key := range []string{"1", "2", "3"} {
+			exists, err := bf.Exists(context.Background(), key)
+			if err != nil {
+				t.Error(err)
+			}
+			if !exists {
+				t.Errorf("Key %s does not exist", key)
+			}
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 4 {
+			t.Error("Count is not 4")
+		}
+
+		existingIndexes := bf.(*countingBloomFilter).indexes([]string{"1"})
+		resp := client.Do(
+			context.Background(),
+			client.B().
+				Hmget().
+				Key("{test}:cbf").
+				Field(existingIndexes...).
+				Build(),
+		)
+		if resp.Error() != nil {
+			t.Error(resp.Error())
+		}
+
+		arr, err := resp.AsIntSlice()
+		if err != nil {
+			t.Error(err)
+		}
+		for _, v := range arr {
+			if v != 2 {
+				t.Error("Value is not 2")
+			}
+		}
+	})
+
+	t.Run("add duplicate items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		keys := []string{"1", "2", "3", "1", "2", "3"}
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 3 {
+			t.Error("Count is not 3")
+		}
+	})
+}
+
+func TestCountingBloomFilterAddMultiError(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = bf.AddMulti(ctx, []string{"1", "2", "3"})
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Error is not context.Canceled")
+	}
+}
+
+func TestCountingBloomFilterExists(t *testing.T) {
+	t.Run("exists", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Add(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.Exists(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		if !exists {
+			t.Error("Key test does not exist")
+		}
+	})
+
+	t.Run("does not exist", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.Exists(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		if exists {
+			t.Error("Key test exists")
+		}
+	})
+}
+
+func TestCountingBloomFilterExistsError(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = bf.Exists(ctx, "1")
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Error is not context.Canceled")
+	}
+}
+
+func TestCountingBloomFilterExistsMulti(t *testing.T) {
+	t.Run("exists", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.AddMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.ExistsMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key test does not exist")
+			}
+		}
+	})
+
+	t.Run("does not exist", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.ExistsMulti(context.Background(), []string{"4", "5", "6"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if e {
+				t.Error("Key test exists")
+			}
+		}
+	})
+
+	t.Run("duplicated saved items exist", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.AddMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		err = bf.AddMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.RemoveMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.ExistsMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key test does not exist")
+			}
+		}
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 3 {
+			t.Error("Count is not 3")
+		}
+	})
+
+	t.Run("empty keys", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.ExistsMulti(context.Background(), []string{})
+		if err != nil {
+			t.Error(err)
+		}
+		if len(exists) != 0 {
+			t.Error("Exists is not empty")
+		}
+	})
+}
+
+func TestCountingBloomFilterExistsMultiError(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = bf.ExistsMulti(ctx, []string{"1", "2", "3"})
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Error is not context.Canceled")
+	}
+}
+
+func TestCountingBloomFilterRemove(t *testing.T) {
+	t.Run("remove", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Add(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.Exists(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		if !exists {
+			t.Error("Key test does not exist")
+		}
+
+		err = bf.Remove(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err = bf.Exists(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		if exists {
+			t.Error("Key test exists")
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 0 {
+			t.Error("Count is not 0")
+		}
+	})
+
+	t.Run("does not exist", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Remove(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func TestCountingBloomFilterRemoveError(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = bf.Remove(ctx, "1")
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Error is not context.Canceled")
+	}
+}
+
+func TestCountingBloomFilterRemoveMulti(t *testing.T) {
+	t.Run("remove multiple items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		keys := []string{"1", "2", "3"}
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		exists, err := bf.ExistsMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key does not exist")
+			}
+		}
+
+		err = bf.RemoveMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		exists, err = bf.ExistsMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if e {
+				t.Error("Key exists")
+			}
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 0 {
+			t.Error("Count is not 0")
+		}
+	})
+
+	t.Run("remove empty items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.RemoveMulti(context.Background(), []string{})
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 0 {
+			t.Error("Count is not 0")
+		}
+	})
+
+	t.Run("remove not exist items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.RemoveMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.ExistsMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if e {
+				t.Error("Key exists")
+			}
+		}
+	})
+
+	t.Run("remove already deleted items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.AddMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		exists, err := bf.ExistsMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key does not exist")
+			}
+		}
+
+		err = bf.RemoveMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		exists, err = bf.ExistsMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if e {
+				t.Error("Key exists")
+			}
+		}
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 0 {
+			t.Error("Count is not 0")
+		}
+
+		err = bf.RemoveMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1", "2", "3"})
+		resp := client.Do(
+			context.Background(),
+			client.B().
+				Hmget().
+				Key("{test}:cbf").
+				Field(removedIndexes...).
+				Build(),
+		)
+		if resp.Error() != nil {
+			t.Error(resp.Error())
+		}
+
+		arr, err := resp.AsIntSlice()
+		if err != nil {
+			t.Error(err)
+		}
+		for _, v := range arr {
+			if v != 0 {
+				t.Error("Value is not 0")
+			}
+		}
+	})
+
+	t.Run("remove duplicate items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		keys := []string{"1", "2", "3"}
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		exists, err := bf.ExistsMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key does not exist")
+			}
+		}
+
+		err = bf.RemoveMulti(context.Background(), []string{"1", "2", "3", "1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		exists, err = bf.ExistsMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key does not exist")
+			}
+		}
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 3 {
+			t.Error("Count is not 3")
+		}
+
+		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1", "2", "3"})
+		resp := client.Do(
+			context.Background(),
+			client.B().
+				Hmget().
+				Key("{test}:cbf").
+				Field(removedIndexes...).
+				Build(),
+		)
+		if resp.Error() != nil {
+			t.Error(resp.Error())
+		}
+
+		arr, err := resp.AsIntSlice()
+		if err != nil {
+			t.Error(err)
+		}
+		for _, v := range arr {
+			if v != 1 {
+				t.Error("Value is not 1")
+			}
+		}
+	})
+}
+
+func TestCountingBloomFilterDelete(t *testing.T) {
+	t.Run("delete exists", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Add(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.Exists(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+		if !exists {
+			t.Error("Key test does not exist")
+		}
+
+		err = bf.Delete(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+
+		resp := client.Do(
+			context.Background(),
+			client.B().
+				Get().
+				Key("{test}:cbf").
+				Build(),
+		)
+		if !rueidis.IsRedisNil(resp.Error()) {
+			t.Error("Error is not rueidis.ErrNil")
+		}
+
+		resp = client.Do(
+			context.Background(),
+			client.B().
+				Get().
+				Key("{test}:cbf:c").
+				Build(),
+		)
+		if !rueidis.IsRedisNil(resp.Error()) {
+			t.Error("Error is not rueidis.ErrNil")
+		}
+	})
+
+	t.Run("delete does not exist", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Delete(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func TestCountingBloomFilterDeleteError(t *testing.T) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = bf.Delete(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Error("Error is not context.Canceled")
+	}
+}
+
+func TestCountingBloomFilterCount(t *testing.T) {
+	t.Run("count exists", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = bf.Add(context.Background(), "1")
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 1 {
+			t.Error("Count is not 1")
+		}
+	})
+
+	t.Run("count does not exist", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 0 {
+			t.Error("Count is not 0")
+		}
+	})
+
+	t.Run("add multiple items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		keys := []string{"1", "2", "3"}
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 3 {
+			t.Error("Count is not 3")
+		}
+	})
+}
+
+func TestCountingBloomFilterCountError(t *testing.T) {
+	t.Run("count error", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = bf.Count(ctx)
+		if !errors.Is(err, context.Canceled) {
+			t.Error("Error is not context.Canceled")
+		}
+	})
+
+	t.Run("counter key is corrupted", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewCountingBloomFilter(client, "test", 100, 0.05)
+		if err != nil {
+			t.Error(err)
+		}
+
+		resp := client.Do(
+			context.Background(),
+			client.B().
+				Set().
+				Key("{test}:cbf:c").
+				Value("not a number").
+				Build(),
+		)
+		if resp.Error() != nil {
+			t.Error(resp.Error())
+		}
+
+		_, err = bf.Count(context.Background())
+		if !errors.Is(err, strconv.ErrSyntax) {
+			t.Error("Error is not strconv.ErrSyntax")
+		}
+	})
+}
+
+func BenchmarkCountingBloomFilterAddMultiBigSize(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100000000, 0.01)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterAddMultiLowRate(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 1000000, 0.0000000001)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterAddMultiManyKeys(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 1000000, 0.01)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 200)
+	for i := 0; i < 200; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterExistsMultiBigSize(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100000000, 0.01)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+	err = bf.AddMulti(context.Background(), keys)
+	if err != nil {
+		b.Error(err)
+	}
+
+	var benchKeys []string
+	for i := 0; i < 10; i++ {
+		key := strconv.Itoa(rand.Intn(b.N))
+		benchKeys = append(benchKeys, key)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := bf.ExistsMulti(context.Background(), benchKeys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterExistsMultiLowRate(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 1000000, 0.0000000001)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+	err = bf.AddMulti(context.Background(), keys)
+	if err != nil {
+		b.Error(err)
+	}
+
+	var benchKeys []string
+	for i := 0; i < 10; i++ {
+		key := strconv.Itoa(rand.Intn(b.N))
+		benchKeys = append(benchKeys, key)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := bf.ExistsMulti(context.Background(), benchKeys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterExistsMultiManyKeys(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 1000000, 0.01)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 200)
+	for i := 0; i < 200; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+	err = bf.AddMulti(context.Background(), keys)
+	if err != nil {
+		b.Error(err)
+	}
+
+	var benchKeys []string
+	for i := 0; i < 200; i++ {
+		key := strconv.Itoa(rand.Intn(b.N))
+		benchKeys = append(benchKeys, key)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := bf.ExistsMulti(context.Background(), benchKeys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterRemoveMultiBigSize(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 100000000, 0.01)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+	for i := 0; i < b.N; i++ {
+		err := bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := bf.RemoveMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterRemoveMultiLowRate(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 1000000, 0.0000000001)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+	for i := 0; i < b.N; i++ {
+		err := bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := bf.RemoveMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCountingBloomFilterRemoveMultiManyKeys(b *testing.B) {
+	client, flushAllAndClose, err := setup()
+	if err != nil {
+		b.Error(err)
+	}
+	defer func() {
+		err := flushAllAndClose()
+		if err != nil {
+			b.Error(err)
+		}
+	}()
+
+	bf, err := NewCountingBloomFilter(client, "test", 1000000, 0.01)
+	if err != nil {
+		b.Error(err)
+	}
+
+	keys := make([]string, 200)
+	for i := 0; i < 200; i++ {
+		keys[i] = strconv.Itoa(i)
+	}
+	for i := 0; i < b.N; i++ {
+		err := bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := bf.RemoveMulti(context.Background(), keys)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}

--- a/rueidisprob/countingbloomfilter_test.go
+++ b/rueidisprob/countingbloomfilter_test.go
@@ -356,13 +356,22 @@ func TestCountingBloomFilterAddMulti(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+		exists, err := bf.ExistsMulti(context.Background(), []string{"1", "2", "3"})
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key does not exist")
+			}
+		}
 
 		count, err := bf.Count(context.Background())
 		if err != nil {
 			t.Error(err)
 		}
-		if count != 3 {
-			t.Error("Count is not 3")
+		if count != 6 {
+			t.Error("Count is not 6")
 		}
 	})
 }


### PR DESCRIPTION
Previous Discussion: https://github.com/redis/rueidis/discussions/510

There are 2 different points from origin design.

1. `Count` returns all inserted items. not distinct items.
2. `RemoveMulti` deduplicate keys. count in Counting Bloom Filter can't be negative. because of these nature, `RemoveMulti` operation can be complicated and performance can be bad. so add constraints to avoid difficulties.