### PR TITLE
feat: improve handling of LOADING response

### DIFF
--- a/client.go
+++ b/client.go
@@ -312,21 +312,21 @@ func (c *dedicatedSingleClient) release() {
 }
 
 func (c *singleClient) isRetryable(err error, ctx context.Context) bool {
-	if err == nil || err == ErrDoCacheAborted || atomic.LoadUint32(&c.stop) != 0 || ctx.Err() != nil {
+	if err == nil || err == Nil || err == ErrDoCacheAborted || atomic.LoadUint32(&c.stop) != 0 || ctx.Err() != nil {
 		return false
 	}
-	if redisErr, ok := err.(*RedisError); ok {
-		return redisErr.IsLoading()
+	if err, ok := err.(*RedisError); ok {
+		return err.IsLoading()
 	}
 	return true
 }
 
 func isRetryable(err error, w wire, ctx context.Context) bool {
-	if err == nil || w.Error() != nil || ctx.Err() != nil {
+	if err == nil || err == Nil || w.Error() != nil || ctx.Err() != nil {
 		return false
 	}
-	if redisErr, ok := err.(*RedisError); ok {
-		return redisErr.IsLoading()
+	if err, ok := err.(*RedisError); ok {
+		return err.IsLoading()
 	}
 	return true
 }

--- a/cluster.go
+++ b/cluster.go
@@ -1129,7 +1129,7 @@ func (c *clusterClient) shouldRefreshRetry(err error, ctx context.Context) (addr
 				mode = RedirectMove
 			} else if addr, ok = err.IsAsk(); ok {
 				mode = RedirectAsk
-			} else if err.IsClusterDown() || err.IsTryAgain() {
+			} else if err.IsClusterDown() || err.IsTryAgain() || err.IsLoading() {
 				mode = RedirectRetry
 			}
 		} else if ctx.Err() == nil {

--- a/cluster.go
+++ b/cluster.go
@@ -1123,7 +1123,7 @@ func (c *clusterClient) Close() {
 }
 
 func (c *clusterClient) shouldRefreshRetry(err error, ctx context.Context) (addr string, mode RedirectMode) {
-	if err != nil && atomic.LoadUint32(&c.stop) == 0 {
+	if err != nil && err != Nil && err != ErrDoCacheAborted && atomic.LoadUint32(&c.stop) == 0 {
 		if err, ok := err.(*RedisError); ok {
 			if addr, ok = err.IsMoved(); ok {
 				mode = RedirectMove

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4917,3 +4917,183 @@ func TestClusterTopologyRefreshment(t *testing.T) {
 		}
 	})
 }
+
+func TestClusterClientLoadingRetry(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+
+	setup := func() (*clusterClient, *mockConn) {
+		m := &mockConn{
+			DoFn: func(cmd Completed) RedisResult {
+				if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
+					return slotsMultiResp
+				}
+				return RedisResult{}
+			},
+		}
+		client, err := newClusterClient(
+			&ClientOption{InitAddress: []string{":0"}},
+			func(dst string, opt *ClientOption) conn { return m },
+			newRetryer(defaultRetryDelayFn),
+		)
+		if err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+		return client, m
+	}
+
+	t.Run("Do Retry on Loading", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoFn = func(cmd Completed) RedisResult {
+			if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
+				return slotsMultiResp
+			}
+			attempts++
+			if attempts == 1 {
+				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+			}
+			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+		}
+
+		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+		if attempts != 2 {
+			t.Fatalf("expected 2 attempts, got %v", attempts)
+		}
+	})
+
+	t.Run("Do not retry on non-loading errors", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoFn = func(cmd Completed) RedisResult {
+			if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
+				return slotsMultiResp
+			}
+			attempts++
+			if attempts == 1 {
+				return newResult(RedisMessage{typ: '-', string: "ERR some other error"}, nil)
+			}
+			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+		}
+
+		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
+			t.Fatal("expected error but got nil")
+		}
+		if attempts != 1 {
+			t.Fatalf("unexpected attempts %v, expected no retry", attempts)
+		}
+	})
+
+	t.Run("DoMulti Retry on Loading", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoMultiFn = func(multi ...Completed) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+			}
+			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+		}
+
+		cmd := client.B().Get().Key("test").Build()
+		resps := client.DoMulti(context.Background(), cmd)
+		if len(resps) != 1 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		if v, err := resps[0].ToString(); err != nil || v != "OK" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+
+	t.Run("DoCache Retry on Loading", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
+			attempts++
+			if attempts == 1 {
+				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+			}
+			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+		}
+
+		cmd := client.B().Get().Key("test").Cache()
+		if v, err := client.DoCache(context.Background(), cmd, time.Minute).ToString(); err != nil || v != "OK" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+
+	t.Run("DoMultiCache Retry on Loading", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+			}
+			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+		}
+
+		cmd := client.B().Get().Key("test").Cache()
+		resps := client.DoMultiCache(context.Background(), CT(cmd, time.Minute))
+		if len(resps) != 1 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		if v, err := resps[0].ToString(); err != nil || v != "OK" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+
+	t.Run("Dedicated Do Retry on Loading", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoFn = func(cmd Completed) RedisResult {
+			if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
+				return slotsMultiResp
+			}
+			attempts++
+			if attempts == 1 {
+				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+			}
+			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+		}
+		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
+
+		err := client.Dedicated(func(c DedicatedClient) error {
+			if v, err := c.Do(context.Background(), c.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
+				t.Fatalf("unexpected response %v %v", v, err)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+	})
+
+	t.Run("Dedicated DoMulti Retry on Loading", func(t *testing.T) {
+		client, m := setup()
+		attempts := 0
+		m.DoMultiFn = func(multi ...Completed) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+			}
+			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+		}
+		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
+
+		err := client.Dedicated(func(c DedicatedClient) error {
+			resps := c.DoMulti(context.Background(), c.B().Get().Key("test").Build())
+			if len(resps) != 1 {
+				t.Fatalf("unexpected response length %v", len(resps))
+			}
+			if v, err := resps[0].ToString(); err != nil || v != "OK" {
+				t.Fatalf("unexpected response %v %v", v, err)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+	})
+}

--- a/message.go
+++ b/message.go
@@ -92,6 +92,11 @@ func (r *RedisError) IsTryAgain() bool {
 	return strings.HasPrefix(r.string, "TRYAGAIN")
 }
 
+// IsLoading checks if it is a redis LOADING message
+func (r *RedisError) IsLoading() bool {
+	return strings.HasPrefix(r.string, "LOADING")
+}
+
 // IsClusterDown checks if it is a redis CLUSTERDOWN message and returns ask address.
 func (r *RedisError) IsClusterDown() bool {
 	return strings.HasPrefix(r.string, "CLUSTERDOWN")

--- a/sentinel.go
+++ b/sentinel.go
@@ -231,11 +231,11 @@ func (c *sentinelClient) Close() {
 }
 
 func (c *sentinelClient) isRetryable(err error, ctx context.Context) (should bool) {
-	if err == nil || atomic.LoadUint32(&c.stop) != 0 || ctx.Err() != nil {
+	if err == nil || err == Nil || err == ErrDoCacheAborted || atomic.LoadUint32(&c.stop) != 0 || ctx.Err() != nil {
 		return false
 	}
-	if redisErr, ok := err.(*RedisError); ok {
-		return redisErr.IsLoading()
+	if err, ok := err.(*RedisError); ok {
+		return err.IsLoading()
 	}
 	return true
 }

--- a/sentinel.go
+++ b/sentinel.go
@@ -66,7 +66,7 @@ func (c *sentinelClient) Do(ctx context.Context, cmd Completed) (resp RedisResul
 	attempts := 1
 retry:
 	resp = c.mConn.Load().(conn).Do(ctx, cmd)
-	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.NonRedisError(), ctx) {
+	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.Error(), ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(
 			ctx, attempts, cmd, resp.Error(),
 		)
@@ -91,7 +91,7 @@ retry:
 	resps := c.mConn.Load().(conn).DoMulti(ctx, multi...)
 	if c.retry && allReadOnly(multi) {
 		for i, resp := range resps.s {
-			if c.isRetryable(resp.NonRedisError(), ctx) {
+			if c.isRetryable(resp.Error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(
 					ctx, attempts, multi[i], resp.Error(),
 				)
@@ -115,7 +115,7 @@ func (c *sentinelClient) DoCache(ctx context.Context, cmd Cacheable, ttl time.Du
 	attempts := 1
 retry:
 	resp = c.mConn.Load().(conn).DoCache(ctx, cmd, ttl)
-	if c.retry && c.isRetryable(resp.NonRedisError(), ctx) {
+	if c.retry && c.isRetryable(resp.Error(), ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(ctx, attempts, Completed(cmd), resp.Error())
 		if shouldRetry {
 			attempts++
@@ -138,7 +138,7 @@ retry:
 	resps := c.mConn.Load().(conn).DoMultiCache(ctx, multi...)
 	if c.retry {
 		for i, resp := range resps.s {
-			if c.isRetryable(resp.NonRedisError(), ctx) {
+			if c.isRetryable(resp.Error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(
 					ctx, attempts, Completed(multi[i].Cmd), resp.Error(),
 				)
@@ -231,7 +231,13 @@ func (c *sentinelClient) Close() {
 }
 
 func (c *sentinelClient) isRetryable(err error, ctx context.Context) (should bool) {
-	return err != nil && atomic.LoadUint32(&c.stop) == 0 && ctx.Err() == nil
+	if err == nil || atomic.LoadUint32(&c.stop) != 0 || ctx.Err() != nil {
+		return false
+	}
+	if redisErr, ok := err.(*RedisError); ok {
+		return redisErr.IsLoading()
+	}
+	return true
 }
 
 func (c *sentinelClient) addSentinel(addr string) {


### PR DESCRIPTION
When a Redis node is loading data (e.g. after restart), it responds with LOADING errors. This makes the client more resilient during Redis node restarts and initial data loading phases.

Close: #656 