### PR TITLE
OpenTelemetry client optimizations

### DIFF
--- a/rueidisotel/metrics.go
+++ b/rueidisotel/metrics.go
@@ -23,7 +23,7 @@ var (
 // MetricAttrs set additional attributes to append to each metric.
 func MetricAttrs(attrs ...attribute.KeyValue) Option {
 	return func(o *otelclient) {
-		o.mAttrs = metric.WithAttributes(attrs...)
+		o.mAttrs = metric.WithAttributeSet(attribute.NewSet(attrs...))
 	}
 }
 
@@ -108,7 +108,7 @@ func NewClient(clientOption rueidis.ClientOption, opts ...Option) (rueidis.Clien
 
 func newClient(opts ...Option) (*otelclient, error) {
 	cli := &otelclient{
-		mAttrs: metric.WithAttributes(),
+		mAttrs: metric.WithAttributeSet(attribute.NewSet()),
 		tAttrs: trace.WithAttributes(),
 	}
 	for _, opt := range opts {

--- a/rueidisotel/metrics.go
+++ b/rueidisotel/metrics.go
@@ -23,7 +23,10 @@ var (
 // MetricAttrs set additional attributes to append to each metric.
 func MetricAttrs(attrs ...attribute.KeyValue) Option {
 	return func(o *otelclient) {
-		o.mAttrs = metric.WithAttributeSet(attribute.NewSet(attrs...))
+		mAttrs := metric.WithAttributeSet(attribute.NewSet(attrs...))
+		// Allocate slices once and use many times
+		o.addOpts = []metric.AddOption{mAttrs}
+		o.recordOpts = []metric.RecordOption{mAttrs}
 	}
 }
 
@@ -39,11 +42,12 @@ type HistogramOption struct {
 }
 
 type dialMetrics struct {
-	mAttrs  metric.MeasurementOption
-	attempt metric.Int64Counter
-	success metric.Int64Counter
-	counts  metric.Int64UpDownCounter
-	latency metric.Float64Histogram
+	addOpts    []metric.AddOption
+	recordOpts []metric.RecordOption
+	attempt    metric.Int64Counter
+	success    metric.Int64Counter
+	counts     metric.Int64UpDownCounter
+	latency    metric.Float64Histogram
 }
 
 // WithHistogramOption sets the HistogramOption.
@@ -70,7 +74,10 @@ func NewClient(clientOption rueidis.ClientOption, opts ...Option) (rueidis.Clien
 		clientOption.DialFn = defaultDialFn
 	}
 
-	metrics := dialMetrics{mAttrs: oclient.mAttrs}
+	metrics := dialMetrics{
+		addOpts:    oclient.addOpts,
+		recordOpts: oclient.recordOpts,
+	}
 
 	metrics.attempt, err = oclient.meter.Int64Counter("rueidis_dial_attempt")
 	if err != nil {
@@ -108,7 +115,6 @@ func NewClient(clientOption rueidis.ClientOption, opts ...Option) (rueidis.Clien
 
 func newClient(opts ...Option) (*otelclient, error) {
 	cli := &otelclient{
-		mAttrs: metric.WithAttributeSet(attribute.NewSet()),
 		tAttrs: trace.WithAttributes(),
 	}
 	for _, opt := range opts {
@@ -143,7 +149,7 @@ func newClient(opts ...Option) (*otelclient, error) {
 func trackDialing(m dialMetrics, dialFn func(string, *net.Dialer, *tls.Config) (conn net.Conn, err error)) func(string, *net.Dialer, *tls.Config) (conn net.Conn, err error) {
 	return func(network string, dialer *net.Dialer, tlsConfig *tls.Config) (conn net.Conn, err error) {
 		ctx := context.Background()
-		m.attempt.Add(ctx, 1, m.mAttrs)
+		m.attempt.Add(ctx, 1, m.addOpts...)
 
 		start := time.Now()
 
@@ -153,29 +159,29 @@ func trackDialing(m dialMetrics, dialFn func(string, *net.Dialer, *tls.Config) (
 		}
 
 		// Use floating point division for higher precision (instead of Seconds method).
-		m.latency.Record(ctx, float64(time.Since(start))/float64(time.Second), m.mAttrs)
-		m.success.Add(ctx, 1, m.mAttrs)
-		m.counts.Add(ctx, 1, m.mAttrs)
+		m.latency.Record(ctx, float64(time.Since(start))/float64(time.Second), m.recordOpts...)
+		m.success.Add(ctx, 1, m.addOpts...)
+		m.counts.Add(ctx, 1, m.addOpts...)
 
 		return &connTracker{
-			Conn:   conn,
-			counts: m.counts,
-			mAttrs: m.mAttrs,
-			once:   0,
+			Conn:    conn,
+			counts:  m.counts,
+			addOpts: m.addOpts,
+			once:    0,
 		}, nil
 	}
 }
 
 type connTracker struct {
 	net.Conn
-	counts metric.Int64UpDownCounter
-	mAttrs metric.MeasurementOption
-	once   int32
+	counts  metric.Int64UpDownCounter
+	addOpts []metric.AddOption
+	once    int32
 }
 
 func (t *connTracker) Close() error {
 	if atomic.CompareAndSwapInt32(&t.once, 0, 1) {
-		t.counts.Add(context.Background(), -1, t.mAttrs)
+		t.counts.Add(context.Background(), -1, t.addOpts...)
 	}
 
 	return t.Conn.Close()

--- a/rueidisotel/trace.go
+++ b/rueidisotel/trace.go
@@ -221,7 +221,7 @@ func (d *dedicated) B() rueidis.Builder {
 }
 
 func (d *dedicated) Do(ctx context.Context, cmd rueidis.Completed) (resp rueidis.RedisResult) {
-	ctx, span := d.start(ctx, first(cmd.Commands()), sum(cmd.Commands()), d.tAttrs)
+	ctx, span := d.start(ctx, first(cmd.Commands()), sum(cmd.Commands()))
 	if d.dbStmtFunc != nil {
 		span.SetAttributes(dbstmt.String(d.dbStmtFunc(cmd.Commands())))
 	}
@@ -232,14 +232,14 @@ func (d *dedicated) Do(ctx context.Context, cmd rueidis.Completed) (resp rueidis
 }
 
 func (d *dedicated) DoMulti(ctx context.Context, multi ...rueidis.Completed) (resp []rueidis.RedisResult) {
-	ctx, span := d.start(ctx, multiFirst(multi), multiSum(multi), d.tAttrs)
+	ctx, span := d.start(ctx, multiFirst(multi), multiSum(multi))
 	resp = d.client.DoMulti(ctx, multi...)
 	d.end(span, firstError(resp))
 	return
 }
 
 func (d *dedicated) Receive(ctx context.Context, subscribe rueidis.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
-	ctx, span := d.start(ctx, first(subscribe.Commands()), sum(subscribe.Commands()), d.tAttrs)
+	ctx, span := d.start(ctx, first(subscribe.Commands()), sum(subscribe.Commands()))
 	if d.dbStmtFunc != nil {
 		span.SetAttributes(dbstmt.String(d.dbStmtFunc(subscribe.Commands())))
 	}
@@ -350,8 +350,8 @@ func (o *otelclient) end(span trace.Span, err error) {
 	endSpan(span, err)
 }
 
-func (d *dedicated) start(ctx context.Context, op string, size int, attrs trace.SpanStartEventOption) (context.Context, trace.Span) {
-	return startSpan(d.tracer, ctx, op, size, attrs)
+func (d *dedicated) start(ctx context.Context, op string, size int) (context.Context, trace.Span) {
+	return startSpan(d.tracer, ctx, op, size, d.tAttrs)
 }
 
 func (d *dedicated) end(span trace.Span, err error) {

--- a/rueidisotel/trace.go
+++ b/rueidisotel/trace.go
@@ -81,7 +81,7 @@ func (o *otelclient) B() rueidis.Builder {
 }
 
 func (o *otelclient) Do(ctx context.Context, cmd rueidis.Completed) (resp rueidis.RedisResult) {
-	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()), o.tAttrs)
+	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()))
 	if o.dbStmtFunc != nil {
 		span.SetAttributes(dbstmt.String(o.dbStmtFunc(cmd.Commands())))
 	}
@@ -92,14 +92,14 @@ func (o *otelclient) Do(ctx context.Context, cmd rueidis.Completed) (resp rueidi
 }
 
 func (o *otelclient) DoMulti(ctx context.Context, multi ...rueidis.Completed) (resp []rueidis.RedisResult) {
-	ctx, span := o.start(ctx, multiFirst(multi), multiSum(multi), o.tAttrs)
+	ctx, span := o.start(ctx, multiFirst(multi), multiSum(multi))
 	resp = o.client.DoMulti(ctx, multi...)
 	o.end(span, firstError(resp))
 	return
 }
 
 func (o *otelclient) DoStream(ctx context.Context, cmd rueidis.Completed) (resp rueidis.RedisResultStream) {
-	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()), o.tAttrs)
+	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()))
 	if o.dbStmtFunc != nil {
 		span.SetAttributes(dbstmt.String(o.dbStmtFunc(cmd.Commands())))
 	}
@@ -110,14 +110,14 @@ func (o *otelclient) DoStream(ctx context.Context, cmd rueidis.Completed) (resp 
 }
 
 func (o *otelclient) DoMultiStream(ctx context.Context, multi ...rueidis.Completed) (resp rueidis.MultiRedisResultStream) {
-	ctx, span := o.start(ctx, multiFirst(multi), multiSum(multi), o.tAttrs)
+	ctx, span := o.start(ctx, multiFirst(multi), multiSum(multi))
 	resp = o.client.DoMultiStream(ctx, multi...)
 	o.end(span, resp.Error())
 	return
 }
 
 func (o *otelclient) DoCache(ctx context.Context, cmd rueidis.Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
-	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()), o.tAttrs)
+	ctx, span := o.start(ctx, first(cmd.Commands()), sum(cmd.Commands()))
 	if o.dbStmtFunc != nil {
 		span.SetAttributes(dbstmt.String(o.dbStmtFunc(cmd.Commands())))
 	}
@@ -135,7 +135,7 @@ func (o *otelclient) DoCache(ctx context.Context, cmd rueidis.Cacheable, ttl tim
 }
 
 func (o *otelclient) DoMultiCache(ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
-	ctx, span := o.start(ctx, multiCacheableFirst(multi), multiCacheableSum(multi), o.tAttrs)
+	ctx, span := o.start(ctx, multiCacheableFirst(multi), multiCacheableSum(multi))
 	resps = o.client.DoMultiCache(ctx, multi...)
 	for _, resp := range resps {
 		if resp.NonRedisError() == nil {
@@ -172,7 +172,7 @@ func (o *otelclient) Dedicate() (rueidis.DedicatedClient, func()) {
 }
 
 func (o *otelclient) Receive(ctx context.Context, subscribe rueidis.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
-	ctx, span := o.start(ctx, first(subscribe.Commands()), sum(subscribe.Commands()), o.tAttrs)
+	ctx, span := o.start(ctx, first(subscribe.Commands()), sum(subscribe.Commands()))
 	if o.dbStmtFunc != nil {
 		span.SetAttributes(dbstmt.String(o.dbStmtFunc(subscribe.Commands())))
 	}
@@ -342,8 +342,8 @@ func multiCacheableFirst(multi []rueidis.CacheableTTL) string {
 	return sb.String()
 }
 
-func (o *otelclient) start(ctx context.Context, op string, size int, attrs trace.SpanStartEventOption) (context.Context, trace.Span) {
-	return startSpan(o.tracer, ctx, op, size, attrs)
+func (o *otelclient) start(ctx context.Context, op string, size int) (context.Context, trace.Span) {
+	return startSpan(o.tracer, ctx, op, size, o.tAttrs)
 }
 
 func (o *otelclient) end(span trace.Span, err error) {


### PR DESCRIPTION
Please see individual commits.

See also:
- Why `metric.WithAttributeSet()`: https://github.com/open-telemetry/opentelemetry-go/blob/metric/v1.28.0/metric/instrument.go#L349-L368.
- Why reuse those slices: https://go.dev/ref/spec#Passing_arguments_to_..._parameters