### PR TITLE
feat: add DisableTCPNoDelay

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -73,6 +73,7 @@ type pipe struct {
 	waits           int32
 	recvs           int32
 	r2ps            bool // identify this pipe is used for resp2 pubsub or not
+	noNoDelay       bool
 }
 
 type pipeFn func(connFn func() (net.Conn, error), option *ClientOption) (p *pipe, err error)
@@ -98,6 +99,7 @@ func _newPipe(connFn func() (net.Conn, error), option *ClientOption, r2ps, nobg 
 		timeout:       option.ConnWriteTimeout,
 		pinggap:       option.Dialer.KeepAlive,
 		maxFlushDelay: option.MaxFlushDelay,
+		noNoDelay:     option.DisableTCPNoDelay,
 
 		r2ps: r2ps,
 	}
@@ -321,7 +323,7 @@ func (p *pipe) _exit(err error) {
 
 func (p *pipe) _background() {
 	p.conn.SetDeadline(time.Time{})
-	if conn, ok := p.conn.(*net.TCPConn); ok {
+	if conn, ok := p.conn.(*net.TCPConn); ok && p.noNoDelay {
 		conn.SetNoDelay(false)
 	}
 	go func() {

--- a/pipe.go
+++ b/pipe.go
@@ -321,6 +321,9 @@ func (p *pipe) _exit(err error) {
 
 func (p *pipe) _background() {
 	p.conn.SetDeadline(time.Time{})
+	if conn, ok := p.conn.(*net.TCPConn); ok {
+		conn.SetNoDelay(false)
+	}
 	go func() {
 		p._exit(p._backgroundWrite())
 		close(p.close)

--- a/rueidis.go
+++ b/rueidis.go
@@ -161,6 +161,11 @@ type ClientOption struct {
 	// produce notable CPU usage reduction under load. Ref: https://github.com/redis/rueidis/issues/156
 	MaxFlushDelay time.Duration
 
+	// DisableTCPNoDelay turns on Nagle's algorithm in pipelining mode by using conn.SetNoDelay(false).
+	// Turning this on can result in lower p99 latencies and lower CPU usages if all your requests are small.
+	// But if you have large requests or fast network, this might degrade the performance. Ref: https://github.com/redis/rueidis/pull/650
+	DisableTCPNoDelay bool
+
 	// ShuffleInit is a handy flag that shuffles the InitAddress after passing to the NewClient() if it is true
 	ShuffleInit bool
 	// ClientNoTouch controls whether commands alter LRU/LFU stats


### PR DESCRIPTION
We found that turning on Nagle's algorithm (`DisableTCPNoDelay=true`) may improve performance depending on the network condition and workloads, especially when all your requests are small and your network interfaces are relatively slow.

Benchmark results on 2 GCP n2-highcpu-2 machines (client and redis server):

PipelineMultiplex=-1 (1 connection):
<img width="980" alt="image" src="https://github.com/user-attachments/assets/a8438deb-16c4-4e0e-9e0f-a71d37e85421">

PipelineMultiplex=1 (2 connections):
<img width="982" alt="image" src="https://github.com/user-attachments/assets/c631d474-723b-4e15-a1e5-e20b57cd5ecd">

PipelineMultiplex=2 (4 connections):
<img width="977" alt="image" src="https://github.com/user-attachments/assets/e9e3b032-3cef-46f3-bf7b-3a5473576b3b">

