### PR TITLE
feat: add time to live for every idle connection

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -101,8 +101,8 @@ func newMux(dst string, option *ClientOption, init, dead wire, wireFn wireFn, wi
 		m.wire[i].Store(init)
 	}
 
-	m.dpool = newPool(option.BlockingPoolSize, dead, option.BlockingPoolCleanup, option.BlockingPoolMinSize, wireFn)
-	m.spool = newPool(option.BlockingPoolSize, dead, option.BlockingPoolCleanup, option.BlockingPoolMinSize, wireNoBgFn)
+	m.dpool = newPool(option.BlockingPoolSize, dead, option.BlockingPoolCleanup, option.BlockingPoolMinSize, option.BlockingPoolConnIdleTime, wireFn)
+	m.spool = newPool(option.BlockingPoolSize, dead, option.BlockingPoolCleanup, option.BlockingPoolMinSize, option.BlockingPoolConnIdleTime, wireNoBgFn)
 	return m
 }
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -1085,6 +1085,7 @@ type mockWire struct {
 	CleanSubscriptionsFn func()
 	SetPubSubHooksFn     func(hooks PubSubHooks) <-chan error
 	SetOnCloseHookFn     func(fn func(error))
+	accessTm time.Time
 }
 
 func (m *mockWire) Do(ctx context.Context, cmd Completed) RedisResult {
@@ -1193,4 +1194,18 @@ func (m *mockWire) Close() {
 	if m.CloseFn != nil {
 		m.CloseFn()
 	}
+}
+
+func (m *mockWire) SetLastAccess(tm time.Time) {
+	if m == nil {
+		return
+	}
+	m.accessTm = tm
+}
+
+func (m *mockWire) LastAccess() time.Time {
+	if m == nil {
+		return time.Time{}
+	}
+	return m.accessTm
 }

--- a/pipe.go
+++ b/pipe.go
@@ -55,6 +55,8 @@ type wire interface {
 	CleanSubscriptions()
 	SetPubSubHooks(hooks PubSubHooks) <-chan error
 	SetOnCloseHook(fn func(error))
+	SetLastAccess(tm time.Time)
+	LastAccess() time.Time
 }
 
 var _ wire = (*pipe)(nil)
@@ -79,6 +81,7 @@ type pipe struct {
 	timeout         time.Duration
 	pinggap         time.Duration
 	maxFlushDelay   time.Duration
+	lastAccess      time.Time // last access time, updated when connection is stored
 	once            sync.Once
 	r2mu            sync.Mutex
 	version         int32
@@ -1585,6 +1588,16 @@ func (p *pipe) Close() {
 		p.r2pipe.Close()
 	}
 	p.r2mu.Unlock()
+}
+
+// SetLastAccess set last access time
+func (p *pipe) SetLastAccess(tm time.Time) {
+	p.lastAccess = tm
+}
+
+// LastAccess get last access time
+func (p *pipe) LastAccess() time.Time {
+	return p.lastAccess
 }
 
 type pshks struct {

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -1054,7 +1054,7 @@ func TestDoStreamRecycle(t *testing.T) {
 	go func() {
 		mock.Expect("PING").ReplyString("OK")
 	}()
-	conns := newPool(1, nil, 0, 0, nil)
+	conns := newPool(1, nil, 0, 0, 0, nil)
 	s := p.DoStream(context.Background(), conns, cmds.NewCompleted([]string{"PING"}))
 	buf := bytes.NewBuffer(nil)
 	if err := s.Error(); err != nil {
@@ -1107,7 +1107,7 @@ func TestDoStreamRecycleDestinationFull(t *testing.T) {
 	go func() {
 		mock.Expect("PING").ReplyBlobString("OK")
 	}()
-	conns := newPool(1, nil, 0, 0, nil)
+	conns := newPool(1, nil, 0, 0, 0, nil)
 	s := p.DoStream(context.Background(), conns, cmds.NewCompleted([]string{"PING"}))
 	buf := &limitedbuffer{buf: make([]byte, 1)}
 	if err := s.Error(); err != nil {
@@ -1140,7 +1140,7 @@ func TestDoMultiStreamRecycle(t *testing.T) {
 	go func() {
 		mock.Expect("PING").Expect("PING").ReplyString("OK").ReplyString("OK")
 	}()
-	conns := newPool(1, nil, 0, 0, nil)
+	conns := newPool(1, nil, 0, 0, 0, nil)
 	s := p.DoMultiStream(context.Background(), conns, cmds.NewCompleted([]string{"PING"}), cmds.NewCompleted([]string{"PING"}))
 	buf := bytes.NewBuffer(nil)
 	if err := s.Error(); err != nil {
@@ -1173,7 +1173,7 @@ func TestDoMultiStreamRecycleDestinationFull(t *testing.T) {
 	go func() {
 		mock.Expect("PING").Expect("PING").ReplyBlobString("OK").ReplyBlobString("OK")
 	}()
-	conns := newPool(1, nil, 0, 0, nil)
+	conns := newPool(1, nil, 0, 0, 0, nil)
 	s := p.DoMultiStream(context.Background(), conns, cmds.NewCompleted([]string{"PING"}), cmds.NewCompleted([]string{"PING"}))
 	buf := &limitedbuffer{buf: make([]byte, 1)}
 	if err := s.Error(); err != nil {
@@ -4147,7 +4147,7 @@ func TestAlreadyCanceledContext(t *testing.T) {
 		t.Fatalf("unexpected err %v", err)
 	}
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	if s := p.DoStream(ctx, cp, cmds.NewCompleted([]string{"GET", "a"})); !errors.Is(s.Error(), context.Canceled) {
 		t.Fatalf("unexpected err %v", s.Error())
 	}
@@ -4192,7 +4192,7 @@ func TestCancelContext_DoStream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	s := p.DoStream(ctx, cp, cmds.NewCompleted([]string{"GET", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
 		t.Fatalf("unexpected err %v", err)
@@ -4209,7 +4209,7 @@ func TestWriteDeadlineIsShorterThanContextDeadline_DoStream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	startTime := time.Now()
 	s := p.DoStream(ctx, cp, cmds.NewCompleted([]string{"GET", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
@@ -4230,7 +4230,7 @@ func TestWriteDeadlineIsNoShorterThanContextDeadline_DoStreamBlocked(t *testing.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	startTime := time.Now()
 	s := p.DoStream(ctx, cp, cmds.NewBlockingCompleted([]string{"BLPOP", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
@@ -4305,7 +4305,7 @@ func TestCancelContext_DoMultiStream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	s := p.DoMultiStream(ctx, cp, cmds.NewCompleted([]string{"GET", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
 		t.Fatalf("unexpected err %v", err)
@@ -4322,7 +4322,7 @@ func TestWriteDeadlineIsShorterThanContextDeadline_DoMultiStream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	startTime := time.Now()
 	s := p.DoMultiStream(ctx, cp, cmds.NewCompleted([]string{"GET", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
@@ -4343,7 +4343,7 @@ func TestWriteDeadlineIsNoShorterThanContextDeadline_DoMultiStreamBlocked(t *tes
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 	startTime := time.Now()
 	s := p.DoMultiStream(ctx, cp, cmds.NewBlockingCompleted([]string{"BLPOP", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
@@ -4375,7 +4375,7 @@ func TestTimeout_DoStream(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	p, _, _, _ := setup(t, ClientOption{ConnWriteTimeout: time.Millisecond * 30})
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 
 	s := p.DoStream(context.Background(), cp, cmds.NewCompleted([]string{"GET", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
@@ -4395,7 +4395,7 @@ func TestForceClose_DoStream_Block(t *testing.T) {
 		p.Close()
 	}()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 
 	s := p.DoStream(context.Background(), cp, cmds.NewBlockingCompleted([]string{"GET", "a"}))
 	if s.Error() != nil {
@@ -4452,7 +4452,7 @@ func TestTimeout_DoMultiStream(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	p, _, _, _ := setup(t, ClientOption{ConnWriteTimeout: time.Millisecond * 30})
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 
 	s := p.DoMultiStream(context.Background(), cp, cmds.NewCompleted([]string{"GET", "a"}))
 	if err := s.Error(); err != io.EOF && !strings.Contains(err.Error(), "i/o") {
@@ -4472,7 +4472,7 @@ func TestForceClose_DoMultiStream_Block(t *testing.T) {
 		p.Close()
 	}()
 
-	cp := newPool(1, nil, 0, 0, nil)
+	cp := newPool(1, nil, 0, 0, 0, nil)
 
 	s := p.DoMultiStream(context.Background(), cp, cmds.NewBlockingCompleted([]string{"GET", "a"}))
 	if s.Error() != nil {

--- a/pool_test.go
+++ b/pool_test.go
@@ -378,12 +378,12 @@ func TestPoolWithIdleTTL(t *testing.T) {
 			p.cond.L.Lock()
 			if p.size != midSize {
 				defer p.cond.L.Unlock()
-				t.Fatalf(" size must be equal to %d, actual: %d", midSize, p.size)
+				t.Fatalf("size must be equal to %d, actual: %d", midSize, p.size)
 			}
 
 			if len(p.list) != midSize {
 				defer p.cond.L.Unlock()
-				t.Fatalf(" pool len must equal to %d, actual: %d", midSize, len(p.list))
+				t.Fatalf("pool len must equal to %d, actual: %d", midSize, len(p.list))
 			}
 			p.cond.L.Unlock()
 		}
@@ -404,12 +404,12 @@ func TestPoolWithIdleTTL(t *testing.T) {
 			p.cond.L.Lock()
 			if p.size != minSize {
 				defer p.cond.L.Unlock()
-				t.Fatalf(" size must be equal to %d, actual: %d", minSize, p.size)
+				t.Fatalf("size must be equal to %d, actual: %d", minSize, p.size)
 			}
 
 			if len(p.list) != minSize {
 				defer p.cond.L.Unlock()
-				t.Fatalf(" pool len must equal to %d, actual: %d", minSize, len(p.list))
+				t.Fatalf("pool len must equal to %d, actual: %d", minSize, len(p.list))
 			}
 			p.cond.L.Unlock()
 		}

--- a/pool_test.go
+++ b/pool_test.go
@@ -15,7 +15,7 @@ func TestPool(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	setup := func(size int) (*pool, *int32) {
 		var count int32
-		return newPool(size, dead, 0, 0, func() wire {
+		return newPool(size, dead, 0, 0, 0, func() wire {
 			atomic.AddInt32(&count, 1)
 			closed := false
 			return &mockWire{
@@ -33,7 +33,7 @@ func TestPool(t *testing.T) {
 	}
 
 	t.Run("DefaultPoolSize", func(t *testing.T) {
-		p := newPool(0, dead, 0, 0, func() wire { return nil })
+		p := newPool(0, dead, 0, 0, 0, func() wire { return nil })
 		if cap(p.list) == 0 {
 			t.Fatalf("DefaultPoolSize is not applied")
 		}
@@ -209,7 +209,7 @@ func TestPoolError(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	setup := func(size int) (*pool, *int32) {
 		var count int32
-		return newPool(size, dead, 0, 0, func() wire {
+		return newPool(size, dead, 0, 0, 0, func() wire {
 			w := &pipe{}
 			w.pshks.Store(emptypshks)
 			c := atomic.AddInt32(&count, 1)
@@ -243,8 +243,8 @@ func TestPoolError(t *testing.T) {
 
 func TestPoolWithIdleTTL(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
-	setup := func(size int, ttl time.Duration, minSize int) *pool {
-		return newPool(size, dead, ttl, minSize, func() wire {
+	setup := func(size int, ttl time.Duration, minSize int, idle time.Duration) *pool {
+		return newPool(size, dead, ttl, minSize, idle, func() wire {
 			closed := false
 			return &mockWire{
 				CloseFn: func() {
@@ -262,8 +262,8 @@ func TestPoolWithIdleTTL(t *testing.T) {
 
 	t.Run("Removing idle conns. Min size is not 0", func(t *testing.T) {
 		minSize := 3
-		p := setup(0, time.Millisecond*50, minSize)
 		conns := make([]wire, 10)
+		p := setup(len(conns), time.Millisecond*50, minSize, 0)
 
 		for i := 0; i < 2; i++ {
 			for i := range conns {
@@ -296,7 +296,7 @@ func TestPoolWithIdleTTL(t *testing.T) {
 	})
 
 	t.Run("Removing idle conns. Min size is 0", func(t *testing.T) {
-		p := setup(0, time.Millisecond*50, 0)
+		p := setup(0, time.Millisecond*50, 0, 0)
 		conns := make([]wire, 10)
 
 		for i := 0; i < 2; i++ {
@@ -322,6 +322,94 @@ func TestPoolWithIdleTTL(t *testing.T) {
 			if len(p.list) != 0 {
 				defer p.cond.L.Unlock()
 				t.Fatalf("pool len must equal to 0, actual: %d", len(p.list))
+			}
+			p.cond.L.Unlock()
+		}
+
+		p.Close()
+	})
+
+	t.Run("Removing idle conns. Min size is not 0, idle > 0", func(t *testing.T) {
+		minSize := 3
+		p := setup(0, time.Millisecond*50, minSize, time.Millisecond*200)
+		conns := make([]wire, 10)
+
+		for i := 0; i < 2; i++ {
+			for i := range conns {
+				w := p.Acquire()
+				conns[i] = w
+			}
+
+			for _, w := range conns {
+				p.Store(w)
+			}
+
+			time.Sleep(time.Millisecond * 60)
+			p.cond.Broadcast()
+			time.Sleep(time.Millisecond * 40)
+
+			p.cond.L.Lock()
+			if p.size != len(conns) {
+				defer p.cond.L.Unlock()
+				t.Fatalf("size must be equal to %d, actual: %d", len(conns), p.size)
+			}
+
+			if len(p.list) != len(conns) {
+				defer p.cond.L.Unlock()
+				t.Fatalf("pool len must equal to %d, actual: %d", len(conns), len(p.list))
+			}
+			p.cond.L.Unlock()
+		}
+
+		time.Sleep(time.Millisecond * 200)
+
+		midSize := 5
+		for i := 0; i < 2; i++ {
+			for i := range midSize {
+				w := p.Acquire()
+				conns[i] = w
+			}
+			for i := range midSize {
+				p.Store(conns[i])
+			}
+			time.Sleep(time.Millisecond * 60)
+			p.cond.Broadcast()
+			time.Sleep(time.Millisecond * 40)
+			p.cond.L.Lock()
+			if p.size != midSize {
+				defer p.cond.L.Unlock()
+				t.Fatalf(" size must be equal to %d, actual: %d", midSize, p.size)
+			}
+
+			if len(p.list) != midSize {
+				defer p.cond.L.Unlock()
+				t.Fatalf(" pool len must equal to %d, actual: %d", midSize, len(p.list))
+			}
+			p.cond.L.Unlock()
+		}
+
+		time.Sleep(time.Millisecond * 200)
+
+		for i := 0; i < 2; i++ {
+			for i := range minSize {
+				w := p.Acquire()
+				conns[i] = w
+			}
+			for i := range minSize {
+				p.Store(conns[i])
+			}
+			time.Sleep(time.Millisecond * 60)
+			p.cond.Broadcast()
+			time.Sleep(time.Millisecond * 40)
+			p.cond.L.Lock()
+			if p.size != minSize {
+				defer p.cond.L.Unlock()
+				t.Fatalf(" size must be equal to %d, actual: %d", minSize, p.size)
+			}
+
+			if len(p.list) != minSize {
+				defer p.cond.L.Unlock()
+				t.Fatalf(" pool len must equal to %d, actual: %d", minSize, len(p.list))
 			}
 			p.cond.L.Unlock()
 		}

--- a/rueidis.go
+++ b/rueidis.go
@@ -159,6 +159,8 @@ type ClientOption struct {
 	// Only relevant if BlockingPoolCleanup is not 0. This parameter limits
 	// the number of idle connections that can be removed by BlockingPoolCleanup.
 	BlockingPoolMinSize int
+	// BlockingPoolConnIdleTime is the minimum time to live for idle connections
+	BlockingPoolConnIdleTime time.Duration
 
 	// BlockingPoolSize is the size of the connection pool shared by blocking commands (ex BLPOP, XREAD with BLOCK).
 	// The default is DefaultPoolSize.


### PR DESCRIPTION
### Intuition
When ClientOption.BlockingPoolCleanup is set, all connections beyond BlockingPoolMinSize in idle list of the pool will be recycled. Which will cause connection be closed and created frequently even if my application has high concurrency. As my obervation, at the very moment the timer function is triggered, there may be more than BlockingPoolMinSize of connection in the idle list which are store recently and supposed to be acquired very soon.

### Approach
My immediate thougth is adding an access time to every connection. The access time is updated when connection is put back into the pool.  Access time will be checked when recycling. If time.Since(accessTime) < BlockingPoolConnIdleTime, that connection will not be recycled. BlockingPoolConnIdleTime is a new ClientOption to define the idle time for every connection.
