### PR TITLE
Support iter.Seq2 for *FieldValue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         module: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
-        go-version: ['1.21.0', '1.22.0']
+        go-version: ['1.21.0', '1.22.0', '1.23.0']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/internal/cmds/iter.go
+++ b/internal/cmds/iter.go
@@ -4,21 +4,21 @@ package cmds
 
 import "iter"
 
-func (c HmsetFieldValue) FieldValues(seq iter.Seq2[string, string]) HmsetFieldValue {
+func (c HmsetFieldValue) FieldValueIter(seq iter.Seq2[string, string]) HmsetFieldValue {
 	for field, value := range seq {
 		c.cs.s = append(c.cs.s, field, value)
 	}
 	return c
 }
 
-func (c HsetFieldValue) FieldValues(seq iter.Seq2[string, string]) HsetFieldValue {
+func (c HsetFieldValue) FieldValueIter(seq iter.Seq2[string, string]) HsetFieldValue {
 	for field, value := range seq {
 		c.cs.s = append(c.cs.s, field, value)
 	}
 	return c
 }
 
-func (c XaddFieldValue) FieldValues(seq iter.Seq2[string, string]) XaddFieldValue {
+func (c XaddFieldValue) FieldValueIter(seq iter.Seq2[string, string]) XaddFieldValue {
 	for field, value := range seq {
 		c.cs.s = append(c.cs.s, field, value)
 	}

--- a/internal/cmds/iter.go
+++ b/internal/cmds/iter.go
@@ -1,0 +1,26 @@
+//go:build go1.23
+
+package cmds
+
+import "iter"
+
+func (c HmsetFieldValue) FieldValues(seq iter.Seq2[string, string]) HmsetFieldValue {
+	for field, value := range seq {
+		c.cs.s = append(c.cs.s, field, value)
+	}
+	return c
+}
+
+func (c HsetFieldValue) FieldValues(seq iter.Seq2[string, string]) HsetFieldValue {
+	for field, value := range seq {
+		c.cs.s = append(c.cs.s, field, value)
+	}
+	return c
+}
+
+func (c XaddFieldValue) FieldValues(seq iter.Seq2[string, string]) XaddFieldValue {
+	for field, value := range seq {
+		c.cs.s = append(c.cs.s, field, value)
+	}
+	return c
+}

--- a/internal/cmds/iter_test.go
+++ b/internal/cmds/iter_test.go
@@ -4,10 +4,16 @@ package cmds
 
 import (
 	"maps"
+	"testing"
 )
 
 func iter0(s Builder) {
-	s.Hmset().Key("1").FieldValue().FieldValues(maps.All(map[string]string{"1": "1"})).Build()
-	s.Hset().Key("1").FieldValue().FieldValues(maps.All(map[string]string{"1": "1"})).Build()
-	s.Xadd().Key("1").Id("*").FieldValue().FieldValues(maps.All(map[string]string{"1": "1"})).Build()
+	s.Hmset().Key("1").FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
+	s.Hset().Key("1").FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
+	s.Xadd().Key("1").Id("*").FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
+}
+
+func TestIter(t *testing.T) {
+	var s = NewBuilder(InitSlot)
+	t.Run("0", func(t *testing.T) { iter0(s) })
 }

--- a/internal/cmds/iter_test.go
+++ b/internal/cmds/iter_test.go
@@ -1,0 +1,13 @@
+//go:build go1.23
+
+package cmds
+
+import (
+	"maps"
+)
+
+func iter0(s Builder) {
+	s.Hmset().Key("1").FieldValue().FieldValues(maps.All(map[string]string{"1": "1"})).Build()
+	s.Hset().Key("1").FieldValue().FieldValues(maps.All(map[string]string{"1": "1"})).Build()
+	s.Xadd().Key("1").Id("*").FieldValue().FieldValues(maps.All(map[string]string{"1": "1"})).Build()
+}


### PR DESCRIPTION
closes #355

I added iter.Seq2 support for `HSET`, `HMSET`, `XADD` which have `FieldValue()` method.
We must support `< go 1.23`, so we must split file to other files.
It's hard to support auto generation because current implementation does not support code splitting.
So I hand-written the implementation.
When go version in `go.mod` is `go 1.23`, I think we can support auto generation by adding flags to `*.json` and its structs.

### Consideration

I named `FieldValues`, but this is maybe not good to support auto generation in the future because we must consider plural form correctly.
Is `FieldValueSeq` better?