### PR TITLE
feat: Add typed cache-aside client implementation and tests

### DIFF
--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -86,7 +86,7 @@ func main() {
 		b, err := json.Marshal(val)
 		return string(b), err
 	}
-    deserializer := func(s string) (*MyValue, error) {
+	deserializer := func(s string) (*MyValue, error) {
 		var val MyValue
 		if err := json.Unmarshal([]byte(s), &val); err != nil {
 			return nil, err

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	typedClient := rueidisaside.NewTypedCacheAsideClient(client, serializer, deserializer)
-	val, err := typedClient.Get(context.Background(), time.Minute, "myKey", func(ctx context.Context, key string) (*MyValue,error) {
+	val, err := typedClient.Get(context.Background(), time.Minute, "myKey", func(ctx context.Context, key string) (*MyValue, error) {
 		var val MyValue
 		if err := db.QueryRowContext(ctx, "SELECT val FROM mytab WHERE id = ?", key).Scan(&val.Val); err == sql.ErrNoRows {
 			return nil, nil

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -94,7 +94,7 @@ func main() {
 		return val, nil
 	}
 
-	typedClient := rueidisaside.NewTypedCacheAsideClient[MyValue](client, serializer, deserializer)
+	typedClient := rueidisaside.NewTypedCacheAsideClient(client, serializer, deserializer)
 	val, err := typedClient.Get(context.Background(), time.Minute, "myKey", func(ctx context.Context, key string) (*MyValue,error) {
 		var val MyValue
 		if err := db.QueryRowContext(ctx, "SELECT val FROM mytab WHERE id = ?", key).Scan(&val.Val); err == sql.ErrNoRows {

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -94,10 +94,7 @@ func main() {
 		return &val, nil
 	}
 
-	typedClient, err := rueidisaside.NewTypedCacheAsideClient[MyValue](client, serializer, deserializer)
-	if err != nil {
-        panic(err)
-    }
+	typedClient := rueidisaside.NewTypedCacheAsideClient[MyValue](client, serializer, deserializer)
 	val, err := typedClient.Get(context.Background(), time.Minute, "myKey", func(ctx context.Context, key string) (*MyValue,error) {
 		var val MyValue
         if err := db.QueryRowContext(ctx, "SELECT val FROM mytab WHERE id = ?", key).Scan(&val.Val); err == sql.ErrNoRows {

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -54,7 +54,7 @@ func main() {
 }
 ```
 
-If you want to use cache typed value, not string, you can use `rueidisaside.TypedCacheAsideClient` instead of `rueidisaside.CacheAsideClient`.
+If you want to use cache typed value, not string, you can use `rueidisaside.TypedCacheAsideClient`.
 
 ```go
 package main

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -97,12 +97,12 @@ func main() {
 	typedClient := rueidisaside.NewTypedCacheAsideClient[MyValue](client, serializer, deserializer)
 	val, err := typedClient.Get(context.Background(), time.Minute, "myKey", func(ctx context.Context, key string) (*MyValue,error) {
 		var val MyValue
-        if err := db.QueryRowContext(ctx, "SELECT val FROM mytab WHERE id = ?", key).Scan(&val.Val); err == sql.ErrNoRows {
-            return nil, nil
-        } else if err != nil {
-            return nil, err
-        }
-        return &val, nil
+		if err := db.QueryRowContext(ctx, "SELECT val FROM mytab WHERE id = ?", key).Scan(&val.Val); err == sql.ErrNoRows {
+			return nil, nil
+		} else if err != nil {
+			return nil, err
+		}
+		return &val, nil
 	})
 	// ...
 }

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -87,11 +87,11 @@ func main() {
 		return string(b), err
 	}
 	deserializer := func(s string) (*MyValue, error) {
-		var val MyValue
+		var val *MyValue
 		if err := json.Unmarshal([]byte(s), &val); err != nil {
 			return nil, err
 		}
-		return &val, nil
+		return val, nil
 	}
 
 	typedClient := rueidisaside.NewTypedCacheAsideClient[MyValue](client, serializer, deserializer)

--- a/rueidisaside/typed_aside.go
+++ b/rueidisaside/typed_aside.go
@@ -30,12 +30,12 @@ func NewTypedCacheAsideClient[T any](
 	client CacheAsideClient,
 	serializer func(*T) (string, error),
 	deserializer func(string) (*T, error),
-) (TypedCacheAsideClient[T], error) {
+) TypedCacheAsideClient[T] {
 	return &typedCacheAsideClient[T]{
 		client:       client,
 		serializer:   serializer,
 		deserializer: deserializer,
-	}, nil
+	}
 }
 
 // Get retrieves a value of type T from the cache, or fetches it using the provided

--- a/rueidisaside/typed_aside.go
+++ b/rueidisaside/typed_aside.go
@@ -2,7 +2,6 @@ package rueidisaside
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -49,7 +48,7 @@ func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, ke
 		}
 		strVal, err := c.serializer(result)
 		if err != nil {
-			return "", fmt.Errorf("serialize value %v: %w", result, err)
+			return "", err
 		}
 		return strVal, nil
 	})
@@ -58,7 +57,7 @@ func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, ke
 	}
 	result, err := c.deserializer(strVal)
 	if err != nil {
-		return nil, fmt.Errorf("deserialize value %s: %w", strVal, err)
+		return nil, err
 	}
 	return result, nil
 }

--- a/rueidisaside/typed_aside.go
+++ b/rueidisaside/typed_aside.go
@@ -54,7 +54,7 @@ func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, ke
 		return strVal, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cache get key %s failed: %w", key, err)
+		return nil, err
 	}
 	result, err := c.deserializer(strVal)
 	if err != nil {

--- a/rueidisaside/typed_aside.go
+++ b/rueidisaside/typed_aside.go
@@ -45,7 +45,7 @@ func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, ke
 	strVal, err := c.client.Get(ctx, ttl, key, func(ctx context.Context, key string) (val string, err error) {
 		result, err := fn(ctx, key)
 		if err != nil {
-			return "", fmt.Errorf("get value by key %s failed: %w", key, err)
+			return "", err
 		}
 		strVal, err := c.serializer(result)
 		if err != nil {

--- a/rueidisaside/typed_aside.go
+++ b/rueidisaside/typed_aside.go
@@ -46,20 +46,12 @@ func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, ke
 		if err != nil {
 			return "", err
 		}
-		strVal, err := c.serializer(result)
-		if err != nil {
-			return "", err
-		}
-		return strVal, nil
+		return c.serializer(result)
 	})
 	if err != nil {
 		return nil, err
 	}
-	result, err := c.deserializer(strVal)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return c.deserializer(strVal)
 }
 
 // Del deletes the value associated with the given key from the cache.

--- a/rueidisaside/typed_aside.go
+++ b/rueidisaside/typed_aside.go
@@ -1,0 +1,74 @@
+package rueidisaside
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TypedCacheAsideClient is an interface that provides a typed cache-aside client.
+// It allows you to cache and retrieve values of a specific type T.
+type TypedCacheAsideClient[T any] interface {
+	Get(ctx context.Context, ttl time.Duration, key string, fn func(ctx context.Context, key string) (val *T, err error)) (val *T, err error)
+	Del(ctx context.Context, key string) error
+	Client() CacheAsideClient
+}
+
+// typedCacheAsideClient is an implementation of the TypedCacheAsideClient interface.
+// It provides a typed cache-aside client that allows caching and retrieving values of a specific type T.
+type typedCacheAsideClient[T any] struct {
+	client       CacheAsideClient
+	serializer   func(*T) (string, error)
+	deserializer func(string) (*T, error)
+}
+
+// NewTypedCacheAsideClient creates a new TypedCacheAsideClient instance that provides a typed cache-aside client.
+// The client, serializer, and deserializer functions are used to interact with the underlying cache.
+// The serializer function is used to convert the provided value of type T to a string, and the deserializer function
+// is used to convert the cached string value back to the original type T.
+func NewTypedCacheAsideClient[T any](
+	client CacheAsideClient,
+	serializer func(*T) (string, error),
+	deserializer func(string) (*T, error),
+) (TypedCacheAsideClient[T], error) {
+	return &typedCacheAsideClient[T]{
+		client:       client,
+		serializer:   serializer,
+		deserializer: deserializer,
+	}, nil
+}
+
+// Get retrieves a value of type T from the cache, or fetches it using the provided
+// function and stores it in the cache. The value is cached for the specified TTL.
+// If the value cannot be retrieved or deserialized, an error is returned.
+func (c typedCacheAsideClient[T]) Get(ctx context.Context, ttl time.Duration, key string, fn func(ctx context.Context, key string) (val *T, err error)) (val *T, err error) {
+	strVal, err := c.client.Get(ctx, ttl, key, func(ctx context.Context, key string) (val string, err error) {
+		result, err := fn(ctx, key)
+		if err != nil {
+			return "", fmt.Errorf("get value by key %s failed: %w", key, err)
+		}
+		strVal, err := c.serializer(result)
+		if err != nil {
+			return "", fmt.Errorf("serialize value %v: %w", result, err)
+		}
+		return strVal, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cache get key %s failed: %w", key, err)
+	}
+	result, err := c.deserializer(strVal)
+	if err != nil {
+		return nil, fmt.Errorf("deserialize value %s: %w", strVal, err)
+	}
+	return result, nil
+}
+
+// Del deletes the value associated with the given key from the cache.
+func (c typedCacheAsideClient[T]) Del(ctx context.Context, key string) error {
+	return c.client.Del(ctx, key)
+}
+
+// Client returns the underlying CacheAsideClient instance used by the TypedCacheAsideClient.
+func (c typedCacheAsideClient[T]) Client() CacheAsideClient {
+	return c.client
+}

--- a/rueidisaside/typed_aside_test.go
+++ b/rueidisaside/typed_aside_test.go
@@ -39,7 +39,8 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 
 	t.Run("successful get and cache", func(t *testing.T) {
 		expected := &testStruct{ID: 1, Name: "test"}
-		val, err := client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+		key := randStr()
+		val, err := client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 			return expected, nil
 		})
 
@@ -51,7 +52,7 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		}
 
 		// Test cached value
-		val2, err := client.Get(context.Background(), time.Second, "test-key", nil)
+		val2, err := client.Get(context.Background(), time.Second, key, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +67,8 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		}
 		clientWithBadSerializer := NewTypedCacheAsideClient[testStruct](baseClient, badSerializer, deserializer)
 
-		_, err := clientWithBadSerializer.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+		key := randStr()
+		_, err := clientWithBadSerializer.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 			return &testStruct{ID: 1, Name: "test"}, nil
 		})
 
@@ -81,7 +83,8 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		}
 		clientWithBadDeserializer := NewTypedCacheAsideClient[testStruct](baseClient, serializer, badDeserializer)
 
-		_, err := clientWithBadDeserializer.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+		key := randStr()
+		_, err := clientWithBadDeserializer.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 			return &testStruct{ID: 1, Name: "test"}, nil
 		})
 
@@ -91,7 +94,8 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 	})
 
 	t.Run("nil value handling", func(t *testing.T) {
-		val, err := client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+		key := randStr()
+		val, err := client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 			return nil, nil
 		})
 
@@ -122,8 +126,9 @@ func TestTypedCacheAsideClient_Del(t *testing.T) {
 	client := NewTypedCacheAsideClient[testStruct](baseClient, serializer, deserializer)
 
 	// Set a value first
+	key := randStr()
 	testVal := &testStruct{ID: 1, Name: "test"}
-	_, err := client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+	_, err := client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 		return testVal, nil
 	})
 	if err != nil {
@@ -131,7 +136,7 @@ func TestTypedCacheAsideClient_Del(t *testing.T) {
 	}
 
 	// Verify it's cached
-	_, err = client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+	_, err = client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (*testStruct, error) {
 		t.Fatal("this function should not be called because the value should be cached")
 		return testVal, nil
 	})
