### PR TITLE
fix: protocol out of sync when mixing sunsubscribe requests and slot migrations

### DIFF
--- a/hack/cmds/gen.go
+++ b/hack/cmds/gen.go
@@ -458,6 +458,7 @@ func main() {
 	}
 
 	checkAllUsed("noRetCMDs", noRetCMDs)
+	checkAllUsed("unsubCMDs", unsubCMDs)
 	checkAllUsed("blockingCMDs", blockingCMDs)
 	checkAllUsed("cacheableCMDs", cacheableCMDs)
 	checkAllUsed("readOnlyCMDs", readOnlyCMDs)
@@ -725,6 +726,13 @@ func rootCf(root goStruct) (tag string) {
 			panic("root cf collision")
 		}
 		tag = "noRetTag"
+	}
+
+	if within(root, unsubCMDs) {
+		if tag != "" {
+			panic("root cf collision")
+		}
+		tag = "unsubTag"
 	}
 
 	if within(root, mtGetCMDs) {
@@ -1022,11 +1030,14 @@ func within(cmd goStruct, cmds map[string]bool) bool {
 }
 
 var noRetCMDs = map[string]bool{
-	"subscribe":    false,
-	"psubscribe":   false,
+	"subscribe":  false,
+	"psubscribe": false,
+	"ssubscribe": false,
+}
+
+var unsubCMDs = map[string]bool{
 	"unsubscribe":  false,
 	"punsubscribe": false,
-	"ssubscribe":   false,
 	"sunsubscribe": false,
 }
 

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -9,6 +9,7 @@ const (
 	noRetTag = uint16(1<<12) | readonly // make noRetTag can also be retried
 	mtGetTag = uint16(1<<11) | readonly // make mtGetTag can also be retried
 	scrRoTag = uint16(1<<10) | readonly // make scrRoTag can also be retried
+	unsubTag = uint16(1<<9) | noRetTag
 	// InitSlot indicates that the command be sent to any redis node in cluster
 	// When SendToReplicas is set, InitSlot command will be sent to primary node
 	InitSlot = uint16(1 << 14)
@@ -38,17 +39,17 @@ var (
 	// UnsubscribeCmd is predefined UNSUBSCRIBE
 	UnsubscribeCmd = Completed{
 		cs: newCommandSlice([]string{"UNSUBSCRIBE"}),
-		cf: noRetTag,
+		cf: unsubTag,
 	}
 	// PUnsubscribeCmd is predefined PUNSUBSCRIBE
 	PUnsubscribeCmd = Completed{
 		cs: newCommandSlice([]string{"PUNSUBSCRIBE"}),
-		cf: noRetTag,
+		cf: unsubTag,
 	}
 	// SUnsubscribeCmd is predefined SUNSUBSCRIBE
 	SUnsubscribeCmd = Completed{
 		cs: newCommandSlice([]string{"SUNSUBSCRIBE"}),
-		cf: noRetTag,
+		cf: unsubTag,
 	}
 	// PingCmd is predefined PING
 	PingCmd = Completed{
@@ -74,7 +75,7 @@ var (
 	// SentinelUnSubscribe is predefined UNSUBSCRIBE ASKING
 	SentinelUnSubscribe = Completed{
 		cs: newCommandSlice([]string{"UNSUBSCRIBE", "+sentinel", "+slave", "-sdown", "+sdown", "+switch-master", "+reboot"}),
-		cf: noRetTag,
+		cf: unsubTag,
 	}
 
 	// DiscardCmd is predefined DISCARD
@@ -126,6 +127,11 @@ func (c *Completed) IsBlock() bool {
 // NoReply checks if it is one of the SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE or PUNSUBSCRIBE commands.
 func (c *Completed) NoReply() bool {
 	return c.cf&noRetTag == noRetTag
+}
+
+// IsUnsub checks if it is one of the UNSUBSCRIBE, PUNSUBSCRIBE, or SUNSUBSCRIBE commands.
+func (c *Completed) IsUnsub() bool {
+	return c.cf&unsubTag == unsubTag
 }
 
 // IsReadOnly checks if it is readonly command and can be retried when network error.

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -109,6 +109,37 @@ func TestCompleted_NoReply(t *testing.T) {
 	if cmd := builder.Punsubscribe().Pattern("").Build(); !cmd.NoReply() {
 		t.Fatalf("should be no reply command")
 	}
+	if cmd := builder.Ssubscribe().Channel("").Build(); !cmd.NoReply() {
+		t.Fatalf("should be no reply command")
+	}
+	if cmd := builder.Sunsubscribe().Channel("").Build(); !cmd.NoReply() {
+		t.Fatalf("should be no reply command")
+	}
+}
+
+func TestCompleted_IsUnsub(t *testing.T) {
+	if cmd := NewCompleted([]string{"a", "b"}); cmd.IsUnsub() {
+		t.Fatalf("should not be no reply command")
+	}
+	builder := NewBuilder(InitSlot)
+	if cmd := builder.Subscribe().Channel("").Build(); cmd.IsUnsub() {
+		t.Fatalf("should be not be unsub command")
+	}
+	if cmd := builder.Unsubscribe().Channel("").Build(); !cmd.IsUnsub() {
+		t.Fatalf("should be unsub command")
+	}
+	if cmd := builder.Psubscribe().Pattern("").Build(); cmd.IsUnsub() {
+		t.Fatalf("should be not be unsub command")
+	}
+	if cmd := builder.Punsubscribe().Pattern("").Build(); !cmd.IsUnsub() {
+		t.Fatalf("should be unsub command")
+	}
+	if cmd := builder.Ssubscribe().Channel("").Build(); cmd.IsUnsub() {
+		t.Fatalf("should be not be unsub command")
+	}
+	if cmd := builder.Sunsubscribe().Channel("").Build(); !cmd.IsUnsub() {
+		t.Fatalf("should be unsub command")
+	}
 }
 
 func TestComplete_IsReadOnly(t *testing.T) {

--- a/internal/cmds/gen_pubsub.go
+++ b/internal/cmds/gen_pubsub.go
@@ -193,7 +193,7 @@ func (c PubsubShardnumsubChannel) Build() Completed {
 type Punsubscribe Incomplete
 
 func (b Builder) Punsubscribe() (c Punsubscribe) {
-	c = Punsubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
+	c = Punsubscribe{cs: get(), ks: b.ks, cf: int16(unsubTag)}
 	c.cs.s = append(c.cs.s, "PUNSUBSCRIBE")
 	return c
 }
@@ -325,7 +325,7 @@ func (c SubscribeChannel) Build() Completed {
 type Sunsubscribe Incomplete
 
 func (b Builder) Sunsubscribe() (c Sunsubscribe) {
-	c = Sunsubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
+	c = Sunsubscribe{cs: get(), ks: b.ks, cf: int16(unsubTag)}
 	c.cs.s = append(c.cs.s, "SUNSUBSCRIBE")
 	return c
 }
@@ -375,7 +375,7 @@ func (c SunsubscribeChannel) Build() Completed {
 type Unsubscribe Incomplete
 
 func (b Builder) Unsubscribe() (c Unsubscribe) {
-	c = Unsubscribe{cs: get(), ks: b.ks, cf: int16(noRetTag)}
+	c = Unsubscribe{cs: get(), ks: b.ks, cf: int16(unsubTag)}
 	c.cs.s = append(c.cs.s, "UNSUBSCRIBE")
 	return c
 }

--- a/pipe.go
+++ b/pipe.go
@@ -25,6 +25,17 @@ const LibVer = "1.0.51"
 
 var noHello = regexp.MustCompile("unknown command .?(HELLO|hello).?")
 
+// See https://github.com/redis/rueidis/pull/691
+func isUnsubReply(msg *RedisMessage) bool {
+	// ex. NOPERM User limiteduser has no permissions to run the 'ping' command
+	if msg.typ == '-' && strings.Contains(msg.string, "'ping'") {
+		msg.typ = '+'
+		msg.string = "PONG"
+		return true
+	}
+	return msg.string == "PONG" || (len(msg.values) != 0 && msg.values[0].string == "pong")
+}
+
 type wire interface {
 	Do(ctx context.Context, cmd Completed) RedisResult
 	DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) RedisResult
@@ -438,6 +449,9 @@ func (p *pipe) _backgroundWrite() (err error) {
 		}
 		for _, cmd := range multi {
 			err = writeCmd(p.w, cmd.Commands())
+			if cmd.IsUnsub() { // See https://github.com/redis/rueidis/pull/691
+				err = writeCmd(p.w, cmds.PingCmd.Commands())
+			}
 		}
 	}
 	return
@@ -456,7 +470,10 @@ func (p *pipe) _backgroundRead() (err error) {
 		ver   = p.version
 		prply bool // push reply
 		unsub bool // unsubscribe notification
-		r2ps  = p.r2ps
+
+		skipUnsubReply bool // if unsubscribe is replied
+
+		r2ps = p.r2ps
 	)
 
 	defer func() {
@@ -516,9 +533,14 @@ func (p *pipe) _backgroundRead() (err error) {
 				// We should ignore them and go fetch next message.
 				// We also treat all the other unsubscribe notifications just like sunsubscribe,
 				// so that we don't need to track how many channels we have subscribed to deal with wildcard unsubscribe command
+				// See https://github.com/redis/rueidis/pull/691
 				if unsub {
 					prply = false
 					unsub = false
+					continue
+				}
+				if skipUnsubReply && isUnsubReply(&msg) {
+					skipUnsubReply = false
 					continue
 				}
 				panic(protocolbug)
@@ -555,7 +577,8 @@ func (p *pipe) _backgroundRead() (err error) {
 			// We should ignore them and go fetch next message.
 			// We also treat all the other unsubscribe notifications just like sunsubscribe,
 			// so that we don't need to track how many channels we have subscribed to deal with wildcard unsubscribe command
-			if unsub && (!multi[ff].NoReply() || !strings.HasSuffix(multi[ff].Commands()[0], "UNSUBSCRIBE")) {
+			// See https://github.com/redis/rueidis/pull/691
+			if unsub {
 				prply = false
 				unsub = false
 				continue
@@ -569,6 +592,16 @@ func (p *pipe) _backgroundRead() (err error) {
 			msg = RedisMessage{} // override successful subscribe/unsubscribe response to empty
 		} else if multi[ff].NoReply() && msg.string == "QUEUED" {
 			panic(multiexecsub)
+		} else if multi[ff].IsUnsub() && !isUnsubReply(&msg) {
+			// See https://github.com/redis/rueidis/pull/691
+			skipUnsubReply = true
+		} else if skipUnsubReply {
+			// See https://github.com/redis/rueidis/pull/691
+			if !isUnsubReply(&msg) {
+				panic(protocolbug)
+			}
+			skipUnsubReply = false
+			continue
 		}
 		resp := newResult(msg, err)
 		if resps != nil {


### PR DESCRIPTION
Fixes https://github.com/redis/rueidis/issues/690

In the TCP dumps provided by the issuer, we found the following traces during slot migration:

```
1. client -> [SUNSUBSCRIBE channel1] -> server
2. server -> [sunsubscribe channel1] -> client
3. client -> [HGET key field] --------> server
4. server -> [MOVED slot address] ----> client
5. server -> [True HGET response] ----> client
```

In the above sequence, (2) was the proactive `sunsubscribe` message sent by the server due to slot migration, and the message was wrongly delivered to the (1) `SUNSUBSCRIBE` request sent by the user. The true response to the (1) should be (4), the `MOVED`.

The wrong delivery of (2) caused the pipeline out-of-sync. The (4) `MOVED` was also wrongly delivered to (3), the `HGET` request. Then finally the (5), the true response of the `HGET`, couldn't be delivered anywhere, thus the pipeline panicked.

This situation is the same as https://github.com/valkey-io/valkey/issues/1066.

## Workaround

Ideally, we need to differentiate whether the server sent those `sunsubscribe` messages due to slot migration, but it is impossible. Our only choice is to ignore all `sunsubscribe` messages and make a dummy response for the `SUNSUBSCRIBE` request. Besides `SUNSUBSCRIBE`, we also apply this method to all `*UNSUBSCRIBE` so that we don't need to keep track of how many channels and patterns the client has subscribed to.

1. We ignore `*unsubscribe` messages while delivering messages to requests.
2. We make up responses for `*UNSUBSCRIBE` requests by injecting a `PING` request after each `*UNSUBSCRIBE`.
3. If a `*UNSUBSCRIBE` request succeeds, then the `PONG` response will be delivered to it.
4. if a `*UNSUBSCRIBE` request fails, such as MOVED or CLUSTERDOWN, then the error will be delivered to it, and the following `PONG` response will be discarded.

If the injected `PING` failed with a NOPERM error, we treat it as a normal PONG response.
