### PR TITLE
fix: refresh cluster topology with `CLUSTER SLOTS` instead of `CLUSTER SHARDS` for clusters which version < 8 due to the server bug.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -137,7 +137,7 @@ type clusterslots struct {
 }
 
 func (s clusterslots) parse(tls bool) map[string]group {
-	if s.ver < 7 {
+	if s.ver < 8 {
 		return parseSlots(s.reply.val, s.addr)
 	}
 	return parseShards(s.reply.val, s.addr, tls)
@@ -147,7 +147,7 @@ func getClusterSlots(c conn, timeout time.Duration) clusterslots {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	v := c.Version()
-	if v < 7 {
+	if v < 8 {
 		return clusterslots{reply: c.Do(ctx, cmds.SlotCmd), addr: c.Addr(), ver: v}
 	}
 	return clusterslots{reply: c.Do(ctx, cmds.ShardsCmd), addr: c.Addr(), ver: v}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -783,7 +783,7 @@ func TestClusterClientInit(t *testing.T) {
 						}
 						return shardsResp
 					},
-					VersionFn: func() int { return 7 },
+					VersionFn: func() int { return 8 },
 				}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -816,7 +816,7 @@ func TestClusterClientInit(t *testing.T) {
 					DoFn: func(cmd Completed) RedisResult {
 						return newResult(RedisMessage{typ: '*', values: []RedisMessage{}}, nil)
 					},
-					VersionFn: func() int { return 7 },
+					VersionFn: func() int { return 8 },
 				}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -859,7 +859,7 @@ func TestClusterClientInit(t *testing.T) {
 		})
 
 		t.Run("shards", func(t *testing.T) {
-			client, err := getClient(7)
+			client, err := getClient(8)
 			if err != nil {
 				t.Fatalf("unexpected err %v", err)
 			}
@@ -933,7 +933,7 @@ func TestClusterClientInit(t *testing.T) {
 							}
 							return shardsResp
 						},
-						VersionFn: func() int { return 7 },
+						VersionFn: func() int { return 8 },
 					}
 				},
 				newRetryer(defaultRetryDelayFn),
@@ -953,7 +953,7 @@ func TestClusterClientInit(t *testing.T) {
 					DoFn: func(cmd Completed) RedisResult {
 						return shardsRespTls
 					},
-					VersionFn: func() int { return 7 },
+					VersionFn: func() int { return 8 },
 				}
 			},
 			newRetryer(defaultRetryDelayFn),


### PR DESCRIPTION
Ref:

https://github.com/redis/rueidis/issues/384#issuecomment-2463031313

https://github.com/redis/redis/pull/13422

https://github.com/valkey-io/valkey/issues/784