### PR TITLE
fix: panic on cluster redirection to a node with stale role

### DIFF
--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -11,7 +11,6 @@ const (
 	scrRoTag = uint16(1<<10) | readonly // make scrRoTag can also be retried
 	unsubTag = uint16(1<<9) | noRetTag
 	// InitSlot indicates that the command be sent to any redis node in cluster
-	// When SendToReplicas is set, InitSlot command will be sent to primary node
 	InitSlot = uint16(1 << 14)
 	// NoSlot indicates that the command has no key slot specified
 	NoSlot = uint16(1 << 15)


### PR DESCRIPTION
Fixes #694

The situation happened when a cluster node got promoted to be the primary and the client followed a `MOVED` redirection but still think the node as a replica. Then the client set the connection to the `rslots` which was not yet initialized. This PR changes two things:

1. Remove the `connrole.replica` field because, in the future, a node can have mixed roles. https://github.com/valkey-io/valkey/issues/1372
2. Trust the `MOVED` redirection. ie. It always points to the primary of the slot so the client should set the connection to `pslots` directly.

Hi @proost, could you help review this? 