### PR TITLE
perf(rueidisprob): reduce allocations in bloom filter operations

### DIFF
--- a/rueidisprob/countingbloomfilter.go
+++ b/rueidisprob/countingbloomfilter.go
@@ -228,7 +228,10 @@ func (f *countingBloomFilter) AddMulti(ctx context.Context, keys []string) error
 		return nil
 	}
 
-	indexes := f.indexes(keys)
+	buf := bytesPool.Get(0, len(keys)*int(f.hashIterations)*8)
+	defer bytesPool.Put(buf)
+
+	indexes := f.indexes(keys, &buf.s)
 
 	args := make([]string, 0, len(indexes)+1)
 	args = append(args, strconv.Itoa(len(keys)))
@@ -238,13 +241,15 @@ func (f *countingBloomFilter) AddMulti(ctx context.Context, keys []string) error
 	return resp.Error()
 }
 
-func (f *countingBloomFilter) indexes(keys []string) []string {
+func (f *countingBloomFilter) indexes(keys []string, buf *[]byte) []string {
 	allIndexes := make([]string, 0, len(keys)*int(f.hashIterations))
 	size := uint64(f.size)
 	for _, key := range keys {
 		h1, h2 := hash([]byte(key))
 		for i := uint(0); i < f.hashIterations; i++ {
-			allIndexes = append(allIndexes, strconv.FormatUint(index(h1, h2, i, size), 10))
+			offset := len(*buf)
+			*buf = strconv.AppendUint(*buf, index(h1, h2, i, size), 10)
+			allIndexes = append(allIndexes, rueidis.BinaryString((*buf)[offset:]))
 		}
 	}
 	return allIndexes
@@ -264,7 +269,10 @@ func (f *countingBloomFilter) ExistsMulti(ctx context.Context, keys []string) ([
 		return nil, nil
 	}
 
-	indexes := f.indexes(keys)
+	buf := bytesPool.Get(0, len(keys)*int(f.hashIterations)*8)
+	defer bytesPool.Put(buf)
+
+	indexes := f.indexes(keys, &buf.s)
 
 	resp := f.client.Do(
 		ctx,
@@ -317,7 +325,11 @@ func (f *countingBloomFilter) RemoveMulti(ctx context.Context, keys []string) er
 		return nil
 	}
 
-	indexes := f.indexes(keys)
+	buf := bytesPool.Get(0, len(keys)*int(f.hashIterations)*8)
+	defer bytesPool.Put(buf)
+
+	indexes := f.indexes(keys, &buf.s)
+
 	args := make([]string, 0, len(indexes)+1)
 	args = append(args, indexes...)
 	args = append(args, f.hashIterationString)
@@ -353,7 +365,10 @@ func (f *countingBloomFilter) ItemMinCountMulti(ctx context.Context, keys []stri
 		return nil, nil
 	}
 
-	indexes := f.indexes(keys)
+	buf := bytesPool.Get(0, len(keys)*int(f.hashIterations)*8)
+	defer bytesPool.Put(buf)
+
+	indexes := f.indexes(keys, &buf.s)
 
 	resp := f.client.Do(
 		ctx,

--- a/rueidisprob/countingbloomfilter_test.go
+++ b/rueidisprob/countingbloomfilter_test.go
@@ -312,7 +312,8 @@ func TestCountingBloomFilterAddMulti(t *testing.T) {
 			t.Error("Count is not 4")
 		}
 
-		existingIndexes := bf.(*countingBloomFilter).indexes([]string{"1"})
+		buf := make([]byte, 0)
+		existingIndexes := bf.(*countingBloomFilter).indexes([]string{"1"}, &buf)
 		resp := client.Do(
 			context.Background(),
 			client.B().
@@ -928,7 +929,9 @@ func TestCountingBloomFilterRemoveMulti(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1", "2", "3"})
+
+		buf := make([]byte, 0)
+		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1", "2", "3"}, &buf)
 		resp := client.Do(
 			context.Background(),
 			client.B().
@@ -1005,7 +1008,8 @@ func TestCountingBloomFilterRemoveMulti(t *testing.T) {
 			t.Error("Count is not 2")
 		}
 
-		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1", "2"})
+		buf := make([]byte, 0)
+		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1", "2"}, &buf)
 		resp := client.Do(
 			context.Background(),
 			client.B().
@@ -1073,7 +1077,8 @@ func TestCountingBloomFilterRemoveMulti(t *testing.T) {
 			t.Error("Count is not 0")
 		}
 
-		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1"})
+		buf := make([]byte, 0)
+		removedIndexes := bf.(*countingBloomFilter).indexes([]string{"1"}, &buf)
 		resp := client.Do(
 			context.Background(),
 			client.B().

--- a/rueidisprob/slidingbloomfilter.go
+++ b/rueidisprob/slidingbloomfilter.go
@@ -167,10 +167,6 @@ redis.call('SET', nextCounterKey, 0)
 	lastRotationSuffix = ":lr"
 )
 
-type Logger interface {
-	Error(msg string, args ...any)
-}
-
 var (
 	_                              BloomFilter = (*slidingBloomFilter)(nil)
 	ErrWindowSizeLessThanOneSecond             = errors.New("window size cannot be less than 1 second")


### PR DESCRIPTION
Optimizes memory allocations in bloom filter operations, resulting in:
- 99.13% fewer allocations in BloomFilter operations
- 98.54% fewer allocations in CountingBloomFilter operations
- 21.72% less memory usage in BloomFilter operations
- 17.25% less memory usage in CountingBloomFilter operations
- 2.41% faster BloomFilter operations
- 2.48% faster CountingBloomFilter operations


```
goos: linux
goarch: amd64
pkg: github.com/redis/rueidis/rueidisprob
cpu: AMD Ryzen 7 7840HS with Radeon 780M Graphics   
                                  │   old.txt   │              new.txt               │
                                  │   sec/op    │   sec/op     vs base               │
BloomFilterAddMultiBigSize-16       355.3µ ± 4%   348.8µ ± 1%  -1.84% (p=0.012 n=20)
BloomFilterAddMultiLowRate-16       642.8µ ± 6%   625.5µ ± 1%  -2.69% (p=0.000 n=20)
BloomFilterAddMultiManyKeys-16      1.727m ± 1%   1.690m ± 1%  -2.16% (p=0.000 n=20)
BloomFilterExistsMultiBigSize-16    348.4µ ± 7%   339.0µ ± 1%  -2.72% (p=0.000 n=20)
BloomFilterExistsMultiLowRate-16    669.1µ ± 1%   661.2µ ± 0%  -1.19% (p=0.000 n=20)
BloomFilterExistsMultiManyKeys-16   1.928m ± 4%   1.854m ± 1%  -3.86% (p=0.000 n=20)
geomean                             749.5µ        731.5µ       -2.41%

                                  │   old.txt    │               new.txt                │
                                  │     B/op     │     B/op      vs base                │
BloomFilterAddMultiBigSize-16       3.291Ki ± 0%   2.253Ki ± 0%  -31.54% (p=0.000 n=20)
BloomFilterAddMultiLowRate-16       13.09Ki ± 0%   10.51Ki ± 0%  -19.68% (p=0.000 n=20)
BloomFilterAddMultiManyKeys-16      59.01Ki ± 0%   48.08Ki ± 0%  -18.52% (p=0.000 n=20)
BloomFilterExistsMultiBigSize-16    3.971Ki ± 0%   2.954Ki ± 0%  -25.60% (p=0.000 n=20)
BloomFilterExistsMultiLowRate-16    13.79Ki ± 0%   11.21Ki ± 0%  -18.70% (p=0.000 n=20)
BloomFilterExistsMultiManyKeys-16   72.41Ki ± 0%   61.48Ki ± 0%  -15.10% (p=0.000 n=20)
geomean                             14.70Ki        11.50Ki       -21.72%

                                  │    old.txt    │              new.txt               │
                                  │   allocs/op   │ allocs/op   vs base                │
BloomFilterAddMultiBigSize-16         72.000 ± 0%   2.000 ± 0%  -97.22% (p=0.000 n=20)
BloomFilterAddMultiLowRate-16        332.000 ± 0%   2.000 ± 0%  -99.40% (p=0.000 n=20)
BloomFilterAddMultiManyKeys-16      1402.000 ± 0%   2.000 ± 0%  -99.86% (p=0.000 n=20)
BloomFilterExistsMultiBigSize-16      74.000 ± 0%   4.000 ± 0%  -94.59% (p=0.000 n=20)
BloomFilterExistsMultiLowRate-16     334.000 ± 0%   4.000 ± 0%  -98.80% (p=0.000 n=20)
BloomFilterExistsMultiManyKeys-16   1404.000 ± 0%   4.000 ± 0%  -99.72% (p=0.000 n=20)
geomean                                324.3        2.828       -99.13%
```

```
goos: linux
goarch: amd64
pkg: github.com/redis/rueidis/rueidisprob
cpu: AMD Ryzen 7 7840HS with Radeon 780M Graphics   
                                                │   old.txt   │              new.txt               │
                                                │   sec/op    │   sec/op     vs base               │
CountingBloomFilterAddMultiBigSize-16             348.5µ ± 1%   344.0µ ± 1%  -1.30% (p=0.020 n=20)
CountingBloomFilterAddMultiLowRate-16             1.426m ± 1%   1.411m ± 1%  -1.03% (p=0.033 n=20)
CountingBloomFilterAddMultiManyKeys-16            1.457m ± 3%   1.372m ± 3%  -5.84% (p=0.000 n=20)
CountingBloomFilterExistsMultiBigSize-16          289.1µ ± 3%   283.1µ ± 4%       ~ (p=0.201 n=20)
CountingBloomFilterExistsMultiLowRate-16          1.021m ± 1%   1.028m ± 2%  +0.63% (p=0.046 n=20)
CountingBloomFilterExistsMultiManyKeys-16         537.4µ ± 1%   523.7µ ± 5%       ~ (p=0.174 n=20)
CountingBloomFilterRemoveMultiBigSize-16          446.0µ ± 1%   440.4µ ± 1%  -1.27% (p=0.001 n=20)
CountingBloomFilterRemoveMultiLowRate-16          2.033m ± 1%   2.021m ± 1%       ~ (p=0.149 n=20)
CountingBloomFilterRemoveMultiManyKeys-16         2.758m ± 4%   2.512m ± 1%  -8.92% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiBigSize-16    290.4µ ± 3%   279.1µ ± 1%  -3.87% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiLowRate-16    1.014m ± 1%   1.016m ± 1%       ~ (p=0.583 n=20)
CountingBloomFilterItemMinCountMultiManyKeys-16   539.5µ ± 1%   524.5µ ± 2%  -2.76% (p=0.004 n=20)
geomean                                           773.1µ        754.0µ       -2.48%

                                                │   old.txt    │               new.txt                │
                                                │     B/op     │     B/op      vs base                │
CountingBloomFilterAddMultiBigSize-16             3.292Ki ± 0%   2.253Ki ± 0%  -31.56% (p=0.000 n=20)
CountingBloomFilterAddMultiLowRate-16             13.10Ki ± 0%   10.52Ki ± 0%  -19.66% (p=0.000 n=20)
CountingBloomFilterAddMultiManyKeys-16            59.00Ki ± 0%   48.07Ki ± 0%  -18.52% (p=0.000 n=20)
CountingBloomFilterExistsMultiBigSize-16          6.923Ki ± 0%   5.893Ki ± 0%  -14.88% (p=0.000 n=20)
CountingBloomFilterExistsMultiLowRate-16          29.11Ki ± 0%   26.53Ki ± 0%   -8.87% (p=0.000 n=20)
CountingBloomFilterExistsMultiManyKeys-16         123.4Ki ± 0%   112.4Ki ± 0%   -8.85% (p=0.000 n=20)
CountingBloomFilterRemoveMultiBigSize-16          3.292Ki ± 0%   2.252Ki ± 0%  -31.59% (p=0.000 n=20)
CountingBloomFilterRemoveMultiLowRate-16          13.09Ki ± 0%   10.51Ki ± 0%  -19.70% (p=0.000 n=20)
CountingBloomFilterRemoveMultiManyKeys-16         58.96Ki ± 0%   48.02Ki ± 0%  -18.56% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiBigSize-16    7.473Ki ± 0%   6.440Ki ± 0%  -13.81% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiLowRate-16    31.72Ki ± 0%   29.14Ki ± 0%   -8.12% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiManyKeys-16   135.1Ki ± 0%   124.2Ki ± 0%   -8.10% (p=0.000 n=20)
geomean                                           20.38Ki        16.87Ki       -17.25%

                                                │    old.txt    │               new.txt               │
                                                │   allocs/op   │  allocs/op   vs base                │
CountingBloomFilterAddMultiBigSize-16               72.000 ± 0%   2.000 ±  0%  -97.22% (p=0.000 n=20)
CountingBloomFilterAddMultiLowRate-16              332.000 ± 0%   2.000 ±  0%  -99.40% (p=0.000 n=20)
CountingBloomFilterAddMultiManyKeys-16            1403.000 ± 0%   3.000 ±  0%  -99.79% (p=0.000 n=20)
CountingBloomFilterExistsMultiBigSize-16            73.000 ± 0%   3.000 ±  0%  -95.89% (p=0.000 n=20)
CountingBloomFilterExistsMultiLowRate-16           333.000 ± 1%   3.000 ±  0%  -99.10% (p=0.000 n=20)
CountingBloomFilterExistsMultiManyKeys-16           1533.0 ± 2%   150.0 ± 14%  -90.22% (p=0.000 n=20)
CountingBloomFilterRemoveMultiBigSize-16            72.000 ± 0%   2.000 ±  0%  -97.22% (p=0.000 n=20)
CountingBloomFilterRemoveMultiLowRate-16           332.000 ± 0%   2.000 ±  0%  -99.40% (p=0.000 n=20)
CountingBloomFilterRemoveMultiManyKeys-16         1402.000 ± 0%   2.000 ±  0%  -99.86% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiBigSize-16      73.000 ± 0%   3.000 ±  0%  -95.89% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiLowRate-16     333.000 ± 0%   3.000 ±  0%  -99.10% (p=0.000 n=20)
CountingBloomFilterItemMinCountMultiManyKeys-16     1535.5 ± 2%   122.5 ±  5%  -92.02% (p=0.000 n=20)
geomean                                              328.2        4.782        -98.54%
```