### PR TITLE
add ACLLogReset to rueidiscompat

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -417,7 +417,8 @@ type CoreCmdable interface {
 	ACLDryRun(ctx context.Context, username string, command ...any) *StringCmd
 	ACLLog(ctx context.Context, count int64) *ACLLogCmd
 	ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd
-	// TODO ACLLogReset(ctx context.Context) *StatusCmd
+	ACLLogReset(ctx context.Context) *StatusCmd
+
 
 	ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *StringCmd
 	GearsCmdable
@@ -3211,6 +3212,11 @@ func (c *Compat) ACLLog(ctx context.Context, count int64) *ACLLogCmd {
 
 func (c *Compat) ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd {
 	cmd := c.client.B().AclSetuser().Username(username).Rule(rules...).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newStatusCmd(resp)
+}
+func (c *Compat) ACLLogReset(ctx context.Context) *StatusCmd {
+	cmd := c.client.B().AclLog().Reset().Build()
 	resp := c.client.Do(ctx, cmd)
 	return newStatusCmd(resp)
 }

--- a/rueidiscompat/pipeline.go
+++ b/rueidiscompat/pipeline.go
@@ -2101,6 +2101,12 @@ func (c *Pipeline) ACLSetUser(ctx context.Context, username string, rules ...str
 	return ret
 }
 
+func (c *Pipeline) ACLLogReset(ctx context.Context) *StatusCmd {
+	ret := c.comp.ACLLogReset(ctx)
+	c.rets = append(c.rets, ret)
+	return ret
+}
+
 func (c *Pipeline) TFunctionLoad(ctx context.Context, lib string) *StatusCmd {
 	ret := c.comp.TFunctionLoad(ctx, lib)
 	c.rets = append(c.rets, ret)


### PR DESCRIPTION
As #738  mentioned, add an ACLLogReset method to provide same interface with go-redis. 