### PR TITLE
feat: Add `Mode()` Method to `rueidis.Client` for Detecting Client Mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ func newSingleClient(opt *ClientOption, prev conn, connFn connFn, retryer retryH
 }
 
 func newSingleClientWithConn(conn conn, builder Builder, retry, disableCache bool, retryer retryHandler) *singleClient {
-	return &singleClient{cmd: builder, conn: conn, retry: retry, retryHandler: retryer, DisableCache: disableCache, mode: ModeStandalone}
+	return &singleClient{cmd: builder, conn: conn, retry: retry, retryHandler: retryer, DisableCache: disableCache, mode: ClientModeStandalone}
 }
 
 func (c *singleClient) B() Builder {

--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ type singleClient struct {
 	cmd          Builder
 	retry        bool
 	DisableCache bool
-	mode         ClientMode
 }
 
 func newSingleClient(opt *ClientOption, prev conn, connFn connFn, retryer retryHandler) (*singleClient, error) {
@@ -37,7 +36,7 @@ func newSingleClient(opt *ClientOption, prev conn, connFn connFn, retryer retryH
 }
 
 func newSingleClientWithConn(conn conn, builder Builder, retry, disableCache bool, retryer retryHandler) *singleClient {
-	return &singleClient{cmd: builder, conn: conn, retry: retry, retryHandler: retryer, DisableCache: disableCache, mode: ClientModeStandalone}
+	return &singleClient{cmd: builder, conn: conn, retry: retry, retryHandler: retryer, DisableCache: disableCache}
 }
 
 func (c *singleClient) B() Builder {
@@ -191,7 +190,7 @@ func (c *singleClient) Nodes() map[string]Client {
 }
 
 func (c *singleClient) Mode() ClientMode {
-	return c.mode
+	return ClientModeStandalone
 }
 
 func (c *singleClient) Close() {

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ type singleClient struct {
 	cmd          Builder
 	retry        bool
 	DisableCache bool
-	mode         Mode
+	mode         ClientMode
 }
 
 func newSingleClient(opt *ClientOption, prev conn, connFn connFn, retryer retryHandler) (*singleClient, error) {
@@ -190,7 +190,7 @@ func (c *singleClient) Nodes() map[string]Client {
 	return map[string]Client{c.conn.Addr(): c}
 }
 
-func (c *singleClient) Mode() Mode {
+func (c *singleClient) Mode() ClientMode {
 	return c.mode
 }
 

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ type singleClient struct {
 	cmd          Builder
 	retry        bool
 	DisableCache bool
+	mode         Mode
 }
 
 func newSingleClient(opt *ClientOption, prev conn, connFn connFn, retryer retryHandler) (*singleClient, error) {
@@ -36,7 +37,7 @@ func newSingleClient(opt *ClientOption, prev conn, connFn connFn, retryer retryH
 }
 
 func newSingleClientWithConn(conn conn, builder Builder, retry, disableCache bool, retryer retryHandler) *singleClient {
-	return &singleClient{cmd: builder, conn: conn, retry: retry, retryHandler: retryer, DisableCache: disableCache}
+	return &singleClient{cmd: builder, conn: conn, retry: retry, retryHandler: retryer, DisableCache: disableCache, mode: ModeStandalone}
 }
 
 func (c *singleClient) B() Builder {
@@ -187,6 +188,10 @@ func (c *singleClient) Dedicate() (DedicatedClient, func()) {
 
 func (c *singleClient) Nodes() map[string]Client {
 	return map[string]Client{c.conn.Addr(): c}
+}
+
+func (c *singleClient) Mode() Mode {
+	return c.mode
 }
 
 func (c *singleClient) Close() {

--- a/client_test.go
+++ b/client_test.go
@@ -262,6 +262,12 @@ func TestSingleClient(t *testing.T) {
 		}
 	})
 
+	t.Run("Mode", func(t *testing.T) {
+		if v := client.Mode(); v != ClientModeStandalone {
+			t.Fatalf("unexpected mode %v", v)
+		}
+	})
+
 	t.Run("Delegate Do", func(t *testing.T) {
 		c := client.B().Get().Key("Do").Build()
 		m.DoFn = func(cmd Completed) RedisResult {

--- a/cluster.go
+++ b/cluster.go
@@ -35,7 +35,7 @@ type clusterClient struct {
 	stop         uint32
 	cmd          Builder
 	retry        bool
-	mode         Mode
+	mode         ClientMode
 }
 
 // NOTE: connrole and conn must be initialized at the same time
@@ -1205,7 +1205,7 @@ func (c *clusterClient) Nodes() map[string]Client {
 	return _nodes
 }
 
-func (c *clusterClient) Mode() Mode {
+func (c *clusterClient) Mode() ClientMode {
 	return c.mode
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -35,6 +35,7 @@ type clusterClient struct {
 	stop         uint32
 	cmd          Builder
 	retry        bool
+	mode         Mode
 }
 
 // NOTE: connrole and conn must be initialized at the same time
@@ -57,6 +58,7 @@ func newClusterClient(opt *ClientOption, connFn connFn, retryer retryHandler) (*
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
 		stopCh:       make(chan struct{}),
+		mode:         ModeCluster,
 	}
 
 	if opt.ReplicaOnly && opt.SendToReplicas != nil {
@@ -1201,6 +1203,10 @@ func (c *clusterClient) Nodes() map[string]Client {
 	}
 	c.mu.RUnlock()
 	return _nodes
+}
+
+func (c *clusterClient) Mode() Mode {
+	return c.mode
 }
 
 func (c *clusterClient) Close() {

--- a/cluster.go
+++ b/cluster.go
@@ -35,7 +35,6 @@ type clusterClient struct {
 	stop         uint32
 	cmd          Builder
 	retry        bool
-	mode         ClientMode
 }
 
 // NOTE: connrole and conn must be initialized at the same time
@@ -58,7 +57,6 @@ func newClusterClient(opt *ClientOption, connFn connFn, retryer retryHandler) (*
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
 		stopCh:       make(chan struct{}),
-		mode:         ClientModeCluster,
 	}
 
 	if opt.ReplicaOnly && opt.SendToReplicas != nil {
@@ -1206,7 +1204,7 @@ func (c *clusterClient) Nodes() map[string]Client {
 }
 
 func (c *clusterClient) Mode() ClientMode {
-	return c.mode
+	return ClientModeCluster
 }
 
 func (c *clusterClient) Close() {

--- a/cluster.go
+++ b/cluster.go
@@ -58,7 +58,7 @@ func newClusterClient(opt *ClientOption, connFn connFn, retryer retryHandler) (*
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
 		stopCh:       make(chan struct{}),
-		mode:         ModeCluster,
+		mode:         ClientModeCluster,
 	}
 
 	if opt.ReplicaOnly && opt.SendToReplicas != nil {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1589,6 +1589,12 @@ func TestClusterClient(t *testing.T) {
 		}
 	})
 
+	t.Run("Mode", func(t *testing.T) {
+		if client.Mode() != ClientModeCluster {
+			t.Fatalf("unexpected mode %v", client.Mode())
+		}
+	})
+
 	t.Run("Delegate Do with no slot", func(t *testing.T) {
 		c := client.B().Info().Build()
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Info" {

--- a/lua_test.go
+++ b/lua_test.go
@@ -204,6 +204,7 @@ type client struct {
 	DedicatedFn    func(fn func(DedicatedClient) error) (err error)
 	DedicateFn     func() (DedicatedClient, func())
 	CloseFn        func()
+	ModeFn         func() Mode
 }
 
 func (c *client) Receive(ctx context.Context, subscribe Completed, fn func(msg PubSubMessage)) error {
@@ -269,6 +270,10 @@ func (c *client) Dedicate() (DedicatedClient, func()) {
 
 func (c *client) Nodes() map[string]Client {
 	return map[string]Client{"addr": c}
+}
+
+func (c *client) Mode() Mode {
+	return c.ModeFn()
 }
 
 func (c *client) Close() {

--- a/lua_test.go
+++ b/lua_test.go
@@ -204,7 +204,7 @@ type client struct {
 	DedicatedFn    func(fn func(DedicatedClient) error) (err error)
 	DedicateFn     func() (DedicatedClient, func())
 	CloseFn        func()
-	ModeFn         func() Mode
+	ModeFn         func() ClientMode
 }
 
 func (c *client) Receive(ctx context.Context, subscribe Completed, fn func(msg PubSubMessage)) error {
@@ -272,7 +272,7 @@ func (c *client) Nodes() map[string]Client {
 	return map[string]Client{"addr": c}
 }
 
-func (c *client) Mode() Mode {
+func (c *client) Mode() ClientMode {
 	return c.ModeFn()
 }
 

--- a/mock/client.go
+++ b/mock/client.go
@@ -60,6 +60,11 @@ func (m *Client) B() rueidis.Builder {
 	return cmds.NewBuilder(m.slot)
 }
 
+// Mode implements rueidis.Client.
+func (m *Client) Mode() rueidis.Mode {
+	return rueidis.ModeStandalone
+}
+
 // Close mocks base method.
 func (m *Client) Close() {
 	m.ctrl.T.Helper()

--- a/mock/client.go
+++ b/mock/client.go
@@ -60,7 +60,6 @@ func (m *Client) B() rueidis.Builder {
 	return cmds.NewBuilder(m.slot)
 }
 
-// Mode implements rueidis.Client.
 func (m *Client) Mode() rueidis.Mode {
 	return rueidis.ModeStandalone
 }

--- a/mock/client.go
+++ b/mock/client.go
@@ -61,7 +61,7 @@ func (m *Client) B() rueidis.Builder {
 }
 
 func (m *Client) Mode() rueidis.ClientMode {
-	return rueidis.ModeStandalone
+	return rueidis.ClientModeStandalone
 }
 
 // Close mocks base method.

--- a/mock/client.go
+++ b/mock/client.go
@@ -60,7 +60,7 @@ func (m *Client) B() rueidis.Builder {
 	return cmds.NewBuilder(m.slot)
 }
 
-func (m *Client) Mode() rueidis.Mode {
+func (m *Client) Mode() rueidis.ClientMode {
 	return rueidis.ModeStandalone
 }
 

--- a/rueidis.go
+++ b/rueidis.go
@@ -36,9 +36,9 @@ const (
 	// MaxPipelineMultiplex is the maximum meaningful value for ClientOption.PipelineMultiplex
 	MaxPipelineMultiplex = 8
 	// https://github.com/valkey-io/valkey/blob/1a34a4ff7f101bb6b17a0b5e9aa3bf7d6bd29f68/src/networking.c#L4118-L4124
-	ModeCluster    ClientMode = "cluster"
-	ModeSentinel   ClientMode = "sentinel"
-	ModeStandalone ClientMode = "standalone"
+	ClientModeCluster    ClientMode = "cluster"
+	ClientModeSentinel   ClientMode = "sentinel"
+	ClientModeStandalone ClientMode = "standalone"
 )
 
 var (

--- a/rueidis.go
+++ b/rueidis.go
@@ -35,6 +35,10 @@ const (
 	DefaultWriteBuffer = 1 << 19
 	// MaxPipelineMultiplex is the maximum meaningful value for ClientOption.PipelineMultiplex
 	MaxPipelineMultiplex = 8
+	// https://github.com/valkey-io/valkey/blob/1a34a4ff7f101bb6b17a0b5e9aa3bf7d6bd29f68/src/networking.c#L4118-L4124
+	ModeCluster    Mode = "cluster"
+	ModeSentinel   Mode = "sentinel"
+	ModeStandalone Mode = "standalone"
 )
 
 var (
@@ -258,6 +262,8 @@ type ReplicaInfo struct {
 	AZ   string
 }
 
+type Mode string
+
 // Client is the redis client interface for both single redis instance and redis cluster. It should be created from the NewClient()
 type Client interface {
 	CoreClient
@@ -307,6 +313,8 @@ type Client interface {
 	// Nodes returns each redis node this client known as rueidis.Client. This is useful if you want to
 	// send commands to some specific redis nodes in the cluster.
 	Nodes() map[string]Client
+
+	Mode() Mode
 }
 
 // DedicatedClient is obtained from Client.Dedicated() and it will be bound to single redis connection and

--- a/rueidis.go
+++ b/rueidis.go
@@ -36,9 +36,9 @@ const (
 	// MaxPipelineMultiplex is the maximum meaningful value for ClientOption.PipelineMultiplex
 	MaxPipelineMultiplex = 8
 	// https://github.com/valkey-io/valkey/blob/1a34a4ff7f101bb6b17a0b5e9aa3bf7d6bd29f68/src/networking.c#L4118-L4124
-	ModeCluster    Mode = "cluster"
-	ModeSentinel   Mode = "sentinel"
-	ModeStandalone Mode = "standalone"
+	ModeCluster    ClientMode = "cluster"
+	ModeSentinel   ClientMode = "sentinel"
+	ModeStandalone ClientMode = "standalone"
 )
 
 var (
@@ -262,7 +262,7 @@ type ReplicaInfo struct {
 	AZ   string
 }
 
-type Mode string
+type ClientMode string
 
 // Client is the redis client interface for both single redis instance and redis cluster. It should be created from the NewClient()
 type Client interface {
@@ -317,7 +317,7 @@ type Client interface {
 	// in standalone, sentinel, or cluster mode.
 	// This can be useful for determining the type of Redis deployment the client is connected to
 	// and for making decisions based on the deployment type.
-	Mode() Mode
+	Mode() ClientMode
 }
 
 // DedicatedClient is obtained from Client.Dedicated() and it will be bound to single redis connection and

--- a/rueidis.go
+++ b/rueidis.go
@@ -313,7 +313,10 @@ type Client interface {
 	// Nodes returns each redis node this client known as rueidis.Client. This is useful if you want to
 	// send commands to some specific redis nodes in the cluster.
 	Nodes() map[string]Client
-
+	// Mode returns the current mode of the client, which indicates whether the client is operating
+	// in standalone, sentinel, or cluster mode.
+	// This can be useful for determining the type of Redis deployment the client is connected to
+	// and for making decisions based on the deployment type.
 	Mode() Mode
 }
 

--- a/rueidiscompat/tx.go
+++ b/rueidiscompat/tx.go
@@ -107,7 +107,7 @@ func (p *txproxy) Nodes() map[string]rueidis.Client {
 	panic("not implemented")
 }
 
-func (p *txproxy) Mode() rueidis.Mode {
+func (p *txproxy) Mode() rueidis.ClientMode {
 	panic("not implemented")
 }
 

--- a/rueidiscompat/tx.go
+++ b/rueidiscompat/tx.go
@@ -107,6 +107,10 @@ func (p *txproxy) Nodes() map[string]rueidis.Client {
 	panic("not implemented")
 }
 
+func (p *txproxy) Mode() rueidis.Mode {
+	panic("not implemented")
+}
+
 type Tx interface {
 	CoreCmdable
 	Watch(ctx context.Context, keys ...string) *StatusCmd

--- a/rueidishook/hook.go
+++ b/rueidishook/hook.go
@@ -82,6 +82,10 @@ func (c *hookclient) Nodes() map[string]rueidis.Client {
 	return nodes
 }
 
+func (c *hookclient) Mode() rueidis.ClientMode {
+	return c.client.Mode()
+}
+
 func (c *hookclient) Close() {
 	c.client.Close()
 }
@@ -148,6 +152,10 @@ func (e *extended) Dedicate() (client rueidis.DedicatedClient, cancel func()) {
 
 func (e *extended) Nodes() map[string]rueidis.Client {
 	panic("Nodes() is not allowed with rueidis.DedicatedClient")
+}
+
+func (e *extended) Mode() rueidis.ClientMode {
+	panic("Mode() is not allowed with rueidis.DedicatedClient")
 }
 
 type result struct {

--- a/rueidisotel/trace.go
+++ b/rueidisotel/trace.go
@@ -203,6 +203,10 @@ func (o *otelclient) Nodes() map[string]rueidis.Client {
 	return nodes
 }
 
+func (o *otelclient) Mode() rueidis.ClientMode {
+	return o.client.Mode()
+}
+
 func (o *otelclient) Close() {
 	o.client.Close()
 }

--- a/sentinel.go
+++ b/sentinel.go
@@ -26,6 +26,7 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
 		replica:      opt.ReplicaOnly,
+		mode:         ModeSentinel,
 	}
 
 	for _, sentinel := range opt.InitAddress {
@@ -56,6 +57,7 @@ type sentinelClient struct {
 	cmd          Builder
 	retry        bool
 	replica      bool
+	mode         Mode
 }
 
 func (c *sentinelClient) B() Builder {
@@ -216,6 +218,10 @@ func (c *sentinelClient) Nodes() map[string]Client {
 	conn := c.mConn.Load().(conn)
 	disableCache := c.mOpt != nil && c.mOpt.DisableCache
 	return map[string]Client{conn.Addr(): newSingleClientWithConn(conn, c.cmd, c.retry, disableCache, c.retryHandler)}
+}
+
+func (c *sentinelClient) Mode() Mode {
+	return c.mode
 }
 
 func (c *sentinelClient) Close() {

--- a/sentinel.go
+++ b/sentinel.go
@@ -26,7 +26,7 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
 		replica:      opt.ReplicaOnly,
-		mode:         ModeSentinel,
+		mode:         ClientModeSentinel,
 	}
 
 	for _, sentinel := range opt.InitAddress {

--- a/sentinel.go
+++ b/sentinel.go
@@ -57,7 +57,7 @@ type sentinelClient struct {
 	cmd          Builder
 	retry        bool
 	replica      bool
-	mode         Mode
+	mode         ClientMode
 }
 
 func (c *sentinelClient) B() Builder {
@@ -220,7 +220,7 @@ func (c *sentinelClient) Nodes() map[string]Client {
 	return map[string]Client{conn.Addr(): newSingleClientWithConn(conn, c.cmd, c.retry, disableCache, c.retryHandler)}
 }
 
-func (c *sentinelClient) Mode() Mode {
+func (c *sentinelClient) Mode() ClientMode {
 	return c.mode
 }
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -26,7 +26,6 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
 		replica:      opt.ReplicaOnly,
-		mode:         ClientModeSentinel,
 	}
 
 	for _, sentinel := range opt.InitAddress {
@@ -57,7 +56,6 @@ type sentinelClient struct {
 	cmd          Builder
 	retry        bool
 	replica      bool
-	mode         ClientMode
 }
 
 func (c *sentinelClient) B() Builder {
@@ -221,7 +219,7 @@ func (c *sentinelClient) Nodes() map[string]Client {
 }
 
 func (c *sentinelClient) Mode() ClientMode {
-	return c.mode
+	return ClientModeSentinel
 }
 
 func (c *sentinelClient) Close() {

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -782,6 +782,12 @@ func TestSentinelClientDelegate(t *testing.T) {
 		}
 	})
 
+	t.Run("Mode", func(t *testing.T) {
+		if mode := client.Mode(); mode != ClientModeSentinel {
+			t.Fatalf("unexpected mode %v", mode)
+		}
+	})
+
 	t.Run("Delegate Do", func(t *testing.T) {
 		c := client.B().Get().Key("Do").Build()
 		m.DoFn = func(cmd Completed) RedisResult {


### PR DESCRIPTION
## Why do we need this?
Previously, Centrifugo required explicit Redis Cluster configuration because the Centrifuge library generates keys differently in cluster mode (using hash tags). However, this approach is inconvenient because cloud providers typically provide a Redis URL (e.g., `redis://...`) without explicitly indicating whether it is a standalone Redis or a Redis Cluster. This prevents users from simply reusing the endpoint when starting Centrifugo.

## New Interface Definition

```golang
type ClientMode string

const (
	ClientModeCluster    ClientMode = "cluster"
	ClientModeSentinel   ClientMode = "sentinel"
	ClientModeStandalone ClientMode = "standalone"
)

type Client interface {
    ...
    Mode() ClientMode
}
```

Closes #790 