### PR TITLE
perf: avoid unnecessary runtime.duffcopy when the compiler fails to inline the helper function

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,7 +56,7 @@ retry:
 			goto retry
 		}
 	}
-	if resp.NonRedisError() == nil { // not recycle cmds if error, since cmds may be used later in pipe. consider recycle them by pipe
+	if resp.err == nil { // not recycle cmds if error, since cmds may be used later in pipe. consider recycle them by pipe
 		cmds.PutCompleted(cmd)
 	}
 	return resp
@@ -100,7 +100,7 @@ retry:
 		}
 	}
 	for i, cmd := range multi {
-		if resps[i].NonRedisError() == nil {
+		if resps[i].err == nil {
 			cmds.PutCompleted(cmd)
 		}
 	}
@@ -128,7 +128,7 @@ retry:
 		}
 	}
 	for i, cmd := range multi {
-		if err := resps[i].NonRedisError(); err == nil || err == ErrDoCacheAborted {
+		if err := resps[i].err; err == nil || err == ErrDoCacheAborted {
 			cmds.PutCacheable(cmd.Cmd)
 		}
 	}
@@ -146,7 +146,7 @@ retry:
 			goto retry
 		}
 	}
-	if err := resp.NonRedisError(); err == nil || err == ErrDoCacheAborted {
+	if err := resp.err; err == nil || err == ErrDoCacheAborted {
 		cmds.PutCacheable(cmd)
 	}
 	return resp
@@ -223,7 +223,7 @@ retry:
 			goto retry
 		}
 	}
-	if resp.NonRedisError() == nil {
+	if resp.err == nil {
 		cmds.PutCompleted(cmd)
 	}
 	return resp
@@ -253,7 +253,7 @@ retry:
 				goto retry
 			}
 		}
