### PR TITLE
fix: close connections that are still blocked while recycling them to pools

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -741,7 +741,9 @@ func (p *pipe) Receive(ctx context.Context, subscribe Completed, fn func(message
 }
 
 func (p *pipe) CleanSubscriptions() {
-	if atomic.LoadInt32(&p.state) == 1 {
+	if atomic.LoadInt32(&p.blcksig) != 0 {
+		p.Close()
+	} else if atomic.LoadInt32(&p.state) == 1 {
 		if p.version >= 7 {
 			p.DoMulti(context.Background(), cmds.UnsubscribeCmd, cmds.PUnsubscribeCmd, cmds.SUnsubscribeCmd, cmds.DiscardCmd)
 		} else {


### PR DESCRIPTION
When returning a dedicated connection to the pool, we try to clear its pubsub subscriptions by sending a UNSUBSCRIBE request. But if the connection is currently in blocking, we will never get UNSUBSCRIBE response. We should just close the connection instead.