### PR TITLE
fix: don't send CLIENT CACHING YES in BCAST and OPTOUT mode

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/redis/rueidis/internal/cmds"
 )
 
 type mockConn struct {
@@ -189,6 +191,10 @@ func (m *mockConn) Addr() string {
 		return m.AddrFn()
 	}
 	return ""
+}
+
+func (m *mockConn) OptInCmd() cmds.Completed {
+	return cmds.OptInCmd
 }
 
 func TestNewSingleClientNoNode(t *testing.T) {

--- a/cluster.go
+++ b/cluster.go
@@ -899,7 +899,7 @@ func askingMultiCache(cc conn, ctx context.Context, multi []CacheableTTL) *redis
 	commands := make([]Completed, 0, len(multi)*6)
 	for _, cmd := range multi {
 		ck, _ := cmds.CacheKey(cmd.Cmd)
-		commands = append(commands, cmds.OptInCmd, cmds.AskingCmd, cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), Completed(cmd.Cmd), cmds.ExecCmd)
+		commands = append(commands, cc.OptInCmd(), cmds.AskingCmd, cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), Completed(cmd.Cmd), cmds.ExecCmd)
 	}
 	results := resultsp.Get(0, len(multi))
 	resps := cc.DoMulti(ctx, commands...)

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -7,10 +7,10 @@ const (
 	blockTag = uint16(1 << 14)
 	readonly = uint16(1 << 13)
 	noRetTag = uint16(1<<12) | readonly | pipeTag // make noRetTag can also be retried and auto pipelining
-	mtGetTag = uint16(1<<11) | readonly // make mtGetTag can also be retried
-	scrRoTag = uint16(1<<10) | readonly // make scrRoTag can also be retried
+	mtGetTag = uint16(1<<11) | readonly           // make mtGetTag can also be retried
+	scrRoTag = uint16(1<<10) | readonly           // make scrRoTag can also be retried
 	unsubTag = uint16(1<<9) | noRetTag
-	pipeTag  = uint16(1<<8) // make blocking mode request can use auto pipelining
+	pipeTag  = uint16(1 << 8) // make blocking mode request can use auto pipelining
 	// InitSlot indicates that the command be sent to any redis node in cluster
 	InitSlot = uint16(1 << 14)
 	// NoSlot indicates that the command has no key slot specified
@@ -21,6 +21,11 @@ var (
 	// OptInCmd is predefined CLIENT CACHING YES
 	OptInCmd = Completed{
 		cs: newCommandSlice([]string{"CLIENT", "CACHING", "YES"}),
+		cf: optInTag,
+	}
+	// OptInNopCmd is a predefined alternative for CLIENT CACHING YES in BCAST/OPTOUT mode.
+	OptInNopCmd = Completed{
+		cs: newCommandSlice([]string{"ECHO", ""}),
 		cf: optInTag,
 	}
 	// MultiCmd is predefined MULTI

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -90,6 +90,9 @@ func TestCompleted_IsOptIn(t *testing.T) {
 	if cmd := OptInCmd; !cmd.IsOptIn() {
 		t.Fatalf("should be opt in command")
 	}
+	if cmd := OptInNopCmd; !cmd.IsOptIn() {
+		t.Fatalf("should be opt in command")
+	}
 }
 
 func TestCompleted_NoReply(t *testing.T) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -126,6 +126,26 @@ func TestMuxAddr(t *testing.T) {
 	}
 }
 
+func TestMuxOptInCmd(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+
+	if m := makeMux("dst1", &ClientOption{
+		ClientTrackingOptions: []string{"OPTOUT"},
+	}, nil); m.OptInCmd() != cmds.OptInNopCmd {
+		t.Fatalf("unexpected OptInCmd")
+	}
+	if m := makeMux("dst1", &ClientOption{
+		ClientTrackingOptions: []string{"PREFIX", "a", "BCAST"},
+	}, nil); m.OptInCmd() != cmds.OptInNopCmd {
+		t.Fatalf("unexpected OptInCmd")
+	}
+	if m := makeMux("dst1", &ClientOption{
+		ClientTrackingOptions: nil,
+	}, nil); m.OptInCmd() != cmds.OptInCmd {
+		t.Fatalf("unexpected OptInCmd")
+	}
+}
+
 func TestMuxDialSuppress(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	var wires, waits, done int64


### PR DESCRIPTION
closes https://github.com/redis/rueidis/issues/799