-		if resp[i].NonRedisError() == nil {
+		if resp[i].err == nil {
 			cmds.PutCompleted(cmd)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -47,9 +47,9 @@ func (c *singleClient) Do(ctx context.Context, cmd Completed) (resp RedisResult)
 	attempts := 1
 retry:
 	resp = c.conn.Do(ctx, cmd)
-	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.Error(), ctx) {
+	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.error(), ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(
-			ctx, attempts, cmd, resp.Error(),
+			ctx, attempts, cmd, resp.error(),
 		)
 		if shouldRetry {
 			attempts++
@@ -88,9 +88,9 @@ retry:
 	resps = c.conn.DoMulti(ctx, multi...).s
 	if c.retry && allReadOnly(multi) {
 		for i, resp := range resps {
-			if c.isRetryable(resp.Error(), ctx) {
+			if c.isRetryable(resp.error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(
-					ctx, attempts, multi[i], resp.Error(),
+					ctx, attempts, multi[i], resp.error(),
 				)
 				if shouldRetry {
 					attempts++
@@ -116,9 +116,9 @@ retry:
 	resps = c.conn.DoMultiCache(ctx, multi...).s
 	if c.retry {
 		for i, resp := range resps {
-			if c.isRetryable(resp.Error(), ctx) {
+			if c.isRetryable(resp.error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(
-					ctx, attempts, Completed(multi[i].Cmd), resp.Error(),
+					ctx, attempts, Completed(multi[i].Cmd), resp.error(),
 				)
 				if shouldRetry {
 					attempts++
@@ -139,8 +139,8 @@ func (c *singleClient) DoCache(ctx context.Context, cmd Cacheable, ttl time.Dura
 	attempts := 1
 retry:
 	resp = c.conn.DoCache(ctx, cmd, ttl)
-	if c.retry && c.isRetryable(resp.Error(), ctx) {
-		shouldRetry := c.retryHandler.WaitOrSkipRetry(ctx, attempts, Completed(cmd), resp.Error())
+	if c.retry && c.isRetryable(resp.error(), ctx) {
+		shouldRetry := c.retryHandler.WaitOrSkipRetry(ctx, attempts, Completed(cmd), resp.error())
 		if shouldRetry {
 			attempts++
 			goto retry
@@ -214,9 +214,9 @@ retry:
 		return newErrResult(err)
 	}
 	resp = c.wire.Do(ctx, cmd)
-	if c.retry && cmd.IsReadOnly() && isRetryable(resp.Error(), c.wire, ctx) {
+	if c.retry && cmd.IsReadOnly() && isRetryable(resp.error(), c.wire, ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(
-			ctx, attempts, cmd, resp.Error(),
+			ctx, attempts, cmd, resp.error(),
 		)
 		if shouldRetry {
 			attempts++
@@ -244,9 +244,9 @@ retry:
 	}
 	resp = c.wire.DoMulti(ctx, multi...).s
 	for i, cmd := range multi {
-		if retryable && isRetryable(resp[i].Error(), c.wire, ctx) {
+		if retryable && isRetryable(resp[i].error(), c.wire, ctx) {
 			shouldRetry := c.retryHandler.WaitOrSkipRetry(
-				ctx, attempts, multi[i], resp[i].Error(),
+				ctx, attempts, multi[i], resp[i].error(),
 			)
 			if shouldRetry {
 				attempts++

--- a/cluster.go
+++ b/cluster.go
@@ -482,7 +482,7 @@ func (c *clusterClient) B() Builder {
 }
 
 func (c *clusterClient) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
-	if resp = c.do(ctx, cmd); resp.NonRedisError() == nil { // not recycle cmds if error, since cmds may be used later in pipe. consider recycle them by pipe
+	if resp = c.do(ctx, cmd); resp.err == nil { // not recycle cmds if error, since cmds may be used later in pipe. consider recycle them by pipe
 		cmds.PutCompleted(cmd)
 	}
 	return resp
@@ -659,7 +659,7 @@ func (c *clusterClient) doresultfn(
 	ei := -1
 	clean = true
 	for i, resp := range resps {
-		clean = clean && resp.NonRedisError() == nil
+		clean = clean && resp.err == nil
 		ii := cIndexes[i]
 		cm := commands[i]
 		results.s[ii] = resp
@@ -803,7 +803,7 @@ retry:
 	}
 
 	for i, cmd := range multi {
-		if results.s[i].NonRedisError() == nil {
+		if results.s[i].err == nil {
 			cmds.PutCompleted(cmd)
 		}
 	}
@@ -851,7 +851,7 @@ process:
 
 func (c *clusterClient) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) (resp RedisResult) {
 	resp = c.doCache(ctx, cmd, ttl)
-	if err := resp.NonRedisError(); err == nil || err == ErrDoCacheAborted {
+	if err := resp.err; err == nil || err == ErrDoCacheAborted {
 		cmds.PutCacheable(cmd)
 	}
 	return resp
@@ -984,7 +984,7 @@ func (c *clusterClient) resultcachefn(
 ) (clean bool) {
 	clean = true
 	for i, resp := range resps {
-		clean = clean && resp.NonRedisError() == nil
+		clean = clean && resp.err == nil
 		ii := cIndexes[i]
 		cm := commands[i]
 		results.s[ii] = resp
@@ -1097,7 +1097,7 @@ retry:
 	}
 
 	for i, cmd := range multi {
-		if err := results.s[i].NonRedisError(); err == nil || err == ErrDoCacheAborted {
+		if err := results.s[i].err; err == nil || err == ErrDoCacheAborted {
 			cmds.PutCacheable(cmd.Cmd)
 		}
 	}
@@ -1308,7 +1308,7 @@ retry:
 			}
 		}
 	}
-	if resp.NonRedisError() == nil {
+	if resp.err == nil {
 		cmds.PutCompleted(cmd)
 	}
 	return resp
@@ -1352,7 +1352,7 @@ retry:
 		}
 	}
 	for i, cmd := range multi {
-		if resp[i].NonRedisError() == nil {
+		if resp[i].err == nil {
 			cmds.PutCompleted(cmd)
 		}
 	}

--- a/helper.go
+++ b/helper.go
@@ -234,7 +234,7 @@ func doMultiCache(cc Client, ctx context.Context, cmds []CacheableTTL, keys []st
 	resps := cc.DoMultiCache(ctx, cmds...)
 	defer resultsp.Put(&redisresults{s: resps})
 	for i, resp := range resps {
-		if err := resp.NonRedisError(); err != nil {
+		if err := resp.err; err != nil {
 			return nil, err
 		}
 		ret[keys[i]] = resp.val
@@ -247,7 +247,7 @@ func doMultiGet(cc Client, ctx context.Context, cmds []Completed, keys []string)
 	resps := cc.DoMulti(ctx, cmds...)
 	defer resultsp.Put(&redisresults{s: resps})
 	for i, resp := range resps {
-		if err := resp.NonRedisError(); err != nil {
+		if err := resp.err; err != nil {
 			return nil, err
 		}
 		ret[keys[i]] = resp.val
@@ -259,7 +259,7 @@ func doMultiSet(cc Client, ctx context.Context, cmds []Completed) (ret map[strin
 	ret = make(map[string]error, len(cmds))
 	resps := cc.DoMulti(ctx, cmds...)
 	for i, resp := range resps {
-		if ret[cmds[i].Commands()[1]] = resp.Error(); resp.NonRedisError() == nil {
+		if ret[cmds[i].Commands()[1]] = resp.Error(); resp.err == nil {
 			intl.PutCompletedForce(cmds[i])
 		}
 	}

--- a/helper.go
+++ b/helper.go
@@ -259,7 +259,7 @@ func doMultiSet(cc Client, ctx context.Context, cmds []Completed) (ret map[strin
 	ret = make(map[string]error, len(cmds))
 	resps := cc.DoMulti(ctx, cmds...)
 	for i, resp := range resps {
-		if ret[cmds[i].Commands()[1]] = resp.Error(); resp.err == nil {
+		if ret[cmds[i].Commands()[1]] = resp.error(); resp.err == nil {
 			intl.PutCompletedForce(cmds[i])
 		}
 	}

--- a/message.go
+++ b/message.go
@@ -136,6 +136,10 @@ func (r RedisResult) NonRedisError() error {
 
 // Error returns either underlying error or redis error or nil
 func (r RedisResult) Error() (err error) {
+	return r.error()
+}
+
+func (r *RedisResult) error() (err error) {
 	if r.err != nil {
 		err = r.err
 	} else {

--- a/pipe.go
+++ b/pipe.go
@@ -630,7 +630,7 @@ func (p *pipe) backgroundPing() {
 			}
 			ch := make(chan error, 1)
 			tm := time.NewTimer(p.timeout)
-			go func() { ch <- p.Do(context.Background(), cmds.PingCmd).NonRedisError() }()
+			go func() { ch <- p.Do(context.Background(), cmds.PingCmd).err }()
 			select {
 			case <-tm.C:
 				err = os.ErrDeadlineExceeded

--- a/pipe.go
+++ b/pipe.go
@@ -216,7 +216,7 @@ func _newPipe(connFn func() (net.Conn, error), option *ClientOption, r2ps, nobg 
 			if i == 0 {
 				p.info, err = r.AsMap()
 			} else {
-				err = r.Error()
+				err = r.error()
 			}
 			if err != nil {
 				if init[i][0] == "READONLY" {
@@ -301,7 +301,7 @@ func _newPipe(connFn func() (net.Conn, error), option *ClientOption, r2ps, nobg 
 					// ignore READONLY command error
 					continue
 				}
-				if err = r.Error(); err != nil {
+				if err = r.error(); err != nil {
 					p.Close()
 					return nil, err
 				}
@@ -1315,7 +1315,7 @@ func (p *pipe) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) Re
 	if err != nil {
 		if _, ok := err.(*RedisError); ok {
 			err = ErrDoCacheAborted
-			if preErr := resp.s[3].Error(); preErr != nil { // if {cmd} get a RedisError
+			if preErr := resp.s[3].error(); preErr != nil { // if {cmd} get a RedisError
 				if _, ok := preErr.(*RedisError); ok {
 					err = preErr
 				}
@@ -1384,7 +1384,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 		if err != nil {
 			if _, ok := err.(*RedisError); ok {
 				err = ErrDoCacheAborted
-				if preErr := resp.s[len(multi)-2].Error(); preErr != nil { // if {rewritten} get a RedisError
+				if preErr := resp.s[len(multi)-2].error(); preErr != nil { // if {rewritten} get a RedisError
 					if _, ok := preErr.(*RedisError); ok {
 						err = preErr
 					}
@@ -1481,10 +1481,10 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisre
 		resp = p.DoMulti(ctx, missing...)
 		defer resultsp.Put(resp)
 		for i := 4; i < len(resp.s); i += 5 {
-			if err := resp.s[i].Error(); err != nil {
+			if err := resp.s[i].error(); err != nil {
 				if _, ok := err.(*RedisError); ok {
 					err = ErrDoCacheAborted
-					if preErr := resp.s[i-1].Error(); preErr != nil { // if {cmd} get a RedisError
+					if preErr := resp.s[i-1].error(); preErr != nil { // if {cmd} get a RedisError
 						if _, ok := preErr.(*RedisError); ok {
 							err = preErr
 						}
@@ -1512,7 +1512,7 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisre
 				if err != nil {
 					if _, ok := err.(*RedisError); ok {
 						err = ErrDoCacheAborted
-						if preErr := resp.s[i-1].Error(); preErr != nil { // if {cmd} get a RedisError
+						if preErr := resp.s[i-1].error(); preErr != nil { // if {cmd} get a RedisError
 							if _, ok := preErr.(*RedisError); ok {
 								err = preErr
 							}

--- a/sentinel.go
+++ b/sentinel.go
@@ -75,7 +75,7 @@ retry:
 			goto retry
 		}
 	}
-	if resp.NonRedisError() == nil { // not recycle cmds if error, since cmds may be used later in pipe. consider recycle them by pipe
+	if resp.err == nil { // not recycle cmds if error, since cmds may be used later in pipe. consider recycle them by pipe
 		cmds.PutCompleted(cmd)
 	}
 	return resp
@@ -104,7 +104,7 @@ retry:
 		}
 	}
 	for i, cmd := range multi {
-		if resps.s[i].NonRedisError() == nil {
+		if resps.s[i].err == nil {
 			cmds.PutCompleted(cmd)
 		}
 	}
@@ -123,7 +123,7 @@ retry:
 		}
 
 	}
-	if err := resp.NonRedisError(); err == nil || err == ErrDoCacheAborted {
+	if err := resp.err; err == nil || err == ErrDoCacheAborted {
 		cmds.PutCacheable(cmd)
 	}
 	return resp
@@ -151,7 +151,7 @@ retry:
 		}
 	}
 	for i, cmd := range multi {
-		if err := resps.s[i].NonRedisError(); err == nil || err == ErrDoCacheAborted {
+		if err := resps.s[i].err; err == nil || err == ErrDoCacheAborted {
 			cmds.PutCacheable(cmd.Cmd)
 		}
 	}

--- a/sentinel.go
+++ b/sentinel.go
@@ -66,9 +66,9 @@ func (c *sentinelClient) Do(ctx context.Context, cmd Completed) (resp RedisResul
 	attempts := 1
 retry:
 	resp = c.mConn.Load().(conn).Do(ctx, cmd)
-	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.Error(), ctx) {
+	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.error(), ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(
-			ctx, attempts, cmd, resp.Error(),
+			ctx, attempts, cmd, resp.error(),
 		)
 		if shouldRetry {
 			attempts++
@@ -91,9 +91,9 @@ retry:
 	resps := c.mConn.Load().(conn).DoMulti(ctx, multi...)
 	if c.retry && allReadOnly(multi) {
 		for i, resp := range resps.s {
-			if c.isRetryable(resp.Error(), ctx) {
+			if c.isRetryable(resp.error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(
-					ctx, attempts, multi[i], resp.Error(),
+					ctx, attempts, multi[i], resp.error(),
 				)
 				if shouldRetry {
 					resultsp.Put(resps)
@@ -115,8 +115,8 @@ func (c *sentinelClient) DoCache(ctx context.Context, cmd Cacheable, ttl time.Du
 	attempts := 1
 retry:
 	resp = c.mConn.Load().(conn).DoCache(ctx, cmd, ttl)
-	if c.retry && c.isRetryable(resp.Error(), ctx) {
-		shouldRetry := c.retryHandler.WaitOrSkipRetry(ctx, attempts, Completed(cmd), resp.Error())
+	if c.retry && c.isRetryable(resp.error(), ctx) {
+		shouldRetry := c.retryHandler.WaitOrSkipRetry(ctx, attempts, Completed(cmd), resp.error())
 		if shouldRetry {
 			attempts++
 			goto retry
@@ -138,9 +138,9 @@ retry:
 	resps := c.mConn.Load().(conn).DoMultiCache(ctx, multi...)
 	if c.retry {
 		for i, resp := range resps.s {
-			if c.isRetryable(resp.Error(), ctx) {
+			if c.isRetryable(resp.error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(
-					ctx, attempts, Completed(multi[i].Cmd), resp.Error(),
+					ctx, attempts, Completed(multi[i].Cmd), resp.error(),
 				)
 				if shouldRetry {
 					resultsp.Put(resps)


### PR DESCRIPTION
Before:
<img width="1605" alt="image" src="https://github.com/user-attachments/assets/2c38c160-6483-4dd1-bb17-97b67c0974da" />
After:
<img width="1603" alt="image" src="https://github.com/user-attachments/assets/30e2ba93-d299-43ea-bbf7-f6e0521c0859" />
