### PR TITLE
fix: too large arguments

### DIFF
--- a/rueidisprob/bloomfilter_test.go
+++ b/rueidisprob/bloomfilter_test.go
@@ -390,6 +390,43 @@ func TestBloomFilterAddMulti(t *testing.T) {
 			t.Error("Count is not 3")
 		}
 	})
+
+	t.Run("add very large number of items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewBloomFilter(client, "test", 10000000, 0.1)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Above `LUAI_MAXCSTACK`(8000) limit
+		keys := make([]string, 8001)
+		for i := 0; i < 8001; i++ {
+			keys[i] = strconv.Itoa(i)
+		}
+
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+
+		count, err := bf.Count(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+		if count != 8001 {
+			t.Error("Count is not 1000")
+		}
+	})
 }
 
 func TestBloomFilterAddMultiError(t *testing.T) {
@@ -586,6 +623,45 @@ func TestBloomFilterExistsMulti(t *testing.T) {
 		}
 		if len(exists) != 0 {
 			t.Error("Exists is not empty")
+		}
+	})
+
+	t.Run("exists very large number of items", func(t *testing.T) {
+		client, flushAllAndClose, err := setup()
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := flushAllAndClose()
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		bf, err := NewBloomFilter(client, "test", 10000000, 0.1)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Above `LUAI_MAXCSTACK`(8000) limit
+		keys := make([]string, 8001)
+		for i := 0; i < 8001; i++ {
+			keys[i] = strconv.Itoa(i)
+		}
+
+		err = bf.AddMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+
+		exists, err := bf.ExistsMulti(context.Background(), keys)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, e := range exists {
+			if !e {
+				t.Error("Key test does not exist")
+			}
 		}
 	})
 }

--- a/rueidisprob/countingbloomfilter.go
+++ b/rueidisprob/countingbloomfilter.go
@@ -3,9 +3,10 @@ package rueidisprob
 import (
 	"context"
 	"errors"
-	"github.com/redis/rueidis"
 	"math"
 	"strconv"
+
+	"github.com/redis/rueidis"
 )
 
 var (
@@ -43,21 +44,16 @@ local hashIterations = tonumber(ARGV[#ARGV])
 local filterKey = KEYS[1]
 local counterKey = KEYS[2]
 
-local hmgetArgs = {}
-for i=1, numElements do
-    table.insert(hmgetArgs, ARGV[i])
-end
-
-local counts = redis.call('HMGET', filterKey, unpack(hmgetArgs))
 local indexCounter = {}
-for i=1, #counts do
+for i=1, numElements do
 	local index = ARGV[i]
+	local count = redis.call('HGET', filterKey, index)
 
 	if (not indexCounter[index]) then
-		if (not counts[i]) then
+		if (not count) then
 			indexCounter[index] = 0
 		else
-			indexCounter[index] = tonumber(counts[i])
+			indexCounter[index] = tonumber(count)
 		end
 	end
 end


### PR DESCRIPTION
I got error, when `redis.call` parameters are too large.
```
user_script:15: too many results to unpack script: 73a336266d816e4bcf60d6cf47daafcad23ad693, on @user_script:15
```

`LUAI_MAXCSTACK` in luaconf.h limits stack slots. script can run very long, but it should be avoided by user not rueidisprob.