### PR TITLE
Move sleep into goroutine in `LazyDo`

### DIFF
--- a/singleflight.go
+++ b/singleflight.go
@@ -48,8 +48,10 @@ func (c *call) LazyDo(threshold time.Duration, fn func() error) {
 	c.cn++
 	ts := c.ts
 	c.mu.Unlock()
-	time.Sleep(time.Until(ts.Add(threshold)))
-	go c.do(ch, fn)
+	go func() {
+		time.Sleep(time.Until(ts.Add(threshold)))
+		c.do(ch, fn)
+	}()
 }
 
 func (c *call) do(ch chan struct{}, fn func() error) (err error) {

--- a/singleflight.go
+++ b/singleflight.go
@@ -48,10 +48,10 @@ func (c *call) LazyDo(threshold time.Duration, fn func() error) {
 	c.cn++
 	ts := c.ts
 	c.mu.Unlock()
-	go func() {
+	go func(threshold time.Duration, ch chan struct{}, fn func() error) {
 		time.Sleep(time.Until(ts.Add(threshold)))
 		c.do(ch, fn)
-	}()
+	}(threshold, ch, fn)
 }
 
 func (c *call) do(ch chan struct{}, fn func() error) (err error) {


### PR DESCRIPTION
This moves the sleep of up to `threshold` out of the caller's request path. This allows callers to use `LazyDo` without sleeping for up to `threshold` when called in succession.

This allows requests to connections that fail to return immediately instead of waiting for a second when they are selected to lazily perform the topology refresh.

Discussed here: https://github.com/redis/rueidis/issues/658