### PR TITLE
Fix: pool acquire allowing concurrently make new wire instead of waiting in line

### DIFF
--- a/redis_test.go
+++ b/redis_test.go
@@ -865,6 +865,7 @@ func TestSingleClientIntegration(t *testing.T) {
 		InitAddress:       []string{"127.0.0.1:6379"},
 		ConnWriteTimeout:  180 * time.Second,
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 
 		DisableAutoPipelining: os.Getenv("DisableAutoPipelining") == "true",
 	})
@@ -898,6 +899,7 @@ func TestSentinelClientIntegration(t *testing.T) {
 		},
 		SelectDB:          2, // https://github.com/redis/rueidis/issues/138
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 
 		DisableAutoPipelining: os.Getenv("DisableAutoPipelining") == "true",
 	})
@@ -929,6 +931,7 @@ func TestClusterClientIntegration(t *testing.T) {
 		ShuffleInit:       true,
 		Dialer:            net.Dialer{KeepAlive: -1},
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 
 		DisableAutoPipelining: os.Getenv("DisableAutoPipelining") == "true",
 	})
@@ -956,6 +959,7 @@ func TestSingleClient5Integration(t *testing.T) {
 		ConnWriteTimeout:  180 * time.Second,
 		DisableCache:      true,
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -978,6 +982,7 @@ func TestCluster5ClientIntegration(t *testing.T) {
 		DisableCache:      true,
 		Dialer:            net.Dialer{KeepAlive: -1},
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1000,6 +1005,7 @@ func TestSentinel5ClientIntegration(t *testing.T) {
 			MasterSet: "test5",
 		},
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1019,6 +1025,7 @@ func TestKeyDBSingleClientIntegration(t *testing.T) {
 		InitAddress:       []string{"127.0.0.1:6344"},
 		ConnWriteTimeout:  180 * time.Second,
 		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1036,8 +1043,10 @@ func TestDragonflyDBSingleClientIntegration(t *testing.T) {
 	}
 	defer ShouldNotLeaked(SetupLeakDetection())
 	client, err := NewClient(ClientOption{
-		InitAddress:      []string{"127.0.0.1:6333"},
-		ConnWriteTimeout: 180 * time.Second,
+		InitAddress:       []string{"127.0.0.1:6333"},
+		ConnWriteTimeout:  180 * time.Second,
+		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1055,9 +1064,11 @@ func TestKvrocksSingleClientIntegration(t *testing.T) {
 	}
 	defer ShouldNotLeaked(SetupLeakDetection())
 	client, err := NewClient(ClientOption{
-		InitAddress:      []string{"127.0.0.1:6666"},
-		ConnWriteTimeout: 180 * time.Second,
-		DisableCache:     true,
+		InitAddress:       []string{"127.0.0.1:6666"},
+		ConnWriteTimeout:  180 * time.Second,
+		DisableCache:      true,
+		PipelineMultiplex: 1,
+		BlockingPoolSize:  10,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/redis_test.go
+++ b/redis_test.go
@@ -182,7 +182,7 @@ func testSETGET(t *testing.T, client Client, csc bool) {
 	for i := 0; i < keys*100 && !t.Failed(); i++ {
 		key := prefix + strconv.Itoa(rand.Intn(keys))
 		jobs <- func() {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 			defer cancel()
 			val, err := client.Do(ctx, client.B().Get().Key(key).Build()).ToString()
 			if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, os.ErrDeadlineExceeded) {
@@ -347,7 +347,7 @@ func testMultiSETGET(t *testing.T, client Client, csc bool) {
 			commands = append(commands, client.B().Get().Key(cmdkeys[len(cmdkeys)-1]).Build())
 		}
 		jobs <- func() {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 			defer cancel()
 			for j, resp := range client.DoMulti(ctx, commands...) {
 				val, err := resp.ToString()


### PR DESCRIPTION
If there is no free wire in the pool, as len(p.list) == 0, it blocks the whole pool until make wire returns. 
The process of making new wire usually take several millionseconds under my environment. But if serveral tasks acquire new wires in that short period concurrently, some tasks may need to wait tens of millionseconds which brings down performance dramatically.