### PR TITLE
Update build.yml and aside.go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         module: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
+        go-version: ['1.21.0', '1.22.0']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.0'
+          go-version: ${{ matrix.go-version }}
 
       - name: Test Module
         run: |


### PR DESCRIPTION
Updated build.yml with new go-version variable with values including 1.21 and 1.22 to the matrix
and
Added an option to ClientOption to use Lua scripts for acquiring locks, enhancing compatibility with older Redis versions that do not support the SET NX GET command.