### PR TITLE
refactor: clean up unused return values

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -538,8 +538,6 @@ func (c *clusterClient) _pickMulti(multi []Completed) (retries *connretry) {
 		conncountp.Put(count)
 
 		for i, cmd := range multi {
-			last = cmd.Slot()
-
 			var cc conn
 			if c.opt.SendToReplicas(cmd) {
 				cc = c.rslots[cmd.Slot()]


### PR DESCRIPTION
I found that last slot of command and toReplica are useless. So remove it.