### PR TITLE
FEATURE rueidislimiter: Introduce RateLimitOption to RateLimiterClient

### DIFF
--- a/rueidislimiter/limit.go
+++ b/rueidislimiter/limit.go
@@ -1,0 +1,15 @@
+package rueidislimiter
+
+import "time"
+
+type RateLimitOption struct {
+	limit  int64
+	window time.Duration
+}
+
+func WithCustomRateLimit(limit int, window time.Duration) RateLimitOption {
+	return RateLimitOption{
+		limit:  int64(limit),
+		window: window,
+	}
+}


### PR DESCRIPTION
Currently it's not possible to use instance of RateLimiter and share it with different use cases.