### PR TITLE
fix: cache auto retry on MOVED / ASK / ...

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -828,20 +828,17 @@ func askingMulti(cc conn, ctx context.Context, multi []Completed) *redisresults 
 }
 
 func askingMultiCache(cc conn, ctx context.Context, multi []CacheableTTL) *redisresults {
-	commands := make([]Completed, 0, len(multi)*7)
+	commands := make([]Completed, 0, len(multi)*6)
 	for _, cmd := range multi {
 		ck, _ := cmds.CacheKey(cmd.Cmd)
-		commands = append(commands, cmds.OptInCmd, cmds.MultiCmd, cmds.AskingCmd, cmds.NewCompleted([]string{"PTTL", ck}), cmds.AskingCmd, Completed(cmd.Cmd), cmds.ExecCmd)
+		commands = append(commands, cmds.OptInCmd, cmds.MultiCmd, cmds.AskingCmd, cmds.NewCompleted([]string{"PTTL", ck}), Completed(cmd.Cmd), cmds.ExecCmd)
 	}
 	results := resultsp.Get(0, len(multi))
 	resps := cc.DoMulti(ctx, commands...)
-	for i := 6; i < len(resps.s); i += 7 {
+	for i := 5; i < len(resps.s); i += 6 {
 		if arr, err := resps.s[i].ToArray(); err != nil {
-			for _, j := range []int{i - 3, i - 1} { // check if PTTL or {Cmd} failed
-				if preErr := resps.s[j].Error(); preErr != nil {
-					err = preErr
-					break
-				}
+			if preErr := resps.s[i-1].Error(); preErr != nil { // if {Cmd} get a RedisError
+				err = preErr
 			}
 			results.s = append(results.s, newErrResult(err))
 		} else {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4628,9 +4628,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
 					},
 				}
 			},
@@ -4658,9 +4658,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
 					},
 				}
 			},
@@ -4689,13 +4689,13 @@ func TestClusterClientErr(t *testing.T) {
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &redisresults{s: []RedisResult{
-								{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-								{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
+								{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
+								{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
 							}}
 						}
 						return &redisresults{s: []RedisResult{
-							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[4].Commands()[1]}}}, nil),
-							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[10].Commands()[1]}}}, nil),
+							{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[5].Commands()[1]}}}, nil),
+							{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[12].Commands()[1]}}}, nil),
 						}}
 					},
 				}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4628,9 +4628,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
 					},
 				}
 			},
@@ -4658,9 +4658,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
 					},
 				}
 			},
@@ -4689,13 +4689,13 @@ func TestClusterClientErr(t *testing.T) {
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &redisresults{s: []RedisResult{
-								{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-								{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
+								{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
+								{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
 							}}
 						}
 						return &redisresults{s: []RedisResult{
-							{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[5].Commands()[1]}}}, nil),
-							{}, {}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[12].Commands()[1]}}}, nil),
+							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[4].Commands()[1]}}}, nil),
+							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[10].Commands()[1]}}}, nil),
 						}}
 					},
 				}

--- a/pipe.go
+++ b/pipe.go
@@ -1315,7 +1315,7 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Re
 	if err != nil {
 		if _, ok := err.(*RedisError); ok {
 			err = ErrDoCacheAborted
-			if preErr := resp.s[2].Error(); preErr != nil { // if PTTL command get a RedisError
+			if preErr := resp.s[3].Error(); preErr != nil { // if {cmd} get a RedisError
 				if _, ok := preErr.(*RedisError); ok {
 					err = preErr
 				}
@@ -1384,12 +1384,9 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 		if err != nil {
 			if _, ok := err.(*RedisError); ok {
 				err = ErrDoCacheAborted
-				for j := 0; j < keys+1; j++ {
-					if preErr := resp.s[len(multi)-2-j].Error(); preErr != nil {
-						if _, ok := preErr.(*RedisError); ok {
-							err = preErr
-							break
-						}
+				if preErr := resp.s[len(multi)-2].Error(); preErr != nil { // if {rewritten} get a RedisError
+					if _, ok := preErr.(*RedisError); ok {
+						err = preErr
 					}
 				}
 			}
@@ -1487,7 +1484,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisre
 			if err := resp.s[i].Error(); err != nil {
 				if _, ok := err.(*RedisError); ok {
 					err = ErrDoCacheAborted
-					if preErr := resp.s[i-2].Error(); preErr != nil { // if PTTL command get a RedisError
+					if preErr := resp.s[i-1].Error(); preErr != nil { // if {cmd} get a RedisError
 						if _, ok := preErr.(*RedisError); ok {
 							err = preErr
 						}
@@ -1515,7 +1512,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisre
 				if err != nil {
 					if _, ok := err.(*RedisError); ok {
 						err = ErrDoCacheAborted
-						if preErr := resp.s[i-2].Error(); preErr != nil { // if PTTL command get a RedisError
+						if preErr := resp.s[i-1].Error(); preErr != nil { // if {cmd} get a RedisError
 							if _, ok := preErr.(*RedisError); ok {
 								err = preErr
 							}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -1669,25 +1669,13 @@ func TestClientSideCachingExecAbortMGet(t *testing.T) {
 			Expect("EXEC").
 			ReplyString("OK").
 			ReplyString("OK").
-			ReplyError("MOVED 0 127.0.0.1").
-			ReplyString("OK").
-			ReplyString("OK").
-			Reply(RedisMessage{typ: '_'})
-		mock.Expect("CLIENT", "CACHING", "YES").
-			Expect("MULTI").
-			Expect("PTTL", "c1").
-			Expect("PTTL", "c2").
-			Expect("MGET", "c1", "c2").
-			Expect("EXEC").
-			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyError("MOVED 0 127.0.0.1").
-			ReplyString("OK").
 			Reply(RedisMessage{typ: '_'})
 	}()
 
-	for i, pair := range [][2]string{{"a1", "a2"}, {"b1", "b2"}, {"c1", "c2"}} {
+	for i, pair := range [][2]string{{"a1", "a2"}, {"b1", "b2"}} {
 		v, err := p.DoCache(context.Background(), Cacheable(cmds.NewMGetCompleted([]string{"MGET", pair[0], pair[1]})), 10*time.Second).ToMessage()
 		if i == 0 {
 			if err != ErrDoCacheAborted {
@@ -1999,8 +1987,8 @@ func TestClientSideCachingExecAbortDoMultiCache(t *testing.T) {
 				Reply(RedisMessage{typ: '_'}).
 				ReplyString("OK").
 				ReplyString("OK").
+				ReplyString("OK").
 				ReplyError("MOVED 0 127.0.0.1").
-				Reply(RedisMessage{typ: '_'}).
 				Reply(RedisMessage{typ: '_'})
 		}()
 


### PR DESCRIPTION
try fix #700 

`DoCache, DoMultiCache` end out with one or some redis transaction like:
`MULTI, PTTL {key}, GET {key}, EXEC`

When we scale a redis-cluster, `PTTL {key}` may return a `MOVED / ASK` error because slot have mark migrate / migrating / migrated to another node, then the transaction may fail. 

We hope driver can handle this case automaticlly by just retry the transaction on node which error said.

EDIT:
We tested in our real test environment and it works.