### PR TITLE
Fix rueidislock highload

### DIFF
--- a/rueidislock/lock_test.go
+++ b/rueidislock/lock_test.go
@@ -677,7 +677,7 @@ func TestLocker_Close(t *testing.T) {
 			t.Fatal(err)
 		}
 		if _, _, err := locker.WithContext(context.Background(), lck); err != ErrLockerClosed {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	}
 	for _, nocsc := range []bool{false, true} {


### PR DESCRIPTION
Closes #602 

This PR keeps using the same event watcher of client-side caching during the retries of `rueidislock.WithContext` and watches the event for retrying.

Previously, there was a race that could lead to the removal of the watcher thus causing busy retries and missing events.