### PR TITLE
feat: Add ACLCatArgs to rueidiscompat

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -420,6 +420,7 @@ type CoreCmdable interface {
 	ACLDelUser(ctx context.Context, username string) *IntCmd
 	ACLLogReset(ctx context.Context) *StatusCmd
 	ACLCat(ctx context.Context) *StringSliceCmd
+	ACLCatArgs(ctx context.Context, options *ACLCatArgs) *StringSliceCmd
 
 	ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *StringCmd
 	GearsCmdable
@@ -3209,6 +3210,20 @@ func (c *Compat) ACLDryRun(ctx context.Context, username string, command ...any)
 	cmd := c.client.B().AclDryrun().Username(username).Command(command[0].(string)).Arg(argsToSlice(command[1:])...).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newStringCmd(resp)
+}
+
+type ACLCatArgs struct {
+	Category string
+}
+
+func (c *Compat) ACLCatArgs(ctx context.Context, options *ACLCatArgs) *StringSliceCmd {
+	// if there is a category passed, build new cmd, if there isn't - use the ACLCat method
+	if options != nil && options.Category != "" {
+		cmd := c.client.B().AclCat().Categoryname(options.Category).Build()
+		resp := c.client.Do(ctx, cmd)
+		return newStringSliceCmd(resp)
+	}
+	return c.ACLCat(ctx)
 }
 
 func (c *Compat) ACLLog(ctx context.Context, count int64) *ACLLogCmd {

--- a/rueidiscompat/pipeline.go
+++ b/rueidiscompat/pipeline.go
@@ -2125,6 +2125,12 @@ func (c *Pipeline) ACLCat(ctx context.Context) *StringSliceCmd {
 	return ret
 }
 
+func (c *Pipeline) ACLCatArgs(ctx context.Context, options *ACLCatArgs) *StringSliceCmd {
+	ret := c.comp.ACLCatArgs(ctx, options)
+	c.rets = append(c.rets, ret)
+	return ret
+}
+
 func (c *Pipeline) TFunctionLoad(ctx context.Context, lib string) *StatusCmd {
 	ret := c.comp.TFunctionLoad(ctx, lib)
 	c.rets = append(c.rets, ret)


### PR DESCRIPTION
As https://github.com/redis/rueidis/issues/743 mentioned, add an ACLCatArgs method to provide the same interface with go-redis.

This function requires `function ACLCat` to be done first, so I created an interface first.
