### PR TITLE
add feature to cmd, give a choice to change execution from spool to auto pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ for _, resp := range client.DoMulti(ctx, cmds...) {
 }
 ```
 
+### Assign Commands to Auto Pipelining
+You can also assign commands to auto pipelining with `ToPipe()`
+
+For single command
+``` golang
+cmd := client.B().Get().Key("key").Build().ToPipe()
+client.Do(ctx, cmd)
+```
+
+For multiple commands
+``` golang
+cmds := make(rueidis.Commands, 0, 10)
+for i := 0; i < 10; i++ {
+    cmds = append(cmds, client.B().Set().Key("key").Value("value").Build())
+}
+cmds[0] = cmds[0].ToPipe() // All cmds will go to auto pipelining
+client.DoMulti(ctx, cmds...)
+```
+
 ## [Server-Assisted Client-Side Caching](https://redis.io/docs/manual/client-side-caching/)
 
 The opt-in mode of [server-assisted client-side caching](https://redis.io/docs/manual/client-side-caching/) is enabled by default and can be used by calling `DoCache()` or `DoMultiCache()` with client-side TTLs specified.

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -10,7 +10,7 @@ const (
 	mtGetTag = uint16(1<<11) | readonly // make mtGetTag can also be retried
 	scrRoTag = uint16(1<<10) | readonly // make scrRoTag can also be retried
 	unsubTag = uint16(1<<9) | noRetTag
-	pipeTag  = uint16(1 << 8) // make blocking mode request can use auto pipelining
+	pipeTag  = uint16(1<<8) // make blocking mode request can use auto pipelining
 	// InitSlot indicates that the command be sent to any redis node in cluster
 	InitSlot = uint16(1 << 14)
 	// NoSlot indicates that the command has no key slot specified
@@ -109,7 +109,7 @@ func (c Completed) Pin() Completed {
 	return c
 }
 
-// ToPipe marks the command with pipeTag
+// ToPipe returns a new command with pipeTag
 func (c Completed) ToPipe() Completed {
 	c.cf |= pipeTag
 	return c
@@ -152,7 +152,7 @@ func (c *Completed) IsWrite() bool {
 
 // IsPipe checks if it is set pipeTag which prefers auto pipelining
 func (c *Completed) IsPipe() bool {
-	return c.cf&pipeTag == pipeTag
+	return c.NoReply() || c.cf&pipeTag == pipeTag
 }
 
 // Commands returns the commands as []string.

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -6,7 +6,7 @@ const (
 	optInTag = uint16(1 << 15)
 	blockTag = uint16(1 << 14)
 	readonly = uint16(1 << 13)
-	noRetTag = uint16(1<<12) | readonly // make noRetTag can also be retried
+	noRetTag = uint16(1<<12) | readonly | pipeTag // make noRetTag can also be retried and auto pipelining
 	mtGetTag = uint16(1<<11) | readonly // make mtGetTag can also be retried
 	scrRoTag = uint16(1<<10) | readonly // make scrRoTag can also be retried
 	unsubTag = uint16(1<<9) | noRetTag
@@ -152,7 +152,7 @@ func (c *Completed) IsWrite() bool {
 
 // IsPipe checks if it is set pipeTag which prefers auto pipelining
 func (c *Completed) IsPipe() bool {
-	return c.NoReply() || c.cf&pipeTag == pipeTag
+	return c.cf&pipeTag == pipeTag
 }
 
 // Commands returns the commands as []string.

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -10,6 +10,7 @@ const (
 	mtGetTag = uint16(1<<11) | readonly // make mtGetTag can also be retried
 	scrRoTag = uint16(1<<10) | readonly // make scrRoTag can also be retried
 	unsubTag = uint16(1<<9) | noRetTag
+	pipeTag  = uint16(1 << 8) // make blocking mode request can use auto pipelining
 	// InitSlot indicates that the command be sent to any redis node in cluster
 	InitSlot = uint16(1 << 14)
 	// NoSlot indicates that the command has no key slot specified
@@ -108,6 +109,12 @@ func (c Completed) Pin() Completed {
 	return c
 }
 
+// ToPipe marks the command with pipeTag
+func (c Completed) ToPipe() Completed {
+	c.cf |= pipeTag
+	return c
+}
+
 // IsEmpty checks if it is an empty command.
 func (c *Completed) IsEmpty() bool {
 	return c.cs == nil || len(c.cs.s) == 0
@@ -141,6 +148,11 @@ func (c *Completed) IsReadOnly() bool {
 // IsWrite checks if it is not readonly command.
 func (c *Completed) IsWrite() bool {
 	return !c.IsReadOnly()
+}
+
+// IsPipe checks if it is set pipeTag which prefers auto pipelining
+func (c *Completed) IsPipe() bool {
+	return c.cf&pipeTag == pipeTag
 }
 
 // Commands returns the commands as []string.

--- a/mux.go
+++ b/mux.go
@@ -210,7 +210,7 @@ func (m *mux) DoMultiStream(ctx context.Context, multi ...Completed) MultiRedisR
 }
 
 func (m *mux) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
-	if m.usePool && !cmd.NoReply() && !cmd.IsPipe() {
+	if m.usePool && !cmd.IsPipe() {
 		resp = m.blocking(m.spool, ctx, cmd)
 	} else if cmd.IsBlock() {
 		resp = m.blocking(m.dpool, ctx, cmd)
@@ -222,7 +222,7 @@ func (m *mux) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
 
 func (m *mux) DoMulti(ctx context.Context, multi ...Completed) (resp *redisresults) {
 	for _, cmd := range multi {
-		if cmd.NoReply() || cmd.IsPipe() {
+		if cmd.IsPipe() {
 			return m.pipelineMulti(ctx, multi)
 		}
 		if cmd.IsBlock() {

--- a/mux.go
+++ b/mux.go
@@ -210,7 +210,7 @@ func (m *mux) DoMultiStream(ctx context.Context, multi ...Completed) MultiRedisR
 }
 
 func (m *mux) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
-	if m.usePool && !cmd.NoReply() {
+	if m.usePool && !cmd.NoReply() && !cmd.IsPipe() {
 		resp = m.blocking(m.spool, ctx, cmd)
 	} else if cmd.IsBlock() {
 		resp = m.blocking(m.dpool, ctx, cmd)
@@ -222,7 +222,7 @@ func (m *mux) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
 
 func (m *mux) DoMulti(ctx context.Context, multi ...Completed) (resp *redisresults) {
 	for _, cmd := range multi {
-		if cmd.NoReply() {
+		if cmd.NoReply() || cmd.IsPipe() {
 			return m.pipelineMulti(ctx, multi)
 		}
 		if cmd.IsBlock() {

--- a/redis_test.go
+++ b/redis_test.go
@@ -398,7 +398,7 @@ func testMultiSETGET(t *testing.T, client Client, csc bool) {
 			commands = append(commands, client.B().Get().Key(cmdkeys[len(cmdkeys)-1]).Build())
 		}
 		if i%10 == 0 {
-			commands[0].ToPipe()
+			commands[0] = commands[0].ToPipe()
 		}
 		jobs <- func() {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)


### PR DESCRIPTION
A solution to issue #771 

```go
client, err := NewClient(ClientOption{
    InitAddress:       []string{"127.0.0.1:6379"},
    // other options
    DisableAutoPipelining:  true,  // change default action to use pool 
})

cmd := client.B().Get().Key(key).Build().ToPipe()   // assign this command to auto pipeline manually
client.Do(ctx, cmd)
```