### PR TITLE
Add WithDBStatement to add db.statement attribute to rueidisotel

### DIFF
--- a/rueidisotel/trace_test.go
+++ b/rueidisotel/trace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -296,14 +297,19 @@ func TestWithMeterProvider(t *testing.T) {
 }
 
 func TestWithDBStatement(t *testing.T) {
-	dbStmtEnabled := true
+	dbStmtFunc := func(cmdTokens []string) string { return strings.Join(cmdTokens, " ") }
 
+	cmd := []string{"SET", "key", "val"}
 	client := &otelclient{}
-	option := WithDBStatement(dbStmtEnabled)
+	option := WithDBStatement(dbStmtFunc)
 	option(client)
 
-	if client.dbStmtEnabled != dbStmtEnabled {
-		t.Fatalf("unexpected dbStmtEnabled: got %t, expected %t", client.dbStmtEnabled, dbStmtEnabled)
+	if client.dbStmtFunc == nil {
+		t.Fatalf("unexpected dbStmtFunc: got nil")
+	}
+
+	if client.dbStmtFunc(cmd) != dbStmtFunc(cmd) {
+		t.Fatalf("unexpected dbStmtFunc result: got %v, expected %v", client.dbStmtFunc(cmd), dbStmtFunc(cmd))
 	}
 }
 

--- a/rueidisotel/trace_test.go
+++ b/rueidisotel/trace_test.go
@@ -295,6 +295,18 @@ func TestWithMeterProvider(t *testing.T) {
 	}
 }
 
+func TestWithDBStatement(t *testing.T) {
+	dbStmtEnabled := true
+
+	client := &otelclient{}
+	option := WithDBStatement(dbStmtEnabled)
+	option(client)
+
+	if client.dbStmtEnabled != dbStmtEnabled {
+		t.Fatalf("unexpected dbStmtEnabled: got %t, expected %t", client.dbStmtEnabled, dbStmtEnabled)
+	}
+}
+
 func TestWithClientSimple(t *testing.T) {
 	client, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6379"}})
 	if err != nil {

--- a/rueidisotel/trace_test.go
+++ b/rueidisotel/trace_test.go
@@ -97,12 +97,15 @@ func TestWithClient(t *testing.T) {
 	mxp := metric.NewManualReader()
 	meterProvider := metric.NewMeterProvider(metric.WithReader(mxp))
 
+	dbStmtFunc := func(cmdTokens []string) string { return strings.Join(cmdTokens, " ") }
+
 	client = WithClient(
 		client,
 		TraceAttrs(attribute.String("any", "label")),
 		MetricAttrs(attribute.String("any", "label")),
 		WithTracerProvider(tracerProvider),
 		WithMeterProvider(meterProvider),
+		WithDBStatement(dbStmtFunc),
 	)
 	defer client.Close()
 	testWithClient(t, client, exp, mxp)
@@ -325,12 +328,15 @@ func TestWithClientSimple(t *testing.T) {
 	mxp := metric.NewManualReader()
 	meterProvider := metric.NewMeterProvider(metric.WithReader(mxp))
 
+	dbStmtFunc := func(cmdTokens []string) string { return strings.Join(cmdTokens, " ") }
+
 	client = WithClient(
 		client,
 		TraceAttrs(attribute.String("any", "label")),
 		MetricAttrs(attribute.String("any", "label")),
 		WithTracerProvider(tracerProvider),
 		WithMeterProvider(meterProvider),
+		WithDBStatement(dbStmtFunc),
 	)
 	defer client.Close()
 


### PR DESCRIPTION
Add tracer option to add the whole command's statement to db.statement attribute.

Need this for integration with APM and couldn't find another way that doesn't involve copying a lot of code from `otelClient`'s implementation.

I mostly use non-multi operations and they seem a bit more complex and opinionated so I didn't implement it on my own.