@@ -140,14 +145,14 @@ func TestTypedCacheAsideClient_Del(t *testing.T) {
 	}
 
 	// Delete the value
-	err = client.Del(context.Background(), "test-key")
+	err = client.Del(context.Background(), key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify it's deleted
 	called := false
-	_, err = client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (val *testStruct, err error) {
+	_, err = client.Get(context.Background(), time.Second, key, func(ctx context.Context, key string) (val *testStruct, err error) {
 		called = true
 		return testVal, nil
 	})

--- a/rueidisaside/typed_aside_test.go
+++ b/rueidisaside/typed_aside_test.go
@@ -1,0 +1,174 @@
+package rueidisaside
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/redis/rueidis"
+)
+
+type testStruct struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestNewTypedCacheAsideClient(t *testing.T) {
+	baseClient := makeClient(t, addr)
+	t.Cleanup(baseClient.Close)
+
+	serializer := func(v *testStruct) (string, error) {
+		if v == nil {
+			return "nilTestStruct", nil
+		}
+		b, err := json.Marshal(v)
+		return string(b), err
+	}
+	deserializer := func(s string) (*testStruct, error) {
+		if s == "nilTestStruct" {
+			return nil, nil
+		}
+		var v testStruct
+		err := json.Unmarshal([]byte(s), &v)
+		return &v, err
+	}
+
+	client, err := NewTypedCacheAsideClient[testStruct](baseClient, serializer, deserializer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client == nil {
+		t.Fatal("client should not be nil")
+	}
+}
+
+func TestTypedCacheAsideClient_Get(t *testing.T) {
+	baseClient := makeClient(t, addr)
+	t.Cleanup(baseClient.Close)
+
+	serializer := func(v *testStruct) (string, error) {
+		if v == nil {
+			return "nilTestStruct", nil
+		}
+		b, err := json.Marshal(v)
+		return string(b), err
+	}
+	deserializer := func(s string) (*testStruct, error) {
+		if s == "nilTestStruct" {
+			return nil, nil
+		}
+		var v testStruct
+		err := json.Unmarshal([]byte(s), &v)
+		return &v, err
+	}
+
+	client, _ := NewTypedCacheAsideClient[testStruct](baseClient, serializer, deserializer)
+
+	t.Run("successful get and cache", func(t *testing.T) {
+		expected := &testStruct{ID: 1, Name: "test"}
+		val, err := client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+			return expected, nil
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != expected {
+			t.Fatalf("expected %v, got %v", expected, val)
+		}
+
+		// Test cached value
+		val2, err := client.Get(context.Background(), time.Second, "test-key", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val2 != expected {
+			t.Fatalf("cached value mismatch: expected %v, got %v", expected, val2)
+		}
+	})
+
+	t.Run("serialization error", func(t *testing.T) {
+		badSerializer := func(v *testStruct) (string, error) {
+			return "", errors.New("serialization error")
+		}
+		clientWithBadSerializer, _ := NewTypedCacheAsideClient[testStruct](baseClient, badSerializer, deserializer)
+
+		_, err := clientWithBadSerializer.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+			return &testStruct{ID: 1, Name: "test"}, nil
+		})
+
+		if err == nil {
+			t.Fatal("expected serialization error")
+		}
+	})
+
+	t.Run("deserialization error", func(t *testing.T) {
+		badDeserializer := func(s string) (*testStruct, error) {
+			return nil, errors.New("deserialization error")
+		}
+		clientWithBadDeserializer, _ := NewTypedCacheAsideClient[testStruct](baseClient, serializer, badDeserializer)
+
+		_, err := clientWithBadDeserializer.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+			return &testStruct{ID: 1, Name: "test"}, nil
+		})
+
+		if err == nil {
+			t.Fatal("expected deserialization error")
+		}
+	})
+
+	t.Run("nil value handling", func(t *testing.T) {
+		val, err := client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+			return nil, nil
+		})
+
+		if err != nil {
+			t.Fatalf("nil valud should not return error: %v", err)
+		}
+		if val != nil {
+			t.Fatalf("expected nil value, got %v", val)
+		}
+	})
+}
+
+func TestTypedCacheAsideClient_Del(t *testing.T) {
+	baseClient := makeClient(t, addr)
+	t.Cleanup(baseClient.Close)
+
+	serializer := func(v *testStruct) (string, error) {
+		b, err := json.Marshal(v)
+		return string(b), err
+	}
+
+	deserializer := func(s string) (*testStruct, error) {
+		var v testStruct
+		err := json.Unmarshal([]byte(s), &v)
+		return &v, err
+	}
+
+	client, _ := NewTypedCacheAsideClient[testStruct](baseClient, serializer, deserializer)
+
+	// Set a value first
+	testVal := &testStruct{ID: 1, Name: "test"}
+	_, err := client.Get(context.Background(), time.Second, "test-key", func(ctx context.Context, key string) (*testStruct, error) {
+		return testVal, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the value
+	err = client.Del(context.Background(), "test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted
+	_, err = client.Get(context.Background(), time.Second, "test-key", nil)
+	if err != nil && !rueidis.IsRedisNil(err) {
+		t.Fatal("expected error for deleted key")
+	}
+}

--- a/rueidisaside/typed_aside_test.go
+++ b/rueidisaside/typed_aside_test.go
@@ -46,7 +46,7 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if val != expected {
+		if val.ID != expected.ID || val.Name != expected.Name {
 			t.Fatalf("expected %v, got %v", expected, val)
 		}
 
@@ -55,7 +55,7 @@ func TestTypedCacheAsideClient_Get(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if val2 != expected {
+		if val.ID != expected.ID || val.Name != expected.Name {
 			t.Fatalf("cached value mismatch: expected %v, got %v", expected, val2)
 		}
 	})


### PR DESCRIPTION
## Description
This PR introduces the `TypedCacheAsideClient` to the rueidisaside package, enhancing its functionality by supporting typed values instead of being limited to strings. The implementation includes serialization and deserialization capabilities, allowing for more flexible and type-safe caching of various data structures such as JSON objects, integers, lists, etc.

This PR addresses the discussion and enhancements proposed in [Issue #716](https://github.com/redis/rueidis/issues/716).

## Changes
- TypedCacheAsideClient Implementation:
  - Added a new generic interface `TypedCacheAsideClient[T any]` that allows caching and retrieving values of any specified type.
  - Implemented serialization and deserialization functions to handle the conversion between typed values and their string representations in Redis.
- Tests:
  - Added comprehensive unit tests in typed_aside_test.go to ensure the reliability and correctness of the new `TypedCacheAsideClient` implementation.
- Documentation:
  - Updated README.md with usage examples demonstrating how to utilize the new TypedCacheAsideClient with custom types

## Additional Discussion: Handling nil Values
While implementing the TypedCacheAsideClient, I encountered considerations regarding the handling of nil values. Currently, the tests verify that nil values are managed correctly, but I seek further guidance on the best practices for handling nil in real-world scenarios.

Questions:
1. Serialization of nil Values: Should nil values be serialized using a special tag or marker to differentiate them from valid serialized strings?
2. Deserialization Strategy: What is the recommended approach for deserializing nil values to ensure they are appropriately represented in the typed client without causing unexpected behavior?

Any insights or recommendations on handling nil values effectively within the TypedCacheAsideClient would be greatly appreciated.

## Conclusion
I believe these enhancements will provide greater flexibility and ease of use for developers utilizing the rueidisaside package, especially when dealing with complex data types. I look forward to your feedback and am open to making any necessary adjustments to align with the project's standards and best practices.

Thank you for considering this contribution!
