### PR TITLE
feat: reduce size of redis message

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -137,7 +137,7 @@ func (a *adapter) Delete(keys []RedisMessage) {
 		}
 	} else {
 		for _, k := range keys {
-			a.del(k.string)
+			a.del(k.string())
 		}
 	}
 	a.mu.Unlock()

--- a/cache_test.go
+++ b/cache_test.go
@@ -23,14 +23,14 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("flights before Update should return empty RedisMessage and non-nil CacheEntry")
 		}
 
-		store.Delete([]RedisMessage{redisMessageContainString('+', "key")}) // Delete should not affect pending CacheEntry
+		store.Delete([]RedisMessage{strmsg('+', "key")}) // Delete should not affect pending CacheEntry
 
 		v2, e2 := store.Flight("key", "cmd", time.Millisecond*100, now)
 		if v2.typ != 0 || e != e2 {
 			t.Fatal("flights before Update should return empty RedisMessage and the same CacheEntry, not be affected by Delete")
 		}
 
-		v = redisMessageContainString('+', "val")
+		v = strmsg('+', "val")
 		v.setExpireAt(now.Add(time.Second).UnixMilli())
 		if pttl := store.Update("key", "cmd", v); pttl < now.Add(90*time.Millisecond).UnixMilli() || pttl > now.Add(100*time.Millisecond).UnixMilli() {
 			t.Fatal("Update should return a desired pttl")
@@ -52,7 +52,7 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("CachePXAT should return a desired pttl")
 		}
 
-		store.Delete([]RedisMessage{redisMessageContainString('+', "key")})
+		store.Delete([]RedisMessage{strmsg('+', "key")})
 		v, e = store.Flight("key", "cmd", time.Millisecond*100, now)
 		if v.typ != 0 || e != nil {
 			t.Fatal("flights after Delete should return empty RedisMessage and nil CacheEntry")
@@ -74,7 +74,7 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("flights before Update should return empty RedisMessage and non-nil CacheEntry")
 		}
 
-		store.Delete([]RedisMessage{redisMessageContainString('+', "key")}) // Delete should not affect pending CacheEntry
+		store.Delete([]RedisMessage{strmsg('+', "key")}) // Delete should not affect pending CacheEntry
 
 		v2, e2 := store.Flight("key", "cmd", time.Millisecond*100, now)
 		if v2.typ != 0 || e != e2 {
@@ -99,13 +99,13 @@ func test(t *testing.T, storeFn func() CacheStore) {
 		var store = storeFn()
 
 		for _, deletions := range [][]RedisMessage{
-			{redisMessageContainString('+', "key")},
+			{strmsg('+', "key")},
 			nil,
 		} {
 			store.Flight("key", "cmd1", time.Millisecond*100, now)
 			store.Flight("key", "cmd2", time.Millisecond*100, now)
-			store.Update("key", "cmd1", redisMessageContainString('+', "val"))
-			store.Update("key", "cmd2", redisMessageContainString('+', "val"))
+			store.Update("key", "cmd1", strmsg('+', "val"))
+			store.Update("key", "cmd2", strmsg('+', "val"))
 
 			store.Delete(deletions)
 
@@ -128,7 +128,7 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("first flight should return empty RedisMessage and nil CacheEntry")
 		}
 
-		v = redisMessageContainString('+', "val")
+		v = strmsg('+', "val")
 		v.setExpireAt(now.Add(time.Millisecond).UnixMilli())
 		store.Update("key", "cmd", v)
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -23,21 +23,21 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("flights before Update should return empty RedisMessage and non-nil CacheEntry")
 		}
 
-		store.Delete([]RedisMessage{{typ: '+', string: "key"}}) // Delete should not affect pending CacheEntry
+		store.Delete([]RedisMessage{redisMessageContainString('+', "key")}) // Delete should not affect pending CacheEntry
 
 		v2, e2 := store.Flight("key", "cmd", time.Millisecond*100, now)
 		if v2.typ != 0 || e != e2 {
 			t.Fatal("flights before Update should return empty RedisMessage and the same CacheEntry, not be affected by Delete")
 		}
 
-		v = RedisMessage{typ: '+', string: "val"}
+		v = redisMessageContainString('+', "val")
 		v.setExpireAt(now.Add(time.Second).UnixMilli())
 		if pttl := store.Update("key", "cmd", v); pttl < now.Add(90*time.Millisecond).UnixMilli() || pttl > now.Add(100*time.Millisecond).UnixMilli() {
 			t.Fatal("Update should return a desired pttl")
 		}
 
 		v2, err = e.Wait(context.Background())
-		if v2.typ != v.typ || v2.string != v.string || err != nil {
+		if v2.typ != v.typ || v2.string() != v.string() || err != nil {
 			t.Fatal("unexpected cache response")
 		}
 		if pttl := v2.CachePXAT(); pttl < now.Add(90*time.Millisecond).UnixMilli() || pttl > now.Add(100*time.Millisecond).UnixMilli() {
@@ -45,14 +45,14 @@ func test(t *testing.T, storeFn func() CacheStore) {
 		}
 
 		v2, _ = store.Flight("key", "cmd", time.Millisecond*100, now)
-		if v2.typ != v.typ || v2.string != v.string {
+		if v2.typ != v.typ || v2.string() != v.string() {
 			t.Fatal("flights after Update should return updated RedisMessage")
 		}
 		if pttl := v2.CachePXAT(); pttl < now.Add(90*time.Millisecond).UnixMilli() || pttl > now.Add(100*time.Millisecond).UnixMilli() {
 			t.Fatal("CachePXAT should return a desired pttl")
 		}
 
-		store.Delete([]RedisMessage{{typ: '+', string: "key"}})
+		store.Delete([]RedisMessage{redisMessageContainString('+', "key")})
 		v, e = store.Flight("key", "cmd", time.Millisecond*100, now)
 		if v.typ != 0 || e != nil {
 			t.Fatal("flights after Delete should return empty RedisMessage and nil CacheEntry")
@@ -74,7 +74,7 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("flights before Update should return empty RedisMessage and non-nil CacheEntry")
 		}
 
-		store.Delete([]RedisMessage{{typ: '+', string: "key"}}) // Delete should not affect pending CacheEntry
+		store.Delete([]RedisMessage{redisMessageContainString('+', "key")}) // Delete should not affect pending CacheEntry
 
 		v2, e2 := store.Flight("key", "cmd", time.Millisecond*100, now)
 		if v2.typ != 0 || e != e2 {
@@ -99,13 +99,13 @@ func test(t *testing.T, storeFn func() CacheStore) {
 		var store = storeFn()
 
 		for _, deletions := range [][]RedisMessage{
-			{{typ: '+', string: "key"}},
+			{redisMessageContainString('+', "key")},
 			nil,
 		} {
 			store.Flight("key", "cmd1", time.Millisecond*100, now)
 			store.Flight("key", "cmd2", time.Millisecond*100, now)
-			store.Update("key", "cmd1", RedisMessage{typ: '+', string: "val"})
-			store.Update("key", "cmd2", RedisMessage{typ: '+', string: "val"})
+			store.Update("key", "cmd1", redisMessageContainString('+', "val"))
+			store.Update("key", "cmd2", redisMessageContainString('+', "val"))
 
 			store.Delete(deletions)
 
@@ -128,7 +128,7 @@ func test(t *testing.T, storeFn func() CacheStore) {
 			t.Fatal("first flight should return empty RedisMessage and nil CacheEntry")
 		}
 
-		v = RedisMessage{typ: '+', string: "val"}
+		v = redisMessageContainString('+', "val")
 		v.setExpireAt(now.Add(time.Millisecond).UnixMilli())
 		store.Update("key", "cmd", v)
 

--- a/client_test.go
+++ b/client_test.go
@@ -280,7 +280,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(RedisMessage{typ: '+', string: "Do"}, nil)
+			return newResult(redisMessageContainString('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -303,7 +303,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -332,7 +332,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)
+			return newResult(redisMessageContainString('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -345,7 +345,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -419,10 +419,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -485,10 +485,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -688,7 +688,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
+			newResult(redisMessageContainString('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -739,7 +739,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
+			newResult(redisMessageContainString('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -758,7 +758,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
+			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -817,7 +817,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
+			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -836,7 +836,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoCacheFn = makeDoCacheFn(
 			newErrResult(ErrClosing),
-			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
+			newResult(redisMessageContainString('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -887,7 +887,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoCacheFn = makeDoCacheFn(
 			newErrResult(ErrClosing),
-			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
+			newResult(redisMessageContainString('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -898,7 +898,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
+			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -957,7 +957,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
+			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1024,7 +1024,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
+			newResult(redisMessageContainString('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1066,7 +1066,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(RedisMessage{typ: '+', string: "Do"}, nil),
+			newResult(redisMessageContainString('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1109,7 +1109,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
+			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1151,7 +1151,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)},
+			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1282,9 +1282,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1301,9 +1301,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "ERR some other error"}, nil)
+				return newResult(redisMessageContainString('-', "ERR some other error"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1320,9 +1320,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1341,9 +1341,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1358,9 +1358,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1379,9 +1379,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -1402,9 +1402,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 

--- a/client_test.go
+++ b/client_test.go
@@ -280,7 +280,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(redisMessageContainString('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -303,7 +303,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Do"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -332,7 +332,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(redisMessageContainString('+', "DoCache"), nil)
+			return newResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -345,7 +345,7 @@ func TestSingleClient(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "DoCache"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -419,10 +419,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -485,10 +485,10 @@ func TestSingleClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -688,7 +688,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(redisMessageContainString('+', "Do"), nil),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -739,7 +739,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(redisMessageContainString('+', "Do"), nil),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.Do(context.Background(), c.B().Get().Key("Do").Build()).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -758,7 +758,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
+			[]RedisResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -817,7 +817,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
+			[]RedisResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMulti(context.Background(), c.B().Get().Key("Do").Build())[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -836,7 +836,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoCacheFn = makeDoCacheFn(
 			newErrResult(ErrClosing),
-			newResult(redisMessageContainString('+', "Do"), nil),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -887,7 +887,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoCacheFn = makeDoCacheFn(
 			newErrResult(ErrClosing),
-			newResult(redisMessageContainString('+', "Do"), nil),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		if v, err := c.DoCache(context.Background(), c.B().Get().Key("Do").Cache(), 0).ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -898,7 +898,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
+			[]RedisResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -957,7 +957,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		}
 		m.DoMultiCacheFn = makeDoMultiCacheFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
+			[]RedisResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		if v, err := c.DoMultiCache(context.Background(), CT(c.B().Get().Key("Do").Cache(), 0))[0].ToString(); !errors.Is(err, ErrClosing) {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -1024,7 +1024,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(redisMessageContainString('+', "Do"), nil),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1066,7 +1066,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoFn = makeDoFn(
 			newErrResult(ErrClosing),
-			newResult(redisMessageContainString('+', "Do"), nil),
+			newResult(strmsg('+', "Do"), nil),
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1109,7 +1109,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
+			[]RedisResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1151,7 +1151,7 @@ func SetupClientRetry(t *testing.T, fn func(mock *mockConn) Client) {
 		c, m := setup()
 		m.DoMultiFn = makeDoMultiFn(
 			[]RedisResult{newErrResult(ErrClosing)},
-			[]RedisResult{newResult(redisMessageContainString('+', "Do"), nil)},
+			[]RedisResult{newResult(strmsg('+', "Do"), nil)},
 		)
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 		if ret := c.Dedicated(func(cc DedicatedClient) error {
@@ -1282,9 +1282,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1301,9 +1301,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "ERR some other error"), nil)
+				return newResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1320,9 +1320,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1341,9 +1341,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1358,9 +1358,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1379,9 +1379,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoFn = func(cmd Completed) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -1402,9 +1402,9 @@ func TestSingleClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 

--- a/cluster.go
+++ b/cluster.go
@@ -196,7 +196,7 @@ func (c *clusterClient) _refresh() (err error) {
 		}
 		result = <-results
 		err = result.reply.Error()
-		if len(result.reply.val.values) != 0 {
+		if len(result.reply.val.values()) != 0 {
 			break
 		}
 	}
@@ -354,23 +354,23 @@ func parseEndpoint(fallback, endpoint string, port int64) string {
 // parseSlots - map redis slots for each redis nodes/addresses
 // defaultAddr is needed in case the node does not know its own IP
 func parseSlots(slots RedisMessage, defaultAddr string) map[string]group {
-	groups := make(map[string]group, len(slots.values))
-	for _, v := range slots.values {
-		master := parseEndpoint(defaultAddr, v.values[2].values[0].string, v.values[2].values[1].integer)
+	groups := make(map[string]group, len(slots.values()))
+	for _, v := range slots.values() {
+		master := parseEndpoint(defaultAddr, v.values()[2].values()[0].string(), v.values()[2].values()[1].integer)
 		if master == "" {
 			continue
 		}
 		g, ok := groups[master]
 		if !ok {
 			g.slots = make([][2]int64, 0)
-			g.nodes = make(nodes, 0, len(v.values)-2)
-			for i := 2; i < len(v.values); i++ {
-				if dst := parseEndpoint(defaultAddr, v.values[i].values[0].string, v.values[i].values[1].integer); dst != "" {
+			g.nodes = make(nodes, 0, len(v.values())-2)
+			for i := 2; i < len(v.values()); i++ {
+				if dst := parseEndpoint(defaultAddr, v.values()[i].values()[0].string(), v.values()[i].values()[1].integer); dst != "" {
 					g.nodes = append(g.nodes, ReplicaInfo{Addr: dst})
 				}
 			}
 		}
-		g.slots = append(g.slots, [2]int64{v.values[0].integer, v.values[1].integer})
+		g.slots = append(g.slots, [2]int64{v.values()[0].integer, v.values()[1].integer})
 		groups[master] = g
 	}
 	return groups
@@ -379,12 +379,14 @@ func parseSlots(slots RedisMessage, defaultAddr string) map[string]group {
 // parseShards - map redis shards for each redis nodes/addresses
 // defaultAddr is needed in case the node does not know its own IP
 func parseShards(shards RedisMessage, defaultAddr string, tls bool) map[string]group {
-	groups := make(map[string]group, len(shards.values))
-	for _, v := range shards.values {
+	groups := make(map[string]group, len(shards.values()))
+	for _, v := range shards.values() {
 		m := -1
 		shard, _ := v.AsMap()
-		slots := shard["slots"].values
-		_nodes := shard["nodes"].values
+		shardSlots := shard["slots"]
+		shardNodes := shard["nodes"]
+		slots := shardSlots.values()
+		_nodes := shardNodes.values()
 		g := group{
 			nodes: make(nodes, 0, len(_nodes)),
 			slots: make([][2]int64, len(slots)/2),
@@ -395,15 +397,16 @@ func parseShards(shards RedisMessage, defaultAddr string, tls bool) map[string]g
 		}
 		for _, n := range _nodes {
 			dict, _ := n.AsMap()
-			if dict["health"].string != "online" {
+			if dictHealth := dict["health"]; dictHealth.string() != "online" {
 				continue
 			}
 			port := dict["port"].integer
 			if tls && dict["tls-port"].integer > 0 {
 				port = dict["tls-port"].integer
 			}
-			if dst := parseEndpoint(defaultAddr, dict["endpoint"].string, port); dst != "" {
-				if dict["role"].string == "master" {
+			dictEndpoint := dict["endpoint"]
+			if dst := parseEndpoint(defaultAddr, dictEndpoint.string(), port); dst != "" {
+				if dictRole := dict["role"]; dictRole.string() == "master" {
 					m = len(g.nodes)
 				}
 				g.nodes = append(g.nodes, ReplicaInfo{Addr: dst})
@@ -695,7 +698,7 @@ func (c *clusterClient) doresultfn(
 				}
 				for ei = i; ei < len(commands) && !isMulti(commands[ei]) && !isExec(commands[ei]); ei++ {
 				}
-				if mi >= 0 && ei < len(commands) && isMulti(commands[mi]) && isExec(commands[ei]) && resps[mi].val.string == ok { // a transaction is found.
+				if mi >= 0 && ei < len(commands) && isMulti(commands[mi]) && isExec(commands[ei]) && resps[mi].val.string() == ok { // a transaction is found.
 					mu.Lock()
 					retries.Redirects++
 					nr := retries.m[nc]

--- a/cluster.go
+++ b/cluster.go
@@ -356,7 +356,7 @@ func parseEndpoint(fallback, endpoint string, port int64) string {
 func parseSlots(slots RedisMessage, defaultAddr string) map[string]group {
 	groups := make(map[string]group, len(slots.values()))
 	for _, v := range slots.values() {
-		master := parseEndpoint(defaultAddr, v.values()[2].values()[0].string(), v.values()[2].values()[1].integer)
+		master := parseEndpoint(defaultAddr, v.values()[2].values()[0].string(), v.values()[2].values()[1].intlen)
 		if master == "" {
 			continue
 		}
@@ -365,12 +365,12 @@ func parseSlots(slots RedisMessage, defaultAddr string) map[string]group {
 			g.slots = make([][2]int64, 0)
 			g.nodes = make(nodes, 0, len(v.values())-2)
 			for i := 2; i < len(v.values()); i++ {
-				if dst := parseEndpoint(defaultAddr, v.values()[i].values()[0].string(), v.values()[i].values()[1].integer); dst != "" {
+				if dst := parseEndpoint(defaultAddr, v.values()[i].values()[0].string(), v.values()[i].values()[1].intlen); dst != "" {
 					g.nodes = append(g.nodes, ReplicaInfo{Addr: dst})
 				}
 			}
 		}
-		g.slots = append(g.slots, [2]int64{v.values()[0].integer, v.values()[1].integer})
+		g.slots = append(g.slots, [2]int64{v.values()[0].intlen, v.values()[1].intlen})
 		groups[master] = g
 	}
 	return groups
@@ -400,9 +400,9 @@ func parseShards(shards RedisMessage, defaultAddr string, tls bool) map[string]g
 			if dictHealth := dict["health"]; dictHealth.string() != "online" {
 				continue
 			}
-			port := dict["port"].integer
-			if tls && dict["tls-port"].integer > 0 {
-				port = dict["tls-port"].integer
+			port := dict["port"].intlen
+			if tls && dict["tls-port"].intlen > 0 {
+				port = dict["tls-port"].intlen
 			}
 			dictEndpoint := dict["endpoint"]
 			if dst := parseEndpoint(defaultAddr, dictEndpoint.string(), port); dst != "" {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -16,684 +16,684 @@ import (
 	"time"
 )
 
-var slotsResp = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var slotsResp = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 16383},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.0.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica
-			{typ: '+', string: "127.0.1.1"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica
+			redisMessageContainString('+', "127.0.1.1"),
 			{typ: ':', integer: 1},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var slotsMultiResp = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var slotsMultiResp = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 8192},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.0.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica
-			{typ: '+', string: "127.0.1.1"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica
+			redisMessageContainString('+', "127.0.1.1"),
 			{typ: ':', integer: 1},
-			{typ: '+', string: ""},
-		}},
-	}},
-	{typ: '*', values: []RedisMessage{
+			redisMessageContainString('+', ""),
+		}),
+	}),
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 8193},
 		{typ: ':', integer: 16383},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.2.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.2.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica
-			{typ: '+', string: "127.0.3.1"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica
+			redisMessageContainString('+', "127.0.3.1"),
 			{typ: ':', integer: 1},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var slotsMultiRespWithoutReplicas = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var slotsMultiRespWithoutReplicas = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 8192},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.0.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-	}},
-	{typ: '*', values: []RedisMessage{
+			redisMessageContainString('+', ""),
+		}),
+	}),
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 8193},
 		{typ: ':', integer: 16383},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.1.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.1.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var slotsMultiRespWithMultiReplicas = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var slotsMultiRespWithMultiReplicas = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 8192},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.0.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica1
-			{typ: '+', string: "127.0.0.2"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica1
+			redisMessageContainString('+', "127.0.0.2"),
 			{typ: ':', integer: 1},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica2
-			{typ: '+', string: "127.0.0.3"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica2
+			redisMessageContainString('+', "127.0.0.3"),
 			{typ: ':', integer: 2},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica3
-			{typ: '+', string: "127.0.0.4"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica3
+			redisMessageContainString('+', "127.0.0.4"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: ""},
-		}},
-	}},
-	{typ: '*', values: []RedisMessage{
+			redisMessageContainString('+', ""),
+		}),
+	}),
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 8193},
 		{typ: ':', integer: 16383},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.1.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.1.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica1
-			{typ: '+', string: "127.0.1.2"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica1
+			redisMessageContainString('+', "127.0.1.2"),
 			{typ: ':', integer: 1},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica2
-			{typ: '+', string: "127.0.1.3"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica2
+			redisMessageContainString('+', "127.0.1.3"),
 			{typ: ':', integer: 2},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica3
-			{typ: '+', string: "127.0.1.4"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica3
+			redisMessageContainString('+', "127.0.1.4"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var singleSlotResp = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var singleSlotResp = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.0.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var singleSlotResp2 = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var singleSlotResp2 = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "127.0.3.1"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "127.0.3.1"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var singleSlotWithoutIP = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: '*', values: []RedisMessage{
+var singleSlotWithoutIP = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: ""},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', ""),
 			{typ: ':', integer: 4},
-			{typ: '+', string: ""},
-		}},
-		{typ: '*', values: []RedisMessage{ // replica
-			{typ: '+', string: "?"},
+			redisMessageContainString('+', ""),
+		}),
+		redisMessageContainSlice('*', []RedisMessage{ // replica
+			redisMessageContainString('+', "?"),
 			{typ: ':', integer: 1},
-			{typ: '+', string: ""},
-		}},
-	}},
-	{typ: '*', values: []RedisMessage{
+			redisMessageContainString('+', ""),
+		}),
+	}),
+	redisMessageContainSlice('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		{typ: '*', values: []RedisMessage{ // master
-			{typ: '+', string: "?"},
+		redisMessageContainSlice('*', []RedisMessage{ // master
+			redisMessageContainString('+', "?"),
 			{typ: ':', integer: 4},
-			{typ: '+', string: ""},
-		}},
-	}},
-}}, nil)
+			redisMessageContainString('+', ""),
+		}),
+	}),
+}), nil)
 
-var shardsResp = newResult(RedisMessage{typ: typeArray, values: []RedisMessage{
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "0"},
-			{typ: typeBlobString, string: "16383"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // failed master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+var shardsResp = newResult(redisMessageContainSlice(typeArray, []RedisMessage{
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "0"),
+			redisMessageContainString(typeBlobString, "16383"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.0.99"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.0.99"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.0.99"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.0.99"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "fail"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "fail"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.0.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.0.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.0.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.0.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // replica
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.1.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.1.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.1.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.1.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "replica"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "replica"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-}}, nil)
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+}), nil)
 
-var shardsRespTls = newResult(RedisMessage{typ: typeArray, values: []RedisMessage{
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "0"},
-			{typ: typeBlobString, string: "16383"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // replica, tls
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+var shardsRespTls = newResult(redisMessageContainSlice(typeArray, []RedisMessage{
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "0"),
+			redisMessageContainString(typeBlobString, "16383"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // replica, tls
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "tls-port"},
+				redisMessageContainString(typeBlobString, "tls-port"),
 				{typ: typeInteger, integer: 2},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.2.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.2.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.2.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.2.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "replica"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "replica"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // failed master, tls + port
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master, tls + port
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "tls-port"},
+				redisMessageContainString(typeBlobString, "tls-port"),
 				{typ: typeInteger, integer: 1},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.1.99"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.1.99"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.1.99"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.1.99"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "fail"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // master, tls + port
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "fail"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master, tls + port
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "tls-port"},
+				redisMessageContainString(typeBlobString, "tls-port"),
 				{typ: typeInteger, integer: 1},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.1.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.1.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.1.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.1.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // replica, port
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // replica, port
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 3},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.3.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.3.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.3.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.3.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "replica"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "replica"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-}}, nil)
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+}), nil)
 
-var shardsMultiResp = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "0"},
-			{typ: typeBlobString, string: "8192"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // failed master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+var shardsMultiResp = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "0"),
+			redisMessageContainString(typeBlobString, "8192"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.0.99"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.0.99"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.0.99"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.0.99"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "fail"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "fail"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.0.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.0.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.0.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.0.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // replica
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.1.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.1.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.1.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.1.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "replica"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "replica"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "8193"},
-			{typ: typeBlobString, string: "16383"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // failed master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "8193"),
+			redisMessageContainString(typeBlobString, "16383"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.2.99"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.2.99"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.2.99"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.2.99"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "fail"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "fail"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.2.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.2.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.2.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.2.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // replica
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.3.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.3.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.3.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.3.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "replica"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "replica"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-}}, nil)
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+}), nil)
 
-var singleShardResp2 = newResult(RedisMessage{typ: '*', values: []RedisMessage{
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "0"},
-			{typ: typeBlobString, string: "0"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // failed master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+var singleShardResp2 = newResult(redisMessageContainSlice('*', []RedisMessage{
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "0"),
+			redisMessageContainString(typeBlobString, "0"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 3},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.3.99"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.3.99"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.3.99"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.3.99"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "fail"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "fail"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 3},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "127.0.3.1"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "127.0.3.1"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "127.0.3.1"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "127.0.3.1"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-}}, nil)
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+}), nil)
 
-var singleShardWithoutIP = newResult(RedisMessage{typ: typeArray, values: []RedisMessage{
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "0"},
-			{typ: typeBlobString, string: "0"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // failed master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+var singleShardWithoutIP = newResult(redisMessageContainSlice(typeArray, []RedisMessage{
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "0"),
+			redisMessageContainString(typeBlobString, "0"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 4},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "fail"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "fail"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 4},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-			{typ: typeMap, values: []RedisMessage{ // replica
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "?"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "?"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "?"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "?"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "replica"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "replica"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-	{typ: typeMap, values: []RedisMessage{
-		{typ: typeBlobString, string: "slots"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeBlobString, string: "0"},
-			{typ: typeBlobString, string: "0"},
-		}},
-		{typ: typeBlobString, string: "nodes"},
-		{typ: typeArray, values: []RedisMessage{
-			{typ: typeMap, values: []RedisMessage{ // master
-				{typ: typeBlobString, string: "id"},
-				{typ: typeBlobString, string: ""},
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+	redisMessageContainSlice(typeMap, []RedisMessage{
+		redisMessageContainString(typeBlobString, "slots"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainString(typeBlobString, "0"),
+			redisMessageContainString(typeBlobString, "0"),
+		}),
+		redisMessageContainString(typeBlobString, "nodes"),
+		redisMessageContainSlice(typeArray, []RedisMessage{
+			redisMessageContainSlice(typeMap, []RedisMessage{ // master
+				redisMessageContainString(typeBlobString, "id"),
+				redisMessageContainString(typeBlobString, ""),
 
-				{typ: typeBlobString, string: "port"},
+				redisMessageContainString(typeBlobString, "port"),
 				{typ: typeInteger, integer: 4},
 
-				{typ: typeBlobString, string: "ip"},
-				{typ: typeBlobString, string: "?"},
+				redisMessageContainString(typeBlobString, "ip"),
+				redisMessageContainString(typeBlobString, "?"),
 
-				{typ: typeBlobString, string: "endpoint"},
-				{typ: typeBlobString, string: "?"},
+				redisMessageContainString(typeBlobString, "endpoint"),
+				redisMessageContainString(typeBlobString, "?"),
 
-				{typ: typeBlobString, string: "role"},
-				{typ: typeBlobString, string: "master"},
+				redisMessageContainString(typeBlobString, "role"),
+				redisMessageContainString(typeBlobString, "master"),
 
-				{typ: typeBlobString, string: "replication-offset"},
+				redisMessageContainString(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				{typ: typeBlobString, string: "health"},
-				{typ: typeBlobString, string: "online"},
-			}},
-		}},
-	}},
-}}, nil)
+				redisMessageContainString(typeBlobString, "health"),
+				redisMessageContainString(typeBlobString, "online"),
+			}),
+		}),
+	}),
+}), nil)
 
 //gocyclo:ignore
 func TestClusterClientInit(t *testing.T) {
@@ -742,7 +742,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(RedisMessage{typ: '*', values: []RedisMessage{}}, nil)
+							return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
 						}
 						return slotsResp
 					},
@@ -762,7 +762,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(RedisMessage{typ: '*', values: []RedisMessage{}}, nil)
+							return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
 						}
 						return shardsResp
 					},
@@ -781,7 +781,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
-						return newResult(RedisMessage{typ: '*', values: []RedisMessage{}}, nil)
+						return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
 					},
 				}
 			},
@@ -797,7 +797,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
-						return newResult(RedisMessage{typ: '*', values: []RedisMessage{}}, nil)
+						return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
 					},
 					VersionFn: func() int { return 8 },
 				}
@@ -1541,7 +1541,7 @@ func TestClusterClient(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
@@ -1551,21 +1551,21 @@ func TestClusterClient(t *testing.T) {
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Do"}, nil)
+				return newResult(redisMessageContainString('+', "Do"), nil)
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Info"}, nil)
+				return newResult(redisMessageContainString('+', "Info"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)
+				return newResult(redisMessageContainString('+', "DoCache"), nil)
 			},
 		},
 	}
@@ -1816,9 +1816,9 @@ func TestClusterClient(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
 					}}
 				},
 			}
@@ -1879,23 +1879,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -1956,7 +1956,7 @@ func TestClusterClient(t *testing.T) {
 				c.B().Get().Key("a").Build(),
 				c.B().Get().Key("a").Build(),
 				c.B().Exec().Build(),
-			)[3].val.values {
+			)[3].val.values() {
 				if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 					t.Fatalf("unexpected response %v %v", v, err)
 				}
@@ -1987,23 +1987,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2064,7 +2064,7 @@ func TestClusterClient(t *testing.T) {
 			c.B().Get().Key("a").Build(),
 			c.B().Get().Key("a").Build(),
 			c.B().Exec().Build(),
-		)[3].val.values {
+		)[3].val.values() {
 			if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
@@ -2201,40 +2201,40 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET Do"}, nil)
+				return newResult(redisMessageContainString('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "INFO"}, nil)
+				return newResult(redisMessageContainString('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET DoCache"}, nil)
+				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
@@ -2416,9 +2416,9 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2479,23 +2479,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2556,7 +2556,7 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 				c.B().Get().Key("a").Build(),
 				c.B().Get().Key("a").Build(),
 				c.B().Exec().Build(),
-			)[3].val.values {
+			)[3].val.values() {
 				if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 					t.Fatalf("unexpected response %v %v", v, err)
 				}
@@ -2587,23 +2587,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2664,7 +2664,7 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 			c.B().Get().Key("a").Build(),
 			c.B().Get().Key("a").Build(),
 			c.B().Exec().Build(),
-		)[3].val.values {
+		)[3].val.values() {
 			if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
@@ -2700,10 +2700,10 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "INFO"}, nil)
+				return newResult(redisMessageContainString('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 		},
 	}
@@ -2711,31 +2711,31 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET Do"}, nil)
+				return newResult(redisMessageContainString('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET DoCache"}, nil)
+				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -2905,9 +2905,9 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2971,23 +2971,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3048,7 +3048,7 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 				c.B().Get().Key("a").Build(),
 				c.B().Get().Key("a").Build(),
 				c.B().Exec().Build(),
-			)[3].val.values {
+			)[3].val.values() {
 				if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 					t.Fatalf("unexpected response %v %v", v, err)
 				}
@@ -3079,23 +3079,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3156,7 +3156,7 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 			c.B().Get().Key("a").Build(),
 			c.B().Get().Key("a").Build(),
 			c.B().Exec().Build(),
-		)[3].val.values {
+		)[3].val.values() {
 			if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
@@ -3192,32 +3192,32 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "INFO"}, nil)
+				return newResult(redisMessageContainString('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "SET Do V"}, nil)
+				return newResult(redisMessageContainString('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "SET K2{a} V2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: "MULTI"}, nil)
+					resps[i] = newResult(redisMessageContainString('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: "EXEC"}, nil)
+					resps[i] = newResult(redisMessageContainString('+', "EXEC"), nil)
 					continue
 				}
 
@@ -3231,20 +3231,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET Do"}, nil)
+				return newResult(redisMessageContainString('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3256,20 +3256,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET DoCache"}, nil)
+				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3495,9 +3495,9 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3561,23 +3561,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3638,7 +3638,7 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 				c.B().Get().Key("a").Build(),
 				c.B().Get().Key("a").Build(),
 				c.B().Exec().Build(),
-			)[3].val.values {
+			)[3].val.values() {
 				if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 					t.Fatalf("unexpected response %v %v", v, err)
 				}
@@ -3669,23 +3669,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3746,7 +3746,7 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 			c.B().Get().Key("a").Build(),
 			c.B().Get().Key("a").Build(),
 			c.B().Exec().Build(),
-		)[3].val.values {
+		)[3].val.values() {
 			if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
@@ -3782,18 +3782,18 @@ func TestClusterClient_SendPrimaryNodeOnlyButOneSlotAssigned(t *testing.T) {
 				return singleSlotResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "INFO"}, nil)
+				return newResult(redisMessageContainString('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: "MULTI"}, nil)
+					resps[i] = newResult(redisMessageContainString('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: "EXEC"}, nil)
+					resps[i] = newResult(redisMessageContainString('+', "EXEC"), nil)
 					continue
 				}
 
@@ -4064,9 +4064,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(RedisMessage{typ: '-', string: "MOVED 0 :0"}, nil)
+						return newResult(redisMessageContainString('-', "MOVED 0 :0"), nil)
 					}
-					return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+					return newResult(redisMessageContainString('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4092,9 +4092,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
+						return newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
 					}
-					return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+					return newResult(redisMessageContainString('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4120,10 +4120,10 @@ func TestClusterClientErr(t *testing.T) {
 
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+							return newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+						return newResult(redisMessageContainString('+', "b"), nil)
 					},
 				}
 			},
@@ -4155,12 +4155,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -4190,13 +4190,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+								ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+							ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -4230,34 +4230,34 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '+', string: "7"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "2"},
-								{typ: '+', string: "3"},
-							}}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "5"},
-								{typ: '+', string: "6"},
-							}}, nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "2"),
+								redisMessageContainString('+', "3"),
+							}), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "5"),
+								redisMessageContainString('+', "6"),
+							}), nil),
 						}}
 					}
 					return nil
@@ -4328,36 +4328,36 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '+', string: "7"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "2"},
-								{typ: '+', string: "3"},
-							}}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "5"},
-								{typ: '+', string: "6"},
-							}}, nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "2"),
+								redisMessageContainString('+', "3"),
+							}), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "5"),
+								redisMessageContainString('+', "6"),
+							}), nil),
 						}}
 					}
 					return nil
@@ -4428,29 +4428,29 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "2"},
-								{typ: '+', string: "3"},
-							}}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "5"},
-								{typ: '+', string: "6"},
-							}}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "2"),
+								redisMessageContainString('+', "3"),
+							}), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "5"),
+								redisMessageContainString('+', "6"),
+							}), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
-							newResult(RedisMessage{typ: '+', string: "7"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(redisMessageContainString('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4521,32 +4521,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "2"},
-								{typ: '+', string: "3"},
-							}}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "5"},
-								{typ: '+', string: "6"},
-							}}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "2"),
+								redisMessageContainString('+', "3"),
+							}), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "5"),
+								redisMessageContainString('+', "6"),
+							}), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "7"}, nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4617,35 +4617,35 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '+', string: "7"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "2"},
-								{typ: '+', string: "3"},
-							}}, nil),
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "5"},
-								{typ: '+', string: "6"},
-							}}, nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "2"),
+								redisMessageContainString('+', "3"),
+							}), nil),
+							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "5"),
+								redisMessageContainString('+', "6"),
+							}), nil),
 						}}
 					}
 					return nil
@@ -4716,38 +4716,38 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '+', string: "7"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "2"},
-								{typ: '+', string: "3"},
-							}}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '+', string: "QUEUED"}, nil),
-							newResult(RedisMessage{typ: '*', values: []RedisMessage{
-								{typ: '+', string: "5"},
-								{typ: '+', string: "6"},
-							}}, nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "2"),
+								redisMessageContainString('+', "3"),
+							}), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainString('+', "QUEUED"), nil),
+							newResult(redisMessageContainSlice('*', []RedisMessage{
+								redisMessageContainString('+', "5"),
+								redisMessageContainString('+', "6"),
+							}), nil),
 						}}
 					}
 					return nil
@@ -4818,17 +4818,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ERR Command not allowed inside a transaction"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
+							newResult(redisMessageContainString('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -4883,17 +4883,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ERR Command not allowed inside a transaction"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "EXECABORT"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "EXECABORT"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "4"}, nil),
+							newResult(redisMessageContainString('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -4948,11 +4948,11 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(RedisMessage{typ: '+', string: "1"}, nil),
-							newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
-							newResult(RedisMessage{typ: '-', string: "ERR Command not allowed inside a transaction"}, nil),
-							newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil),
+							newResult(redisMessageContainString('+', "1"), nil),
+							newResult(redisMessageContainString('+', "OK"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(redisMessageContainString('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
 						}}
 					}
 					return nil
@@ -4999,12 +4999,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5036,12 +5036,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5073,9 +5073,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+						return newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 					}
-					return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+					return newResult(redisMessageContainString('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5105,12 +5105,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5142,12 +5142,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5182,12 +5182,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5217,9 +5217,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
+							return newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
 						}
-						return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+						return newResult(redisMessageContainString('+', "b"), nil)
 					},
 				}
 			},
@@ -5245,10 +5245,10 @@ func TestClusterClientErr(t *testing.T) {
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+							return newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+						return newResult(redisMessageContainString('+', "b"), nil)
 					},
 				}
 			},
@@ -5280,12 +5280,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Cmd.Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5315,13 +5315,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :2"}, nil)
+								ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Cmd.Commands()[1]}, nil)
+							ret[i] = newResult(redisMessageContainString('+', multi[i].Cmd.Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -5355,12 +5355,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(RedisMessage{typ: '-', string: "MOVED 0 :1"}, nil)
+							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(RedisMessage{typ: '+', string: multi[i].Cmd.Commands()[1]}, nil)
+						ret[i] = newResult(redisMessageContainString('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5391,13 +5391,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 							return slotsMultiResp
 						}
-						return newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
+						return newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, newResult(RedisMessage{typ: '+', string: "b"}, nil)}}
+						return &redisresults{s: []RedisResult{{}, newResult(redisMessageContainString('+', "b"), nil)}}
 					},
 				}
 			},
@@ -5424,13 +5424,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]RedisResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
+								ret[i] = newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
-							ret[i+1] = newResult(RedisMessage{typ: '+', string: multi[i+1].Commands()[1]}, nil)
+							ret[i] = newResult(redisMessageContainString('+', "OK"), nil)
+							ret[i+1] = newResult(redisMessageContainString('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -5459,13 +5459,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]RedisResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
+								ret[i] = newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
-							ret[i+1] = newResult(RedisMessage{typ: '+', string: multi[i+1].Commands()[1]}, nil)
+							ret[i] = newResult(redisMessageContainString('+', "OK"), nil)
+							ret[i+1] = newResult(redisMessageContainString('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -5497,13 +5497,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
-						return newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)
+						return newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, redisMessageContainString('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5527,13 +5527,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
-						return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {typ: '+', string: "b"}}}, nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, redisMessageContainString('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5557,18 +5557,18 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
-						return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil)}}
+						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &redisresults{s: []RedisResult{
-								{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
-								{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :1"}, nil),
+								{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
 							}}
 						}
 						return &redisresults{s: []RedisResult{
-							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[4].Commands()[1]}}}, nil),
-							{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {typ: '+', string: multi[10].Commands()[1]}}}, nil),
+							{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, redisMessageContainString('+', multi[4].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, redisMessageContainString('+', multi[10].Commands()[1])}), nil),
 						}}
 					},
 				}
@@ -5599,9 +5599,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)
+						return newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
 					}
-					return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+					return newResult(redisMessageContainString('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5623,10 +5623,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
+						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]RedisResult, len(multi))
-					ret[0] = newResult(RedisMessage{typ: '+', string: "b"}, nil)
+					ret[0] = newResult(redisMessageContainString('+', "b"), nil)
 					return &redisresults{s: ret}
 				}}
 			},
@@ -5649,10 +5649,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
+						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]RedisResult, len(multi))
-					ret[0] = newResult(RedisMessage{typ: '+', string: multi[0].Commands()[1]}, nil)
+					ret[0] = newResult(redisMessageContainString('+', multi[0].Commands()[1]), nil)
 					return &redisresults{s: ret}
 				}}
 			},
@@ -5683,9 +5683,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)
+							return newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
 						}
-						return newResult(RedisMessage{typ: '+', string: "b"}, nil)
+						return newResult(redisMessageContainString('+', "b"), nil)
 					},
 				}
 			},
@@ -5708,9 +5708,9 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
+						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
 					}
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "b"}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "b"), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5735,9 +5735,9 @@ func TestClusterClientErr(t *testing.T) {
 					return shardsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "TRYAGAIN"}, nil)}}
+						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
 					}
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: multi[0].Cmd.Commands()[1]}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', multi[0].Cmd.Commands()[1]), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -6199,9 +6199,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -6221,9 +6221,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "ERR some other error"}, nil)
+				return newResult(redisMessageContainString('-', "ERR some other error"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -6240,9 +6240,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -6261,9 +6261,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6278,9 +6278,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6302,9 +6302,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -6325,9 +6325,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -6377,9 +6377,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "MOVED 0 127.0.0.1"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "MOVED 0 127.0.0.1"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6399,9 +6399,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 127.0.0.1"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 127.0.0.1"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil), newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil), newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6442,14 +6442,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		attempts := 0
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
-			return newResult(RedisMessage{typ: '-', string: "ASK 0 :0"}, nil)
+			return newResult(redisMessageContainString('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :0"}, nil), newResult(RedisMessage{typ: '_'}, nil)}}
+				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :0"), nil), newResult(RedisMessage{typ: '_'}, nil)}}
 			}
-			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {}, {}, {}, {typ: '+', string: "OK"}}}, nil)}}
+			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, {}, {}, {}, redisMessageContainString('+', "OK")}), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -6465,14 +6465,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 
 		attempts := 0
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "ASK 0 :0"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(RedisMessage{typ: '-', string: "ASK 0 :0"}, nil), newResult(RedisMessage{typ: '_'}, nil)}}
+				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :0"), nil), newResult(RedisMessage{typ: '_'}, nil)}}
 			}
-			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(RedisMessage{typ: '*', values: []RedisMessage{{}, {}, {}, {}, {}, RedisMessage{typ: '+', string: "OK"}}}, nil)}}
+			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, {}, {}, {}, redisMessageContainString('+', "OK")}), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -6494,32 +6494,32 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "INFO"}, nil)
+				return newResult(redisMessageContainString('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "SET Do V"}, nil)
+				return newResult(redisMessageContainString('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "SET K2{a} V2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: "MULTI"}, nil)
+					resps[i] = newResult(redisMessageContainString('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: "EXEC"}, nil)
+					resps[i] = newResult(redisMessageContainString('+', "EXEC"), nil)
 					continue
 				}
 
@@ -6533,20 +6533,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET Do"}, nil)
+				return newResult(redisMessageContainString('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -6558,20 +6558,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET DoCache"}, nil)
+				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
+					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -6800,9 +6800,9 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
 					}}
 				},
 			}
@@ -6862,23 +6862,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -6939,7 +6939,7 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 				c.B().Get().Key("a").Build(),
 				c.B().Get().Key("a").Build(),
 				c.B().Exec().Build(),
-			)[3].val.values {
+			)[3].val.values() {
 				if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 					t.Fatalf("unexpected response %v %v", v, err)
 				}
@@ -6970,23 +6970,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -7047,7 +7047,7 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 			c.B().Get().Key("a").Build(),
 			c.B().Get().Key("a").Build(),
 			c.B().Exec().Build(),
-		)[3].val.values {
+		)[3].val.values() {
 			if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
@@ -7083,40 +7083,40 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET Do"}, nil)
+				return newResult(redisMessageContainString('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "INFO"}, nil)
+				return newResult(redisMessageContainString('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET DoCache"}, nil)
+				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K1{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "GET K2{a}"}, nil)
+				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(RedisMessage{typ: '+', string: strings.Join(cmd.Cmd.Commands(), " ")}, nil)
+				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
@@ -7301,9 +7301,9 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
 					}}
 				},
 			}
@@ -7364,23 +7364,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -7441,7 +7441,7 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 				c.B().Get().Key("a").Build(),
 				c.B().Get().Key("a").Build(),
 				c.B().Exec().Build(),
-			)[3].val.values {
+			)[3].val.values() {
 				if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 					t.Fatalf("unexpected response %v %v", v, err)
 				}
@@ -7472,23 +7472,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '+', string: "OK"}, nil),
-						newResult(RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "Delegate0"},
-							{typ: '+', string: "Delegate1"},
-						}}, nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainString('+', "OK"), nil),
+						newResult(redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "Delegate0"),
+							redisMessageContainString('+', "Delegate1"),
+						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(RedisMessage{typ: '+', string: "Delegate0"}, nil),
-					newResult(RedisMessage{typ: '+', string: "Delegate1"}, nil),
+					newResult(redisMessageContainString('+', "Delegate0"), nil),
+					newResult(redisMessageContainString('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -7549,7 +7549,7 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 			c.B().Get().Key("a").Build(),
 			c.B().Get().Key("a").Build(),
 			c.B().Exec().Build(),
-		)[3].val.values {
+		)[3].val.values() {
 			if v, err := resp.ToString(); err != nil || v != "Delegate"+strconv.Itoa(i) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -16,680 +16,680 @@ import (
 	"time"
 )
 
-var slotsResp = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var slotsResp = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 16383},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.0.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica
-			redisMessageContainString('+', "127.0.1.1"),
+		slicemsg('*', []RedisMessage{ // replica
+			strmsg('+', "127.0.1.1"),
 			{typ: ':', integer: 1},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var slotsMultiResp = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var slotsMultiResp = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 8192},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.0.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica
-			redisMessageContainString('+', "127.0.1.1"),
+		slicemsg('*', []RedisMessage{ // replica
+			strmsg('+', "127.0.1.1"),
 			{typ: ':', integer: 1},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
-	redisMessageContainSlice('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 8193},
 		{typ: ':', integer: 16383},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.2.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.2.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica
-			redisMessageContainString('+', "127.0.3.1"),
+		slicemsg('*', []RedisMessage{ // replica
+			strmsg('+', "127.0.3.1"),
 			{typ: ':', integer: 1},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var slotsMultiRespWithoutReplicas = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 8192},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.0.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
-	redisMessageContainSlice('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 8193},
 		{typ: ':', integer: 16383},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.1.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.1.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var slotsMultiRespWithMultiReplicas = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 8192},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.0.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica1
-			redisMessageContainString('+', "127.0.0.2"),
+		slicemsg('*', []RedisMessage{ // replica1
+			strmsg('+', "127.0.0.2"),
 			{typ: ':', integer: 1},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica2
-			redisMessageContainString('+', "127.0.0.3"),
+		slicemsg('*', []RedisMessage{ // replica2
+			strmsg('+', "127.0.0.3"),
 			{typ: ':', integer: 2},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica3
-			redisMessageContainString('+', "127.0.0.4"),
+		slicemsg('*', []RedisMessage{ // replica3
+			strmsg('+', "127.0.0.4"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
-	redisMessageContainSlice('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 8193},
 		{typ: ':', integer: 16383},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.1.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.1.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica1
-			redisMessageContainString('+', "127.0.1.2"),
+		slicemsg('*', []RedisMessage{ // replica1
+			strmsg('+', "127.0.1.2"),
 			{typ: ':', integer: 1},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica2
-			redisMessageContainString('+', "127.0.1.3"),
+		slicemsg('*', []RedisMessage{ // replica2
+			strmsg('+', "127.0.1.3"),
 			{typ: ':', integer: 2},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica3
-			redisMessageContainString('+', "127.0.1.4"),
+		slicemsg('*', []RedisMessage{ // replica3
+			strmsg('+', "127.0.1.4"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var singleSlotResp = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var singleSlotResp = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.0.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.0.1"),
 			{typ: ':', integer: 0},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var singleSlotResp2 = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var singleSlotResp2 = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "127.0.3.1"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "127.0.3.1"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var singleSlotWithoutIP = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice('*', []RedisMessage{
+var singleSlotWithoutIP = newResult(slicemsg('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', ""),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', ""),
 			{typ: ':', integer: 4},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
-		redisMessageContainSlice('*', []RedisMessage{ // replica
-			redisMessageContainString('+', "?"),
+		slicemsg('*', []RedisMessage{ // replica
+			strmsg('+', "?"),
 			{typ: ':', integer: 1},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
-	redisMessageContainSlice('*', []RedisMessage{
+	slicemsg('*', []RedisMessage{
 		{typ: ':', integer: 0},
 		{typ: ':', integer: 0},
-		redisMessageContainSlice('*', []RedisMessage{ // master
-			redisMessageContainString('+', "?"),
+		slicemsg('*', []RedisMessage{ // master
+			strmsg('+', "?"),
 			{typ: ':', integer: 4},
-			redisMessageContainString('+', ""),
+			strmsg('+', ""),
 		}),
 	}),
 }), nil)
 
-var shardsResp = newResult(redisMessageContainSlice(typeArray, []RedisMessage{
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "0"),
-			redisMessageContainString(typeBlobString, "16383"),
+var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "0"),
+			strmsg(typeBlobString, "16383"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // failed master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.0.99"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.0.99"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.0.99"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.0.99"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "fail"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "fail"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.0.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.0.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.0.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.0.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // replica
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.1.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.1.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.1.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.1.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "replica"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "replica"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
 }), nil)
 
-var shardsRespTls = newResult(redisMessageContainSlice(typeArray, []RedisMessage{
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "0"),
-			redisMessageContainString(typeBlobString, "16383"),
+var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "0"),
+			strmsg(typeBlobString, "16383"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // replica, tls
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // replica, tls
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "tls-port"),
+				strmsg(typeBlobString, "tls-port"),
 				{typ: typeInteger, integer: 2},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.2.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.2.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.2.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.2.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "replica"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "replica"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master, tls + port
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // failed master, tls + port
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "tls-port"),
+				strmsg(typeBlobString, "tls-port"),
 				{typ: typeInteger, integer: 1},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.1.99"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.1.99"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.1.99"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.1.99"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "fail"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "fail"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master, tls + port
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // master, tls + port
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "tls-port"),
+				strmsg(typeBlobString, "tls-port"),
 				{typ: typeInteger, integer: 1},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.1.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.1.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.1.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.1.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // replica, port
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // replica, port
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 3},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.3.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.3.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.3.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.3.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "replica"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "replica"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
 }), nil)
 
-var shardsMultiResp = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "0"),
-			redisMessageContainString(typeBlobString, "8192"),
+var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "0"),
+			strmsg(typeBlobString, "8192"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // failed master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.0.99"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.0.99"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.0.99"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.0.99"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "fail"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "fail"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.0.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.0.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.0.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.0.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // replica
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.1.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.1.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.1.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.1.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "replica"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "replica"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "8193"),
-			redisMessageContainString(typeBlobString, "16383"),
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "8193"),
+			strmsg(typeBlobString, "16383"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // failed master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.2.99"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.2.99"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.2.99"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.2.99"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "fail"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "fail"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 0},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.2.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.2.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.2.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.2.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // replica
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.3.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.3.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.3.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.3.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "replica"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "replica"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
 }), nil)
 
-var singleShardResp2 = newResult(redisMessageContainSlice('*', []RedisMessage{
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "0"),
-			redisMessageContainString(typeBlobString, "0"),
+var singleShardResp2 = newResult(slicemsg('*', []RedisMessage{
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "0"),
+			strmsg(typeBlobString, "0"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // failed master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 3},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.3.99"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.3.99"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.3.99"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.3.99"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "fail"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "fail"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 3},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "127.0.3.1"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "127.0.3.1"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "127.0.3.1"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "127.0.3.1"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
 }), nil)
 
-var singleShardWithoutIP = newResult(redisMessageContainSlice(typeArray, []RedisMessage{
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "0"),
-			redisMessageContainString(typeBlobString, "0"),
+var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "0"),
+			strmsg(typeBlobString, "0"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // failed master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // failed master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 4},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, ""),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, ""),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "fail"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "fail"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 4},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, ""),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, ""),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
-			redisMessageContainSlice(typeMap, []RedisMessage{ // replica
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+			slicemsg(typeMap, []RedisMessage{ // replica
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 1},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "?"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "?"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "?"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "?"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "replica"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "replica"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
-	redisMessageContainSlice(typeMap, []RedisMessage{
-		redisMessageContainString(typeBlobString, "slots"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainString(typeBlobString, "0"),
-			redisMessageContainString(typeBlobString, "0"),
+	slicemsg(typeMap, []RedisMessage{
+		strmsg(typeBlobString, "slots"),
+		slicemsg(typeArray, []RedisMessage{
+			strmsg(typeBlobString, "0"),
+			strmsg(typeBlobString, "0"),
 		}),
-		redisMessageContainString(typeBlobString, "nodes"),
-		redisMessageContainSlice(typeArray, []RedisMessage{
-			redisMessageContainSlice(typeMap, []RedisMessage{ // master
-				redisMessageContainString(typeBlobString, "id"),
-				redisMessageContainString(typeBlobString, ""),
+		strmsg(typeBlobString, "nodes"),
+		slicemsg(typeArray, []RedisMessage{
+			slicemsg(typeMap, []RedisMessage{ // master
+				strmsg(typeBlobString, "id"),
+				strmsg(typeBlobString, ""),
 
-				redisMessageContainString(typeBlobString, "port"),
+				strmsg(typeBlobString, "port"),
 				{typ: typeInteger, integer: 4},
 
-				redisMessageContainString(typeBlobString, "ip"),
-				redisMessageContainString(typeBlobString, "?"),
+				strmsg(typeBlobString, "ip"),
+				strmsg(typeBlobString, "?"),
 
-				redisMessageContainString(typeBlobString, "endpoint"),
-				redisMessageContainString(typeBlobString, "?"),
+				strmsg(typeBlobString, "endpoint"),
+				strmsg(typeBlobString, "?"),
 
-				redisMessageContainString(typeBlobString, "role"),
-				redisMessageContainString(typeBlobString, "master"),
+				strmsg(typeBlobString, "role"),
+				strmsg(typeBlobString, "master"),
 
-				redisMessageContainString(typeBlobString, "replication-offset"),
+				strmsg(typeBlobString, "replication-offset"),
 				{typ: typeInteger, integer: 72156},
 
-				redisMessageContainString(typeBlobString, "health"),
-				redisMessageContainString(typeBlobString, "online"),
+				strmsg(typeBlobString, "health"),
+				strmsg(typeBlobString, "online"),
 			}),
 		}),
 	}),
@@ -742,7 +742,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
+							return newResult(slicemsg('*', []RedisMessage{}), nil)
 						}
 						return slotsResp
 					},
@@ -762,7 +762,7 @@ func TestClusterClientInit(t *testing.T) {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
 						if atomic.AddInt64(&first, 1) == 1 {
-							return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
+							return newResult(slicemsg('*', []RedisMessage{}), nil)
 						}
 						return shardsResp
 					},
@@ -781,7 +781,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
-						return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
+						return newResult(slicemsg('*', []RedisMessage{}), nil)
 					},
 				}
 			},
@@ -797,7 +797,7 @@ func TestClusterClientInit(t *testing.T) {
 			func(dst string, opt *ClientOption) conn {
 				return &mockConn{
 					DoFn: func(cmd Completed) RedisResult {
-						return newResult(redisMessageContainSlice('*', []RedisMessage{}), nil)
+						return newResult(slicemsg('*', []RedisMessage{}), nil)
 					},
 					VersionFn: func() int { return 8 },
 				}
@@ -1541,7 +1541,7 @@ func TestClusterClient(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
@@ -1551,21 +1551,21 @@ func TestClusterClient(t *testing.T) {
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Do"), nil)
+				return newResult(strmsg('+', "Do"), nil)
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Info"), nil)
+				return newResult(strmsg('+', "Info"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "DoCache"), nil)
+				return newResult(strmsg('+', "DoCache"), nil)
 			},
 		},
 	}
@@ -1816,9 +1816,9 @@ func TestClusterClient(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -1879,23 +1879,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -1987,23 +1987,23 @@ func TestClusterClient(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2201,40 +2201,40 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
@@ -2416,9 +2416,9 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2479,23 +2479,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2587,23 +2587,23 @@ func TestClusterClient_SendToOnlyPrimaryNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -2700,10 +2700,10 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 		},
 	}
@@ -2711,31 +2711,31 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 		},
 	}
@@ -2905,9 +2905,9 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -2971,23 +2971,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3079,23 +3079,23 @@ func TestClusterClient_SendToOnlyReplicaNodes(t *testing.T) {
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3192,32 +3192,32 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "SET Do V"), nil)
+				return newResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "SET K2{a} V2{a}"), nil)
+				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(redisMessageContainString('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(redisMessageContainString('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -3231,20 +3231,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3256,20 +3256,20 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -3495,9 +3495,9 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -3561,23 +3561,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3669,23 +3669,23 @@ func TestClusterClient_SendReadOperationToReplicaNodesWriteOperationToPrimaryNod
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -3782,18 +3782,18 @@ func TestClusterClient_SendPrimaryNodeOnlyButOneSlotAssigned(t *testing.T) {
 				return singleSlotResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(redisMessageContainString('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(redisMessageContainString('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -4064,9 +4064,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(redisMessageContainString('-', "MOVED 0 :0"), nil)
+						return newResult(strmsg('-', "MOVED 0 :0"), nil)
 					}
-					return newResult(redisMessageContainString('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4092,9 +4092,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
+						return newResult(strmsg('-', "MOVED 0 :1"), nil)
 					}
-					return newResult(redisMessageContainString('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -4120,10 +4120,10 @@ func TestClusterClientErr(t *testing.T) {
 
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+							return newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(redisMessageContainString('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -4155,12 +4155,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -4190,13 +4190,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -4230,33 +4230,33 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('+', "4"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "2"),
-								redisMessageContainString('+', "3"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "2"),
+								strmsg('+', "3"),
 							}), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "5"),
-								redisMessageContainString('+', "6"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "5"),
+								strmsg('+', "6"),
 							}), nil),
 						}}
 					}
@@ -4328,35 +4328,35 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('+', "4"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "2"),
-								redisMessageContainString('+', "3"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "2"),
+								strmsg('+', "3"),
 							}), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "5"),
-								redisMessageContainString('+', "6"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "5"),
+								strmsg('+', "6"),
 							}), nil),
 						}}
 					}
@@ -4428,29 +4428,29 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "2"),
-								redisMessageContainString('+', "3"),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "2"),
+								strmsg('+', "3"),
 							}), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "5"),
-								redisMessageContainString('+', "6"),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "5"),
+								strmsg('+', "6"),
 							}), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "4"), nil),
-							newResult(redisMessageContainString('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4521,32 +4521,32 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "2"),
-								redisMessageContainString('+', "3"),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "2"),
+								strmsg('+', "3"),
 							}), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "5"),
-								redisMessageContainString('+', "6"),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "5"),
+								strmsg('+', "6"),
 							}), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "4"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "7"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					}
 					return nil
@@ -4617,34 +4617,34 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "2"),
-								redisMessageContainString('+', "3"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "2"),
+								strmsg('+', "3"),
 							}), nil),
-							newResult(redisMessageContainString('+', "4"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "5"),
-								redisMessageContainString('+', "6"),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "5"),
+								strmsg('+', "6"),
 							}), nil),
 						}}
 					}
@@ -4716,37 +4716,37 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('+', "7"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "ASK 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('+', "7"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "2"),
-								redisMessageContainString('+', "3"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "2"),
+								strmsg('+', "3"),
 							}), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "4"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainString('+', "QUEUED"), nil),
-							newResult(redisMessageContainSlice('*', []RedisMessage{
-								redisMessageContainString('+', "5"),
-								redisMessageContainString('+', "6"),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "4"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(strmsg('+', "QUEUED"), nil),
+							newResult(slicemsg('*', []RedisMessage{
+								strmsg('+', "5"),
+								strmsg('+', "6"),
 							}), nil),
 						}}
 					}
@@ -4818,17 +4818,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -4883,17 +4883,17 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "EXECABORT"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "EXECABORT"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					case 2:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "4"), nil),
+							newResult(strmsg('+', "4"), nil),
 						}}
 					}
 					return nil
@@ -4948,11 +4948,11 @@ func TestClusterClientErr(t *testing.T) {
 					switch atomic.AddInt64(&count, 1) {
 					case 1:
 						return &redisresults{s: []RedisResult{
-							newResult(redisMessageContainString('+', "1"), nil),
-							newResult(redisMessageContainString('+', "OK"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
-							newResult(redisMessageContainString('-', "ERR Command not allowed inside a transaction"), nil),
-							newResult(redisMessageContainString('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('+', "1"), nil),
+							newResult(strmsg('+', "OK"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
+							newResult(strmsg('-', "ERR Command not allowed inside a transaction"), nil),
+							newResult(strmsg('-', "MOVED 0 :1"), nil),
 						}}
 					}
 					return nil
@@ -4999,12 +4999,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5036,12 +5036,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
+							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5073,9 +5073,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+						return newResult(strmsg('-', "MOVED 0 :2"), nil)
 					}
-					return newResult(redisMessageContainString('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5105,12 +5105,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5142,12 +5142,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5182,12 +5182,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 2 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
+							ret[i] = newResult(strmsg('-', "TRYAGAIN"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5217,9 +5217,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
+							return newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
-						return newResult(redisMessageContainString('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5245,10 +5245,10 @@ func TestClusterClientErr(t *testing.T) {
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
-							return newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+							return newResult(strmsg('-', "MOVED 0 :2"), nil)
 						}
 
-						return newResult(redisMessageContainString('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5280,12 +5280,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5315,13 +5315,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Contains(dst, ":0") {
 							atomic.AddInt64(&count, 1)
 							for i := range ret {
-								ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :2"), nil)
+								ret[i] = newResult(strmsg('-', "MOVED 0 :2"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('+', multi[i].Cmd.Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -5355,12 +5355,12 @@ func TestClusterClientErr(t *testing.T) {
 					ret := make([]RedisResult, len(multi))
 					if atomic.AddInt64(&count, 1) <= 3 {
 						for i := range ret {
-							ret[i] = newResult(redisMessageContainString('-', "MOVED 0 :1"), nil)
+							ret[i] = newResult(strmsg('-', "MOVED 0 :1"), nil)
 						}
 						return &redisresults{s: ret}
 					}
 					for i := range ret {
-						ret[i] = newResult(redisMessageContainString('+', multi[i].Cmd.Commands()[1]), nil)
+						ret[i] = newResult(strmsg('+', multi[i].Cmd.Commands()[1]), nil)
 					}
 					return &redisresults{s: ret}
 				}}
@@ -5391,13 +5391,13 @@ func TestClusterClientErr(t *testing.T) {
 						if strings.Join(cmd.Commands(), " ") == "CLUSTER SLOTS" {
 							return slotsMultiResp
 						}
-						return newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
+						return newResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
+							return &redisresults{s: []RedisResult{{}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, newResult(redisMessageContainString('+', "b"), nil)}}
+						return &redisresults{s: []RedisResult{{}, newResult(strmsg('+', "b"), nil)}}
 					},
 				}
 			},
@@ -5424,13 +5424,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]RedisResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
+								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(redisMessageContainString('+', "OK"), nil)
-							ret[i+1] = newResult(redisMessageContainString('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', "OK"), nil)
+							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -5459,13 +5459,13 @@ func TestClusterClientErr(t *testing.T) {
 						ret := make([]RedisResult, len(multi))
 						if atomic.AddInt64(&count, 1) <= 3 {
 							for i := range ret {
-								ret[i] = newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
+								ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
 							}
 							return &redisresults{s: ret}
 						}
 						for i := 0; i < len(multi); i += 2 {
-							ret[i] = newResult(redisMessageContainString('+', "OK"), nil)
-							ret[i+1] = newResult(redisMessageContainString('+', multi[i+1].Commands()[1]), nil)
+							ret[i] = newResult(strmsg('+', "OK"), nil)
+							ret[i+1] = newResult(strmsg('+', multi[i+1].Commands()[1]), nil)
 						}
 						return &redisresults{s: ret}
 					},
@@ -5497,13 +5497,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
-						return newResult(redisMessageContainString('-', "ASK 0 :1"), nil)
+						return newResult(strmsg('-', "ASK 0 :1"), nil)
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, redisMessageContainString('+', "b")}), nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []RedisMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5527,13 +5527,13 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
-						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
+						return &redisresults{s: []RedisResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
+							return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil)}}
 						}
-						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, redisMessageContainString('+', "b")}), nil)}}
+						return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []RedisMessage{{}, strmsg('+', "b")}), nil)}}
 					},
 				}
 			},
@@ -5557,18 +5557,18 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					},
 					DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
-						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 :1"), nil)}}
+						return &redisresults{s: []RedisResult{newResult(strmsg('-', "ASK 0 :1"), nil)}}
 					},
 					DoMultiFn: func(multi ...Completed) *redisresults {
 						if atomic.AddInt64(&count, 1) <= 3 {
 							return &redisresults{s: []RedisResult{
-								{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
-								{}, {}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
+								{}, {}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :1"), nil),
 							}}
 						}
 						return &redisresults{s: []RedisResult{
-							{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, redisMessageContainString('+', multi[4].Commands()[1])}), nil),
-							{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, redisMessageContainString('+', multi[10].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, newResult(slicemsg('*', []RedisMessage{{}, {}, strmsg('+', multi[4].Commands()[1])}), nil),
+							{}, {}, {}, {}, {}, newResult(slicemsg('*', []RedisMessage{{}, {}, strmsg('+', multi[10].Commands()[1])}), nil),
 						}}
 					},
 				}
@@ -5599,9 +5599,9 @@ func TestClusterClientErr(t *testing.T) {
 						return slotsMultiResp
 					}
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
+						return newResult(strmsg('-', "TRYAGAIN"), nil)
 					}
-					return newResult(redisMessageContainString('+', "b"), nil)
+					return newResult(strmsg('+', "b"), nil)
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5623,10 +5623,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
+						return &redisresults{s: []RedisResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]RedisResult, len(multi))
-					ret[0] = newResult(redisMessageContainString('+', "b"), nil)
+					ret[0] = newResult(strmsg('+', "b"), nil)
 					return &redisresults{s: ret}
 				}}
 			},
@@ -5649,10 +5649,10 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiFn: func(multi ...Completed) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
+						return &redisresults{s: []RedisResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
 					ret := make([]RedisResult, len(multi))
-					ret[0] = newResult(redisMessageContainString('+', multi[0].Commands()[1]), nil)
+					ret[0] = newResult(strmsg('+', multi[0].Commands()[1]), nil)
 					return &redisresults{s: ret}
 				}}
 			},
@@ -5683,9 +5683,9 @@ func TestClusterClientErr(t *testing.T) {
 					},
 					DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
 						if atomic.AddInt64(&count, 1) <= 3 {
-							return newResult(redisMessageContainString('-', "TRYAGAIN"), nil)
+							return newResult(strmsg('-', "TRYAGAIN"), nil)
 						}
-						return newResult(redisMessageContainString('+', "b"), nil)
+						return newResult(strmsg('+', "b"), nil)
 					},
 				}
 			},
@@ -5708,9 +5708,9 @@ func TestClusterClientErr(t *testing.T) {
 					return slotsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
+						return &redisresults{s: []RedisResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "b"), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', "b"), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -5735,9 +5735,9 @@ func TestClusterClientErr(t *testing.T) {
 					return shardsMultiResp
 				}, DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 					if atomic.AddInt64(&count, 1) <= 3 {
-						return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "TRYAGAIN"), nil)}}
+						return &redisresults{s: []RedisResult{newResult(strmsg('-', "TRYAGAIN"), nil)}}
 					}
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', multi[0].Cmd.Commands()[1]), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', multi[0].Cmd.Commands()[1]), nil)}}
 				}}
 			},
 			newRetryer(defaultRetryDelayFn),
@@ -6199,9 +6199,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -6221,9 +6221,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "ERR some other error"), nil)
+				return newResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -6240,9 +6240,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -6261,9 +6261,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6278,9 +6278,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -6302,9 +6302,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoFn: m.DoFn} }
 
@@ -6325,9 +6325,9 @@ func TestClusterClientLoadingRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		m.AcquireFn = func() wire { return &mockWire{DoMultiFn: m.DoMultiFn} }
 
@@ -6377,9 +6377,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "MOVED 0 127.0.0.1"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "MOVED 0 127.0.0.1"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6399,9 +6399,9 @@ func TestClusterClientMovedRetry(t *testing.T) {
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 127.0.0.1"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "ASK 0 127.0.0.1"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil), newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil), newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Set().Key("test").Value(`test`).Build()
@@ -6442,14 +6442,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 		client, m := setup()
 		attempts := 0
 		m.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
-			return newResult(redisMessageContainString('-', "ASK 0 :0"), nil)
+			return newResult(strmsg('-', "ASK 0 :0"), nil)
 		}
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :0"), nil), newResult(RedisMessage{typ: '_'}, nil)}}
+				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(RedisMessage{typ: '_'}, nil)}}
 			}
-			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, {}, {}, {}, redisMessageContainString('+', "OK")}), nil)}}
+			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []RedisMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resp := client.DoCache(context.Background(), client.B().Get().Key("a1").Cache(), 10*time.Second)
 		if v, err := resp.ToString(); err != nil || v != "OK" {
@@ -6465,14 +6465,14 @@ func TestClusterClientCacheASKRetry(t *testing.T) {
 
 		attempts := 0
 		m.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "ASK 0 :0"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('-', "ASK 0 :0"), nil)}}
 		}
 		m.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(redisMessageContainString('-', "ASK 0 :0"), nil), newResult(RedisMessage{typ: '_'}, nil)}}
+				return &redisresults{s: []RedisResult{{}, {}, {}, {}, newResult(strmsg('-', "ASK 0 :0"), nil), newResult(RedisMessage{typ: '_'}, nil)}}
 			}
-			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(redisMessageContainSlice('*', []RedisMessage{{}, {}, {}, {}, {}, redisMessageContainString('+', "OK")}), nil)}}
+			return &redisresults{s: []RedisResult{{}, {}, {}, {}, {}, newResult(slicemsg('*', []RedisMessage{{}, {}, {}, {}, {}, strmsg('+', "OK")}), nil)}}
 		}
 		resps := client.DoMultiCache(context.Background(), CT(client.B().Get().Key("a1").Cache(), 10*time.Second))
 		if v, err := resps[0].ToString(); err != nil || v != "OK" {
@@ -6494,32 +6494,32 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 				return slotsMultiResp
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 			"SET Do V": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "SET Do V"), nil)
+				return newResult(strmsg('+', "SET Do V"), nil)
 			},
 			"SET K2{a} V2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "SET K2{a} V2{a}"), nil)
+				return newResult(strmsg('+', "SET K2{a} V2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K1") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "SET K2") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "MULTI") {
-					resps[i] = newResult(redisMessageContainString('+', "MULTI"), nil)
+					resps[i] = newResult(strmsg('+', "MULTI"), nil)
 					continue
 				}
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "EXEC") {
-					resps[i] = newResult(redisMessageContainString('+', "EXEC"), nil)
+					resps[i] = newResult(strmsg('+', "EXEC"), nil)
 					continue
 				}
 
@@ -6533,20 +6533,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 	replicaNodeConn := &mockConn{
 		DoOverride: map[string]func(cmd Completed) RedisResult{
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -6558,20 +6558,20 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
 				if strings.HasPrefix(strings.Join(cmd.Cmd.Commands(), " "), "GET K1") {
-					resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+					resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 					continue
 				}
 
@@ -6800,9 +6800,9 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -6862,23 +6862,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -6970,23 +6970,23 @@ func TestClusterClient_SendReadOperationToReplicaNodeWriteOperationToPrimaryNode
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -7083,40 +7083,40 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 				return slotsMultiResp
 			},
 			"GET Do": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET Do"), nil)
+				return newResult(strmsg('+', "GET Do"), nil)
 			},
 			"GET K1{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 			"INFO": func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "INFO"), nil)
+				return newResult(strmsg('+', "INFO"), nil)
 			},
 		},
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
 		DoCacheOverride: map[string]func(cmd Cacheable, ttl time.Duration) RedisResult{
 			"GET DoCache": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET DoCache"), nil)
+				return newResult(strmsg('+', "GET DoCache"), nil)
 			},
 			"GET K1{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K1{a}"), nil)
+				return newResult(strmsg('+', "GET K1{a}"), nil)
 			},
 			"GET K2{a}": func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return newResult(redisMessageContainString('+', "GET K2{a}"), nil)
+				return newResult(strmsg('+', "GET K2{a}"), nil)
 			},
 		},
 		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
 			resps := make([]RedisResult, len(multi))
 			for i, cmd := range multi {
-				resps[i] = newResult(redisMessageContainString('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
+				resps[i] = newResult(strmsg('+', strings.Join(cmd.Cmd.Commands(), " ")), nil)
 			}
 			return &redisresults{s: resps}
 		},
@@ -7301,9 +7301,9 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 			return &mockWire{
 				DoMultiFn: func(multi ...Completed) *redisresults {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{strmsg('+', "a")}), nil),
 					}}
 				},
 			}
@@ -7364,23 +7364,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -7472,23 +7472,23 @@ func TestClusterClient_SendToOnlyPrimaryNodeWhenPrimaryNodeSelected(t *testing.T
 		closed := false
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
 				if len(cmd) == 4 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainString('+', "OK"), nil),
-						newResult(redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "Delegate0"),
-							redisMessageContainString('+', "Delegate1"),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(strmsg('+', "OK"), nil),
+						newResult(slicemsg('*', []RedisMessage{
+							strmsg('+', "Delegate0"),
+							strmsg('+', "Delegate1"),
 						}), nil),
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					newResult(redisMessageContainString('+', "Delegate0"), nil),
-					newResult(redisMessageContainString('+', "Delegate1"), nil),
+					newResult(strmsg('+', "Delegate0"), nil),
+					newResult(strmsg('+', "Delegate1"), nil),
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -18,16 +18,16 @@ import (
 
 var slotsResp = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 16383},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 16383},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.0.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica
 			strmsg('+', "127.0.1.1"),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 			strmsg('+', ""),
 		}),
 	}),
@@ -35,30 +35,30 @@ var slotsResp = newResult(slicemsg('*', []RedisMessage{
 
 var slotsMultiResp = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 8192},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 8192},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.0.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica
 			strmsg('+', "127.0.1.1"),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 			strmsg('+', ""),
 		}),
 	}),
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 8193},
-		{typ: ':', integer: 16383},
+		{typ: ':', intlen: 8193},
+		{typ: ':', intlen: 16383},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.2.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica
 			strmsg('+', "127.0.3.1"),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 			strmsg('+', ""),
 		}),
 	}),
@@ -66,20 +66,20 @@ var slotsMultiResp = newResult(slicemsg('*', []RedisMessage{
 
 var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 8192},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 8192},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.0.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 	}),
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 8193},
-		{typ: ':', integer: 16383},
+		{typ: ':', intlen: 8193},
+		{typ: ':', intlen: 16383},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.1.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 	}),
@@ -87,50 +87,50 @@ var slotsMultiRespWithoutReplicas = newResult(slicemsg('*', []RedisMessage{
 
 var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 8192},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 8192},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.0.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica1
 			strmsg('+', "127.0.0.2"),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica2
 			strmsg('+', "127.0.0.3"),
-			{typ: ':', integer: 2},
+			{typ: ':', intlen: 2},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica3
 			strmsg('+', "127.0.0.4"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', ""),
 		}),
 	}),
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 8193},
-		{typ: ':', integer: 16383},
+		{typ: ':', intlen: 8193},
+		{typ: ':', intlen: 16383},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.1.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica1
 			strmsg('+', "127.0.1.2"),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica2
 			strmsg('+', "127.0.1.3"),
-			{typ: ':', integer: 2},
+			{typ: ':', intlen: 2},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica3
 			strmsg('+', "127.0.1.4"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', ""),
 		}),
 	}),
@@ -138,11 +138,11 @@ var slotsMultiRespWithMultiReplicas = newResult(slicemsg('*', []RedisMessage{
 
 var singleSlotResp = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 0},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 0},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.0.1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 			strmsg('+', ""),
 		}),
 	}),
@@ -150,11 +150,11 @@ var singleSlotResp = newResult(slicemsg('*', []RedisMessage{
 
 var singleSlotResp2 = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 0},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 0},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "127.0.3.1"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', ""),
 		}),
 	}),
@@ -162,25 +162,25 @@ var singleSlotResp2 = newResult(slicemsg('*', []RedisMessage{
 
 var singleSlotWithoutIP = newResult(slicemsg('*', []RedisMessage{
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 0},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 0},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', ""),
-			{typ: ':', integer: 4},
+			{typ: ':', intlen: 4},
 			strmsg('+', ""),
 		}),
 		slicemsg('*', []RedisMessage{ // replica
 			strmsg('+', "?"),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 			strmsg('+', ""),
 		}),
 	}),
 	slicemsg('*', []RedisMessage{
-		{typ: ':', integer: 0},
-		{typ: ':', integer: 0},
+		{typ: ':', intlen: 0},
+		{typ: ':', intlen: 0},
 		slicemsg('*', []RedisMessage{ // master
 			strmsg('+', "?"),
-			{typ: ':', integer: 4},
+			{typ: ':', intlen: 4},
 			strmsg('+', ""),
 		}),
 	}),
@@ -200,7 +200,7 @@ var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.0.99"),
@@ -212,7 +212,7 @@ var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "fail"),
@@ -222,7 +222,7 @@ var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.0.1"),
@@ -234,7 +234,7 @@ var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -244,7 +244,7 @@ var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 1},
+				{typ: typeInteger, intlen: 1},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.1.1"),
@@ -256,7 +256,7 @@ var shardsResp = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "replica"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -279,7 +279,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "tls-port"),
-				{typ: typeInteger, integer: 2},
+				{typ: typeInteger, intlen: 2},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.2.1"),
@@ -291,7 +291,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "replica"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -301,10 +301,10 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "tls-port"),
-				{typ: typeInteger, integer: 1},
+				{typ: typeInteger, intlen: 1},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.1.99"),
@@ -316,7 +316,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "fail"),
@@ -326,10 +326,10 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "tls-port"),
-				{typ: typeInteger, integer: 1},
+				{typ: typeInteger, intlen: 1},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.1.1"),
@@ -341,7 +341,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -351,7 +351,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 3},
+				{typ: typeInteger, intlen: 3},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.3.1"),
@@ -363,7 +363,7 @@ var shardsRespTls = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "replica"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -386,7 +386,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.0.99"),
@@ -398,7 +398,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "fail"),
@@ -408,7 +408,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.0.1"),
@@ -420,7 +420,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -430,7 +430,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 1},
+				{typ: typeInteger, intlen: 1},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.1.1"),
@@ -442,7 +442,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "replica"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -462,7 +462,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.2.99"),
@@ -474,7 +474,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "fail"),
@@ -484,7 +484,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 0},
+				{typ: typeInteger, intlen: 0},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.2.1"),
@@ -496,7 +496,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -506,7 +506,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 1},
+				{typ: typeInteger, intlen: 1},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.3.1"),
@@ -518,7 +518,7 @@ var shardsMultiResp = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "replica"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -541,7 +541,7 @@ var singleShardResp2 = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 3},
+				{typ: typeInteger, intlen: 3},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.3.99"),
@@ -553,7 +553,7 @@ var singleShardResp2 = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "fail"),
@@ -563,7 +563,7 @@ var singleShardResp2 = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 3},
+				{typ: typeInteger, intlen: 3},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "127.0.3.1"),
@@ -575,7 +575,7 @@ var singleShardResp2 = newResult(slicemsg('*', []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -598,7 +598,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 4},
+				{typ: typeInteger, intlen: 4},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, ""),
@@ -610,7 +610,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "fail"),
@@ -620,7 +620,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 4},
+				{typ: typeInteger, intlen: 4},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, ""),
@@ -632,7 +632,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -642,7 +642,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 1},
+				{typ: typeInteger, intlen: 1},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "?"),
@@ -654,7 +654,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "replica"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),
@@ -674,7 +674,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, ""),
 
 				strmsg(typeBlobString, "port"),
-				{typ: typeInteger, integer: 4},
+				{typ: typeInteger, intlen: 4},
 
 				strmsg(typeBlobString, "ip"),
 				strmsg(typeBlobString, "?"),
@@ -686,7 +686,7 @@ var singleShardWithoutIP = newResult(slicemsg(typeArray, []RedisMessage{
 				strmsg(typeBlobString, "master"),
 
 				strmsg(typeBlobString, "replication-offset"),
-				{typ: typeInteger, integer: 72156},
+				{typ: typeInteger, intlen: 72156},
 
 				strmsg(typeBlobString, "health"),
 				strmsg(typeBlobString, "online"),

--- a/helper_test.go
+++ b/helper_test.go
@@ -35,7 +35,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}, {typ: '+', string: "2"}}}, nil)
+				return newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainString('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -46,14 +46,16 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "1"}, nil),
-						newResult(RedisMessage{typ: '+', string: "2"}, nil),
+						newResult(redisMessageContainString('+', "1"), nil),
+						newResult(redisMessageContainString('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
 				return nil
 			}
-			if v, err := MGetCache(client, context.Background(), 100, []string{"1", "2"}); err != nil || v["1"].string != "1" || v["2"].string != "2" {
+			if v, err := MGetCache(client, context.Background(), 100, []string{"1", "2"}); err != nil {
+				t.Fatalf("unexpected response %v %v", v, err)
+			} else if v1, v2 := v["1"], v["2"]; v1.string() != "1" || v2.string() != "2" {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 		})
@@ -107,7 +109,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: key}, nil)
+					result[i] = newResult(redisMessageContainString('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -116,7 +118,7 @@ func TestMGetCache(t *testing.T) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 			for _, key := range keys {
-				if v[key].string != key {
+				if vKey, ok := v[key]; !ok || vKey.string() != key {
 					t.Fatalf("unexpected response %v", v)
 				}
 			}
@@ -134,7 +136,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: key}, nil)
+					result[i] = newResult(redisMessageContainString('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -143,7 +145,7 @@ func TestMGetCache(t *testing.T) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 			for _, key := range keys {
-				if v[key].string != key {
+				if vKey, ok := v[key]; !ok || vKey.string() != key {
 					t.Fatalf("unexpected response %v", v)
 				}
 			}
@@ -189,9 +191,11 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}, {typ: '+', string: "2"}}}, nil)
+				return newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainString('+', "2")}), nil)
 			}
-			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil || v["1"].string != "1" || v["2"].string != "2" {
+			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
+				t.Fatalf("unexpected response %v %v", v, err)
+			} else if v1, v2 := v["1"], v["2"]; v1.string() != "1" || v2.string() != "2" {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 		})
@@ -237,7 +241,7 @@ func TestMGet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: key}, nil)
+					result[i] = newResult(redisMessageContainString('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -246,7 +250,7 @@ func TestMGet(t *testing.T) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 			for _, key := range keys {
-				if v[key].string != key {
+				if vKey, ok := v[key]; !ok || vKey.string() != key {
 					t.Fatalf("unexpected response %v", v)
 				}
 			}
@@ -384,7 +388,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+				return newResult(redisMessageContainString('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -437,7 +441,7 @@ func TestMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+					result[i] = newResult(redisMessageContainString('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -489,7 +493,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+				return newResult(redisMessageContainString('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -542,7 +546,7 @@ func TestMSetNX(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+					result[i] = newResult(redisMessageContainString('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -618,14 +622,16 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &redisresults{s: []RedisResult{
-						newResult(RedisMessage{typ: '+', string: "1"}, nil),
-						newResult(RedisMessage{typ: '+', string: "2"}, nil),
+						newResult(redisMessageContainString('+', "1"), nil),
+						newResult(redisMessageContainString('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
 				return nil
 			}
-			if v, err := JsonMGetCache(client, context.Background(), 100, []string{"1", "2"}, "$"); err != nil || v["1"].string != "1" || v["2"].string != "2" {
+			if v, err := JsonMGetCache(client, context.Background(), 100, []string{"1", "2"}, "$"); err != nil {
+				t.Fatalf("unexpected response %v %v", v, err)
+			} else if v1, v2 := v["1"], v["2"]; v1.string() != "1" || v2.string() != "2" {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 		})
@@ -671,7 +677,7 @@ func TestJsonMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: key}, nil)
+					result[i] = newResult(redisMessageContainString('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -680,7 +686,7 @@ func TestJsonMGetCache(t *testing.T) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 			for _, key := range keys {
-				if v[key].string != key {
+				if vKey, ok := v[key]; !ok || vKey.string() != key {
 					t.Fatalf("unexpected response %v", v)
 				}
 			}
@@ -726,9 +732,11 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "1"}, {typ: '+', string: "2"}}}, nil)
+				return newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainString('+', "2")}), nil)
 			}
-			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil || v["1"].string != "1" || v["2"].string != "2" {
+			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
+				t.Fatalf("unexpected response %v %v", v, err)
+			} else if v1, v2 := v["1"], v["2"]; v1.string() != "1" || v2.string() != "2" {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 		})
@@ -774,7 +782,7 @@ func TestJsonMGet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: key}, nil)
+					result[i] = newResult(redisMessageContainString('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -783,7 +791,7 @@ func TestJsonMGet(t *testing.T) {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
 			for _, key := range keys {
-				if v[key].string != key {
+				if vKey, ok := v[key]; !ok || vKey.string() != key {
 					t.Fatalf("unexpected response %v", v)
 				}
 			}
@@ -825,7 +833,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+				return newResult(redisMessageContainString('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -878,7 +886,7 @@ func TestJsonMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+					result[i] = newResult(redisMessageContainString('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -921,10 +929,10 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 		Inners []*Inner
 	}
 	values := []RedisMessage{
-		{string: `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`, typ: '+'},
-		{string: `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`, typ: '+'},
+		redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
+		redisMessageContainString('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
 	}
-	result := RedisResult{val: RedisMessage{typ: '*', values: values}}
+	result := RedisResult{val: redisMessageContainSlice('*', values)}
 
 	t.Run("Scan []*T", func(t *testing.T) {
 		got := make([]*T, 0)
@@ -956,11 +964,11 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 
 	t.Run("Scan []*T: has nil error message", func(t *testing.T) {
 		hasNilValues := []RedisMessage{
-			{string: `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`, typ: '+'},
+			redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
 			{typ: '_'},
-			{string: `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`, typ: '+'},
+			redisMessageContainString('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
 		}
-		hasNilResult := RedisResult{val: RedisMessage{typ: '*', values: hasNilValues}}
+		hasNilResult := RedisResult{val: redisMessageContainSlice('*', hasNilValues)}
 
 		got := make([]*T, 0)
 		want := []*T{
@@ -978,11 +986,11 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 
 	t.Run("Scan []T: has nil error message", func(t *testing.T) {
 		hasNilValues := []RedisMessage{
-			{string: `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`, typ: '+'},
+			redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
 			{typ: '_'},
-			{string: `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`, typ: '+'},
+			redisMessageContainString('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
 		}
-		hasNilResult := RedisResult{val: RedisMessage{typ: '*', values: hasNilValues}}
+		hasNilResult := RedisResult{val: redisMessageContainSlice('*', hasNilValues)}
 
 		got := make([]T, 0)
 		want := []T{
@@ -1006,10 +1014,10 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 
 	t.Run("has non-nil error message in result", func(t *testing.T) {
 		hasErrValues := []RedisMessage{
-			{string: `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`, typ: '+'},
-			{string: `invalid`, typ: '-'},
+			redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
+			redisMessageContainString('-', `invalid`),
 		}
-		hasErrResult := RedisResult{val: RedisMessage{typ: '*', values: hasErrValues}}
+		hasErrResult := RedisResult{val: redisMessageContainSlice('*', hasErrValues)}
 
 		got := make([]*T, 0)
 		if err := DecodeSliceOfJSON(hasErrResult, &got); err == nil {

--- a/helper_test.go
+++ b/helper_test.go
@@ -292,7 +292,7 @@ func TestMDel(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"DEL", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(RedisMessage{typ: ':', integer: 2}, nil)
+				return newResult(RedisMessage{typ: ':', intlen: 2}, nil)
 			}
 			if v := MDel(client, context.Background(), []string{"1", "2"}); v["1"] != nil || v["2"] != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -340,7 +340,7 @@ func TestMDel(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(RedisMessage{typ: ':', integer: 1}, nil)
+					result[i] = newResult(RedisMessage{typ: ':', intlen: 1}, nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -594,7 +594,7 @@ func TestMSetNXNotSet(t *testing.T) {
 		}
 		t.Run("Delegate Do Not Set", func(t *testing.T) {
 			m.DoFn = func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: ':', integer: 0}, nil)
+				return newResult(RedisMessage{typ: ':', intlen: 0}, nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != ErrMSetNXNotSet || err["2"] != ErrMSetNXNotSet {
 				t.Fatalf("unexpected response %v", err)

--- a/helper_test.go
+++ b/helper_test.go
@@ -35,7 +35,7 @@ func TestMGetCache(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainString('+', "2")}), nil)
+				return newResult(slicemsg('*', []RedisMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGetCache(disabledCacheClient, context.Background(), 100, []string{"1", "2"}); err != nil || v == nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -46,8 +46,8 @@ func TestMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"GET", "1"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"GET", "2"}) && multi[1].TTL == 100 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "1"), nil),
-						newResult(redisMessageContainString('+', "2"), nil),
+						newResult(strmsg('+', "1"), nil),
+						newResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -109,7 +109,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -136,7 +136,7 @@ func TestMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -191,7 +191,7 @@ func TestMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"MGET", "1", "2"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainString('+', "2")}), nil)
+				return newResult(slicemsg('*', []RedisMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := MGet(client, context.Background(), []string{"1", "2"}); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -241,7 +241,7 @@ func TestMGet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -388,7 +388,7 @@ func TestMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSET", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(redisMessageContainString('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -441,7 +441,7 @@ func TestMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', "OK"), nil)
+					result[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -493,7 +493,7 @@ func TestMSetNX(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"MSETNX", "2", "2", "1", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(redisMessageContainString('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := MSetNX(client, context.Background(), map[string]string{"1": "1", "2": "2"}); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -546,7 +546,7 @@ func TestMSetNX(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', "OK"), nil)
+					result[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -622,8 +622,8 @@ func TestJsonMGetCache(t *testing.T) {
 				if reflect.DeepEqual(multi[0].Cmd.Commands(), []string{"JSON.GET", "1", "$"}) && multi[0].TTL == 100 &&
 					reflect.DeepEqual(multi[1].Cmd.Commands(), []string{"JSON.GET", "2", "$"}) && multi[1].TTL == 100 {
 					return &redisresults{s: []RedisResult{
-						newResult(redisMessageContainString('+', "1"), nil),
-						newResult(redisMessageContainString('+', "2"), nil),
+						newResult(strmsg('+', "1"), nil),
+						newResult(strmsg('+', "2"), nil),
 					}}
 				}
 				t.Fatalf("unexpected command %v", multi)
@@ -677,7 +677,7 @@ func TestJsonMGetCache(t *testing.T) {
 						t.Fatalf("unexpected command %v", multi)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -732,7 +732,7 @@ func TestJsonMGet(t *testing.T) {
 				if !reflect.DeepEqual(cmd.Commands(), []string{"JSON.MGET", "1", "2", "$"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainString('+', "2")}), nil)
+				return newResult(slicemsg('*', []RedisMessage{strmsg('+', "1"), strmsg('+', "2")}), nil)
 			}
 			if v, err := JsonMGet(client, context.Background(), []string{"1", "2"}, "$"); err != nil {
 				t.Fatalf("unexpected response %v %v", v, err)
@@ -782,7 +782,7 @@ func TestJsonMGet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', key), nil)
+					result[i] = newResult(strmsg('+', key), nil)
 				}
 				return &redisresults{s: result}
 			}
@@ -833,7 +833,7 @@ func TestJsonMSet(t *testing.T) {
 					!reflect.DeepEqual(cmd.Commands(), []string{"JSON.MSET", "2", "$", "2", "1", "$", "1"}) {
 					t.Fatalf("unexpected command %v", cmd)
 				}
-				return newResult(redisMessageContainString('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
 			if err := JsonMSet(client, context.Background(), map[string]string{"1": "1", "2": "2"}, "$"); err["1"] != nil || err["2"] != nil {
 				t.Fatalf("unexpected response %v", err)
@@ -886,7 +886,7 @@ func TestJsonMSet(t *testing.T) {
 						t.Fatalf("unexpected command %v", cmd)
 						return nil
 					}
-					result[i] = newResult(redisMessageContainString('+', "OK"), nil)
+					result[i] = newResult(strmsg('+', "OK"), nil)
 				}
 				if len(cpy) != 0 {
 					t.Fatalf("unexpected command %v", cmd)
@@ -929,10 +929,10 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 		Inners []*Inner
 	}
 	values := []RedisMessage{
-		redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
-		redisMessageContainString('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
+		strmsg('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
+		strmsg('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
 	}
-	result := RedisResult{val: redisMessageContainSlice('*', values)}
+	result := RedisResult{val: slicemsg('*', values)}
 
 	t.Run("Scan []*T", func(t *testing.T) {
 		got := make([]*T, 0)
@@ -964,11 +964,11 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 
 	t.Run("Scan []*T: has nil error message", func(t *testing.T) {
 		hasNilValues := []RedisMessage{
-			redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
+			strmsg('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
 			{typ: '_'},
-			redisMessageContainString('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
+			strmsg('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
 		}
-		hasNilResult := RedisResult{val: redisMessageContainSlice('*', hasNilValues)}
+		hasNilResult := RedisResult{val: slicemsg('*', hasNilValues)}
 
 		got := make([]*T, 0)
 		want := []*T{
@@ -986,11 +986,11 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 
 	t.Run("Scan []T: has nil error message", func(t *testing.T) {
 		hasNilValues := []RedisMessage{
-			redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
+			strmsg('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
 			{typ: '_'},
-			redisMessageContainString('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
+			strmsg('+', `{"ID":2, "Name": "n2", "Inners": [{"Field": "f2"}]}`),
 		}
-		hasNilResult := RedisResult{val: redisMessageContainSlice('*', hasNilValues)}
+		hasNilResult := RedisResult{val: slicemsg('*', hasNilValues)}
 
 		got := make([]T, 0)
 		want := []T{
@@ -1014,10 +1014,10 @@ func TestDecodeSliceOfJSON(t *testing.T) {
 
 	t.Run("has non-nil error message in result", func(t *testing.T) {
 		hasErrValues := []RedisMessage{
-			redisMessageContainString('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
-			redisMessageContainString('-', `invalid`),
+			strmsg('+', `{"ID":1, "Name": "n1", "Inners": [{"Field": "f1"}]}`),
+			strmsg('-', `invalid`),
 		}
-		hasErrResult := RedisResult{val: redisMessageContainSlice('*', hasErrValues)}
+		hasErrResult := RedisResult{val: slicemsg('*', hasErrValues)}
 
 		got := make([]*T, 0)
 		if err := DecodeSliceOfJSON(hasErrResult, &got); err == nil {

--- a/lru.go
+++ b/lru.go
@@ -317,7 +317,7 @@ func (c *lru) Delete(keys []RedisMessage) {
 		}
 	} else {
 		for _, k := range keys {
-			c.purge(k.string, c.store[k.string])
+			c.purge(k.string(), c.store[k.string()])
 		}
 	}
 	c.mu.Unlock()

--- a/lru_test.go
+++ b/lru_test.go
@@ -54,7 +54,7 @@ func TestLRU(t *testing.T) {
 		if v, entry := lru.Flight("1", "GET", TTL, time.Now()); v.typ != 0 || entry != nil {
 			t.Fatalf("got unexpected value from the Flight after pttl: %v %v", v, entry)
 		}
-		m := redisMessageContainString('+', "1")
+		m := strmsg('+', "1")
 		lru.Update("1", "GET", m)
 		if v, _ := lru.Flight("1", "GET", TTL, time.Now()); v.typ == 0 {
 			t.Fatalf("did not get the value from the second Flight")
@@ -102,7 +102,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i <= Entries; i++ {
 			lru.Flight(strconv.Itoa(i), "GET", TTL, time.Now())
-			m := redisMessageContainString('+', strconv.Itoa(i))
+			m := strmsg('+', strconv.Itoa(i))
 			m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
@@ -118,7 +118,7 @@ func TestLRU(t *testing.T) {
 
 	t.Run("Cache Delete", func(t *testing.T) {
 		lru := setup(t)
-		lru.Delete([]RedisMessage{redisMessageContainString(0x0, "0")})
+		lru.Delete([]RedisMessage{strmsg(0x0, "0")})
 		if v, _ := lru.Flight("0", "GET", TTL, time.Now()); v.typ != 0 {
 			t.Fatalf("got unexpected value from the first Flight: %v", v)
 		}
@@ -128,7 +128,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i < Entries; i++ {
 			lru.Flight(strconv.Itoa(i), "GET", TTL, time.Now())
-			m := redisMessageContainString('+', strconv.Itoa(i))
+			m := strmsg('+', strconv.Itoa(i))
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
 		for i := 1; i < Entries; i++ {
@@ -161,7 +161,7 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("got unexpected value after Close: %v", err)
 		}
 
-		m := redisMessageContainString('+', "this Update should have no effect")
+		m := strmsg('+', "this Update should have no effect")
 		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 		lru.Update("1", "GET", m)
 		for i := 0; i < 2; i++ { // entry should be always nil after the first call if Close
@@ -265,7 +265,7 @@ func TestLRU(t *testing.T) {
 		if v, entry := lru.Flight("1", "GET", TTL, time.Now()); v.typ != 0 || entry != nil {
 			t.Fatalf("got unexpected value from the Flight after pttl: %v %v", v, entry)
 		}
-		m := redisMessageContainString('+', "1")
+		m := strmsg('+', "1")
 		lru.Update("1", "GET", m)
 		if v, _ := flights(lru, time.Now(), TTL, "GET", "1"); v.typ == 0 {
 			t.Fatalf("did not get the value from the second Flight")
@@ -313,7 +313,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i <= Entries; i++ {
 			flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i))
-			m := redisMessageContainString('+', strconv.Itoa(i))
+			m := strmsg('+', strconv.Itoa(i))
 			m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
@@ -329,7 +329,7 @@ func TestLRU(t *testing.T) {
 
 	t.Run("Batch Cache Delete", func(t *testing.T) {
 		lru := setup(t)
-		lru.Delete([]RedisMessage{redisMessageContainString(0x0, "0")})
+		lru.Delete([]RedisMessage{strmsg(0x0, "0")})
 		if v, _ := flights(lru, time.Now(), TTL, "GET", "0"); v.typ != 0 {
 			t.Fatalf("got unexpected value from the first Flight: %v", v)
 		}
@@ -339,7 +339,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i < Entries; i++ {
 			flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i))
-			m := redisMessageContainString('+', strconv.Itoa(i))
+			m := strmsg('+', strconv.Itoa(i))
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
 		for i := 1; i < Entries; i++ {
@@ -372,7 +372,7 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("got unexpected value after Close: %v", err)
 		}
 
-		m := redisMessageContainString('+', "this Update should have no effect")
+		m := strmsg('+', "this Update should have no effect")
 		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 		lru.Update("1", "GET", m)
 		for i := 0; i < 2; i++ { // entry should be always nil after the first call if Close

--- a/lru_test.go
+++ b/lru_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/redis/rueidis/internal/cmds"
 )
@@ -24,7 +25,12 @@ func TestLRU(t *testing.T) {
 		if v, entry := store.Flight("0", "GET", TTL, time.Now()); v.typ != 0 || entry != nil {
 			t.Fatalf("got unexpected value from the first Flight: %v %v", v, entry)
 		}
-		m := RedisMessage{typ: '+', string: "0", values: []RedisMessage{{}}}
+		m := RedisMessage{
+			typ:     '+',
+			bytes:   unsafe.StringData("0"),
+			array:   unsafe.SliceData([]RedisMessage{{}}),
+			integer: 1,
+		}
 		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 		store.Update("0", "GET", m)
 		return store.(*lru)
@@ -34,7 +40,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		if v, _ := lru.Flight("0", "GET", TTL, time.Now()); v.typ == 0 {
 			t.Fatalf("did not get the value from the second Flight")
-		} else if v.string != "0" {
+		} else if v.string() != "0" {
 			t.Fatalf("got unexpected value from the second Flight: %v", v)
 		}
 		time.Sleep(PTTL * time.Millisecond)
@@ -48,11 +54,11 @@ func TestLRU(t *testing.T) {
 		if v, entry := lru.Flight("1", "GET", TTL, time.Now()); v.typ != 0 || entry != nil {
 			t.Fatalf("got unexpected value from the Flight after pttl: %v %v", v, entry)
 		}
-		m := RedisMessage{typ: '+', string: "1"}
+		m := redisMessageContainString('+', "1")
 		lru.Update("1", "GET", m)
 		if v, _ := lru.Flight("1", "GET", TTL, time.Now()); v.typ == 0 {
 			t.Fatalf("did not get the value from the second Flight")
-		} else if v.string != "1" {
+		} else if v.string() != "1" {
 			t.Fatalf("got unexpected value from the second Flight: %v", v)
 		}
 	})
@@ -96,7 +102,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i <= Entries; i++ {
 			lru.Flight(strconv.Itoa(i), "GET", TTL, time.Now())
-			m := RedisMessage{typ: '+', string: strconv.Itoa(i)}
+			m := redisMessageContainString('+', strconv.Itoa(i))
 			m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
@@ -105,14 +111,14 @@ func TestLRU(t *testing.T) {
 		}
 		if v, _ := lru.Flight(strconv.Itoa(Entries), "GET", TTL, time.Now()); v.typ == 0 {
 			t.Fatalf("did not get the latest value from the Flight")
-		} else if v.string != strconv.Itoa(Entries) {
+		} else if v.string() != strconv.Itoa(Entries) {
 			t.Fatalf("got unexpected value from the Flight: %v", v)
 		}
 	})
 
 	t.Run("Cache Delete", func(t *testing.T) {
 		lru := setup(t)
-		lru.Delete([]RedisMessage{{string: "0"}})
+		lru.Delete([]RedisMessage{redisMessageContainString(0x0, "0")})
 		if v, _ := lru.Flight("0", "GET", TTL, time.Now()); v.typ != 0 {
 			t.Fatalf("got unexpected value from the first Flight: %v", v)
 		}
@@ -122,11 +128,11 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i < Entries; i++ {
 			lru.Flight(strconv.Itoa(i), "GET", TTL, time.Now())
-			m := RedisMessage{typ: '+', string: strconv.Itoa(i)}
+			m := redisMessageContainString('+', strconv.Itoa(i))
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
 		for i := 1; i < Entries; i++ {
-			if v, _ := lru.Flight(strconv.Itoa(i), "GET", TTL, time.Now()); v.string != strconv.Itoa(i) {
+			if v, _ := lru.Flight(strconv.Itoa(i), "GET", TTL, time.Now()); v.string() != strconv.Itoa(i) {
 				t.Fatalf("got unexpected value before flush all: %v", v)
 			}
 		}
@@ -155,7 +161,7 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("got unexpected value after Close: %v", err)
 		}
 
-		m := RedisMessage{typ: '+', string: "this Update should have no effect"}
+		m := redisMessageContainString('+', "this Update should have no effect")
 		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 		lru.Update("1", "GET", m)
 		for i := 0; i < 2; i++ { // entry should be always nil after the first call if Close
@@ -245,7 +251,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		if v, _ := lru.Flight("0", "GET", TTL, time.Now()); v.typ == 0 {
 			t.Fatalf("did not get the value from the second Flight")
-		} else if v.string != "0" {
+		} else if v.string() != "0" {
 			t.Fatalf("got unexpected value from the second Flight: %v", v)
 		}
 		time.Sleep(PTTL * time.Millisecond)
@@ -259,11 +265,11 @@ func TestLRU(t *testing.T) {
 		if v, entry := lru.Flight("1", "GET", TTL, time.Now()); v.typ != 0 || entry != nil {
 			t.Fatalf("got unexpected value from the Flight after pttl: %v %v", v, entry)
 		}
-		m := RedisMessage{typ: '+', string: "1"}
+		m := redisMessageContainString('+', "1")
 		lru.Update("1", "GET", m)
 		if v, _ := flights(lru, time.Now(), TTL, "GET", "1"); v.typ == 0 {
 			t.Fatalf("did not get the value from the second Flight")
-		} else if v.string != "1" {
+		} else if v.string() != "1" {
 			t.Fatalf("got unexpected value from the second Flight: %v", v)
 		}
 	})
@@ -307,7 +313,7 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i <= Entries; i++ {
 			flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i))
-			m := RedisMessage{typ: '+', string: strconv.Itoa(i)}
+			m := redisMessageContainString('+', strconv.Itoa(i))
 			m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
@@ -316,14 +322,14 @@ func TestLRU(t *testing.T) {
 		}
 		if v, _ := flights(lru, time.Now(), TTL, "GET", strconv.Itoa(Entries)); v.typ == 0 {
 			t.Fatalf("did not get the latest value from the Flight")
-		} else if v.string != strconv.Itoa(Entries) {
+		} else if v.string() != strconv.Itoa(Entries) {
 			t.Fatalf("got unexpected value from the Flight: %v", v)
 		}
 	})
 
 	t.Run("Batch Cache Delete", func(t *testing.T) {
 		lru := setup(t)
-		lru.Delete([]RedisMessage{{string: "0"}})
+		lru.Delete([]RedisMessage{redisMessageContainString(0x0, "0")})
 		if v, _ := flights(lru, time.Now(), TTL, "GET", "0"); v.typ != 0 {
 			t.Fatalf("got unexpected value from the first Flight: %v", v)
 		}
@@ -333,11 +339,11 @@ func TestLRU(t *testing.T) {
 		lru := setup(t)
 		for i := 1; i < Entries; i++ {
 			flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i))
-			m := RedisMessage{typ: '+', string: strconv.Itoa(i)}
+			m := redisMessageContainString('+', strconv.Itoa(i))
 			lru.Update(strconv.Itoa(i), "GET", m)
 		}
 		for i := 1; i < Entries; i++ {
-			if v, _ := flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i)); v.string != strconv.Itoa(i) {
+			if v, _ := flights(lru, time.Now(), TTL, "GET", strconv.Itoa(i)); v.string() != strconv.Itoa(i) {
 				t.Fatalf("got unexpected value before flush all: %v", v)
 			}
 		}
@@ -366,7 +372,7 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("got unexpected value after Close: %v", err)
 		}
 
-		m := RedisMessage{typ: '+', string: "this Update should have no effect"}
+		m := redisMessageContainString('+', "this Update should have no effect")
 		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 		lru.Update("1", "GET", m)
 		for i := 0; i < 2; i++ { // entry should be always nil after the first call if Close

--- a/lru_test.go
+++ b/lru_test.go
@@ -26,10 +26,10 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("got unexpected value from the first Flight: %v %v", v, entry)
 		}
 		m := RedisMessage{
-			typ:     '+',
-			bytes:   unsafe.StringData("0"),
-			array:   unsafe.SliceData([]RedisMessage{{}}),
-			integer: 1,
+			typ:    '+',
+			bytes:  unsafe.StringData("0"),
+			array:  unsafe.SliceData([]RedisMessage{{}}),
+			intlen: 1,
 		}
 		m.setExpireAt(time.Now().Add(PTTL * time.Millisecond).UnixMilli())
 		store.Update("0", "GET", m)

--- a/lua_test.go
+++ b/lua_test.go
@@ -28,9 +28,9 @@ func TestNewLuaScriptOnePass(t *testing.T) {
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+				return newResult(redisMessageContainString('+', "OK"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "unexpected"}, nil)
+			return newResult(redisMessageContainString('+', "unexpected"), nil)
 		},
 	}
 
@@ -59,12 +59,12 @@ func TestNewLuaScript(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(RedisMessage{typ: '-', string: "NOSCRIPT"}, nil)
+				return newResult(redisMessageContainString('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				return newResult(RedisMessage{typ: '_'}, nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "unexpected"}, nil)
+			return newResult(redisMessageContainString('+', "unexpected"), nil)
 		},
 	}
 
@@ -93,12 +93,12 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(RedisMessage{typ: '-', string: "NOSCRIPT"}, nil)
+				return newResult(redisMessageContainString('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
 				return newResult(RedisMessage{typ: '_'}, nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "unexpected"}, nil)
+			return newResult(redisMessageContainString('+', "unexpected"), nil)
 		},
 	}
 
@@ -121,7 +121,7 @@ func TestNewLuaScriptExecMultiError(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
-			return newResult(RedisMessage{typ: '-', string: "ANY ERR"}, nil)
+			return newResult(redisMessageContainString('-', "ANY ERR"), nil)
 		},
 	}
 
@@ -145,12 +145,12 @@ func TestNewLuaScriptExecMulti(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []RedisResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(RedisMessage{typ: '+', string: "OK"}, nil))
+					resp = append(resp, newResult(redisMessageContainString('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -177,12 +177,12 @@ func TestNewLuaScriptExecMultiRo(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []RedisResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(RedisMessage{typ: '+', string: "OK"}, nil))
+					resp = append(resp, newResult(redisMessageContainString('+', "OK"), nil))
 				}
 			}
 			return resp

--- a/lua_test.go
+++ b/lua_test.go
@@ -28,9 +28,9 @@ func TestNewLuaScriptOnePass(t *testing.T) {
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-				return newResult(redisMessageContainString('+', "OK"), nil)
+				return newResult(strmsg('+', "OK"), nil)
 			}
-			return newResult(redisMessageContainString('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -59,12 +59,12 @@ func TestNewLuaScript(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(redisMessageContainString('-', "NOSCRIPT"), nil)
+				return newResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
 				return newResult(RedisMessage{typ: '_'}, nil)
 			}
-			return newResult(redisMessageContainString('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -93,12 +93,12 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
 			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
 				eval = true
-				return newResult(redisMessageContainString('-', "NOSCRIPT"), nil)
+				return newResult(strmsg('-', "NOSCRIPT"), nil)
 			}
 			if eval && reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
 				return newResult(RedisMessage{typ: '_'}, nil)
 			}
-			return newResult(redisMessageContainString('+', "unexpected"), nil)
+			return newResult(strmsg('+', "unexpected"), nil)
 		},
 	}
 
@@ -121,7 +121,7 @@ func TestNewLuaScriptExecMultiError(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
-			return newResult(redisMessageContainString('-', "ANY ERR"), nil)
+			return newResult(strmsg('-', "ANY ERR"), nil)
 		},
 	}
 
@@ -145,12 +145,12 @@ func TestNewLuaScriptExecMulti(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []RedisResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(redisMessageContainString('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp
@@ -177,12 +177,12 @@ func TestNewLuaScriptExecMultiRo(t *testing.T) {
 			return cmds.NewBuilder(cmds.NoSlot)
 		},
 		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		},
 		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []RedisResult) {
 			for _, cmd := range multi {
 				if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
-					resp = append(resp, newResult(redisMessageContainString('+', "OK"), nil))
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
 				}
 			}
 			return resp

--- a/message.go
+++ b/message.go
@@ -52,11 +52,19 @@ func IsRedisErr(err error) (ret *RedisError, ok bool) {
 // RedisError is an error response or a nil message from redis instance
 type RedisError RedisMessage
 
+// string retrives the contained string of the RedisMessage
+func (m *RedisError) string() string {
+	if m.bytes == nil {
+		return ""
+	}
+	return unsafe.String(m.bytes, m.integer)
+}
+
 func (r *RedisError) Error() string {
 	if r.IsNil() {
 		return "redis nil message"
 	}
-	return r.string
+	return r.string()
 }
 
 // IsNil checks if it is a redis nil message.
@@ -66,16 +74,16 @@ func (r *RedisError) IsNil() bool {
 
 // IsMoved checks if it is a redis MOVED message and returns moved address.
 func (r *RedisError) IsMoved() (addr string, ok bool) {
-	if ok = strings.HasPrefix(r.string, "MOVED"); ok {
-		addr = fixIPv6HostPort(strings.Split(r.string, " ")[2])
+	if ok = strings.HasPrefix(r.string(), "MOVED"); ok {
+		addr = fixIPv6HostPort(strings.Split(r.string(), " ")[2])
 	}
 	return
 }
 
 // IsAsk checks if it is a redis ASK message and returns ask address.
 func (r *RedisError) IsAsk() (addr string, ok bool) {
-	if ok = strings.HasPrefix(r.string, "ASK"); ok {
-		addr = fixIPv6HostPort(strings.Split(r.string, " ")[2])
+	if ok = strings.HasPrefix(r.string(), "ASK"); ok {
+		addr = fixIPv6HostPort(strings.Split(r.string(), " ")[2])
 	}
 	return
 }
@@ -91,27 +99,27 @@ func fixIPv6HostPort(addr string) string {
 
 // IsTryAgain checks if it is a redis TRYAGAIN message and returns ask address.
 func (r *RedisError) IsTryAgain() bool {
-	return strings.HasPrefix(r.string, "TRYAGAIN")
+	return strings.HasPrefix(r.string(), "TRYAGAIN")
 }
 
 // IsLoading checks if it is a redis LOADING message
 func (r *RedisError) IsLoading() bool {
-	return strings.HasPrefix(r.string, "LOADING")
+	return strings.HasPrefix(r.string(), "LOADING")
 }
 
 // IsClusterDown checks if it is a redis CLUSTERDOWN message and returns ask address.
 func (r *RedisError) IsClusterDown() bool {
-	return strings.HasPrefix(r.string, "CLUSTERDOWN")
+	return strings.HasPrefix(r.string(), "CLUSTERDOWN")
 }
 
 // IsNoScript checks if it is a redis NOSCRIPT message.
 func (r *RedisError) IsNoScript() bool {
-	return strings.HasPrefix(r.string, "NOSCRIPT")
+	return strings.HasPrefix(r.string(), "NOSCRIPT")
 }
 
 // IsBusyGroup checks if it is a redis BUSYGROUP message.
 func (r *RedisError) IsBusyGroup() bool {
-	return strings.HasPrefix(r.string, "BUSYGROUP")
+	return strings.HasPrefix(r.string(), "BUSYGROUP")
 }
 
 func newResult(val RedisMessage, err error) RedisResult {
@@ -523,12 +531,39 @@ func (r *prettyRedisResult) MarshalJSON() ([]byte, error) {
 
 // RedisMessage is a redis response message, it may be a nil response
 type RedisMessage struct {
-	attrs   *RedisMessage
-	string  string
-	values  []RedisMessage
+	attrs *RedisMessage
+	bytes *byte
+	array *RedisMessage
+
+	// integer is used for a simple number or
+	// in conjunction with array or bytes to store the length of array or string
 	integer int64
 	typ     byte
 	ttl     [7]byte
+}
+
+func (m *RedisMessage) string() string {
+	if m.bytes == nil {
+		return ""
+	}
+	return unsafe.String(m.bytes, m.integer)
+}
+
+func (m *RedisMessage) values() []RedisMessage {
+	if m.array == nil {
+		return nil
+	}
+	return unsafe.Slice(m.array, m.integer)
+}
+
+func (m *RedisMessage) setString(s string) {
+	m.bytes = unsafe.StringData(s)
+	m.integer = int64(len(s))
+}
+
+func (m *RedisMessage) setValues(values []RedisMessage) {
+	m.array = unsafe.SliceData(values)
+	m.integer = int64(len(values))
 }
 
 func (m *RedisMessage) cachesize() int {
@@ -536,11 +571,11 @@ func (m *RedisMessage) cachesize() int {
 	switch m.typ {
 	case typeInteger, typeNull, typeBool:
 	case typeArray, typeMap, typeSet:
-		for _, val := range m.values {
+		for _, val := range m.values() {
 			n += val.cachesize()
 		}
 	default:
-		n += len(m.string)
+		n += len(m.string())
 	}
 	return n
 }
@@ -553,15 +588,15 @@ func (m *RedisMessage) serialize(o *bytes.Buffer) {
 		binary.BigEndian.PutUint64(buf[:], uint64(m.integer))
 		o.Write(buf[:])
 	case typeArray, typeMap, typeSet:
-		binary.BigEndian.PutUint64(buf[:], uint64(len(m.values)))
+		binary.BigEndian.PutUint64(buf[:], uint64(len(m.values())))
 		o.Write(buf[:])
-		for _, val := range m.values {
+		for _, val := range m.values() {
 			val.serialize(o)
 		}
 	default:
-		binary.BigEndian.PutUint64(buf[:], uint64(len(m.string)))
+		binary.BigEndian.PutUint64(buf[:], uint64(len(m.string())))
 		o.Write(buf[:])
-		o.WriteString(m.string)
+		o.WriteString(m.string())
 	}
 }
 
@@ -574,25 +609,26 @@ func (m *RedisMessage) unmarshalView(c int64, buf []byte) (int64, error) {
 	}
 	m.typ = buf[c]
 	c += 1
-	m.integer = int64(binary.BigEndian.Uint64(buf[c : c+8]))
+	size := int64(binary.BigEndian.Uint64(buf[c : c+8]))
 	c += 8 // TODO: can we use VarInt instead of fixed 8 bytes for length?
 	switch m.typ {
 	case typeInteger, typeNull, typeBool:
+		m.integer = size
 	case typeArray, typeMap, typeSet:
-		m.values = make([]RedisMessage, m.integer)
-		m.integer = 0
-		for i := range m.values {
-			if c, err = m.values[i].unmarshalView(c, buf); err != nil {
+		m.setValues(make([]RedisMessage, size))
+		size = 0
+		for i := range m.values() {
+			if c, err = m.values()[i].unmarshalView(c, buf); err != nil {
 				break
 			}
 		}
 	default:
-		if int64(len(buf)) < c+m.integer {
+		if int64(len(buf)) < c+size {
 			return 0, ErrCacheUnmarshal
 		}
-		m.string = BinaryString(buf[c : c+m.integer])
-		c += m.integer
-		m.integer = 0
+		m.setString(BinaryString(buf[c : c+size]))
+		c += size
+		size = 0
 	}
 	return c, err
 }
@@ -672,7 +708,7 @@ func (m *RedisMessage) Error() error {
 	if m.typ == typeSimpleErr || m.typ == typeBlobErr {
 		// kvrocks: https://github.com/redis/rueidis/issues/152#issuecomment-1333923750
 		mm := *m
-		mm.string = strings.TrimPrefix(m.string, "ERR ")
+		mm.setString(strings.TrimPrefix(m.string(), "ERR "))
 		return (*RedisError)(&mm)
 	}
 	return nil
@@ -681,13 +717,13 @@ func (m *RedisMessage) Error() error {
 // ToString check if message is a redis string response, and return it
 func (m *RedisMessage) ToString() (val string, err error) {
 	if m.IsString() {
-		return m.string, nil
+		return m.string(), nil
 	}
-	if m.IsInt64() || m.values != nil {
+	if m.IsInt64() || m.values() != nil {
 		typ := m.typ
 		return "", fmt.Errorf("%w: redis message type %s is not a string", errParse, typeNames[typ])
 	}
-	return m.string, m.Error()
+	return m.string(), m.Error()
 }
 
 // AsReader check if message is a redis string response and wrap it with the strings.NewReader
@@ -749,7 +785,7 @@ func (m *RedisMessage) AsBool() (val bool, err error) {
 	}
 	switch m.typ {
 	case typeBlobString, typeSimpleString:
-		val = m.string == "OK"
+		val = m.string() == "OK"
 		return
 	case typeInteger:
 		val = m.integer != 0
@@ -766,7 +802,7 @@ func (m *RedisMessage) AsBool() (val bool, err error) {
 // AsFloat64 check if message is a redis string response, and parse it as float64
 func (m *RedisMessage) AsFloat64() (val float64, err error) {
 	if m.IsFloat64() {
-		return util.ToFloat64(m.string)
+		return util.ToFloat64(m.string())
 	}
 	v, err := m.ToString()
 	if err != nil {
@@ -802,7 +838,7 @@ func (m *RedisMessage) ToBool() (val bool, err error) {
 // ToFloat64 check if message is a redis RESP3 double response, and return it
 func (m *RedisMessage) ToFloat64() (val float64, err error) {
 	if m.IsFloat64() {
-		return util.ToFloat64(m.string)
+		return util.ToFloat64(m.string())
 	}
 	if err = m.Error(); err != nil {
 		return 0, err
@@ -814,7 +850,7 @@ func (m *RedisMessage) ToFloat64() (val float64, err error) {
 // ToArray check if message is a redis array/set response, and return it
 func (m *RedisMessage) ToArray() ([]RedisMessage, error) {
 	if m.IsArray() {
-		return m.values, nil
+		return m.values(), nil
 	}
 	if err := m.Error(); err != nil {
 		return nil, err
@@ -832,7 +868,7 @@ func (m *RedisMessage) AsStrSlice() ([]string, error) {
 	}
 	s := make([]string, 0, len(values))
 	for _, v := range values {
-		s = append(s, v.string)
+		s = append(s, v.string())
 	}
 	return s, nil
 }
@@ -846,8 +882,8 @@ func (m *RedisMessage) AsIntSlice() ([]int64, error) {
 	}
 	s := make([]int64, len(values))
 	for i, v := range values {
-		if len(v.string) != 0 {
-			if s[i], err = strconv.ParseInt(v.string, 10, 64); err != nil {
+		if len(v.string()) != 0 {
+			if s[i], err = strconv.ParseInt(v.string(), 10, 64); err != nil {
 				return nil, err
 			}
 		} else {
@@ -866,8 +902,8 @@ func (m *RedisMessage) AsFloatSlice() ([]float64, error) {
 	}
 	s := make([]float64, len(values))
 	for i, v := range values {
-		if len(v.string) != 0 {
-			if s[i], err = util.ToFloat64(v.string); err != nil {
+		if len(v.string()) != 0 {
+			if s[i], err = util.ToFloat64(v.string()); err != nil {
 				return nil, err
 			}
 		} else {
@@ -946,21 +982,21 @@ func (m *RedisMessage) AsXRead() (ret map[string][]XRangeEntry, err error) {
 		return nil, err
 	}
 	if m.IsMap() {
-		ret = make(map[string][]XRangeEntry, len(m.values)/2)
-		for i := 0; i < len(m.values); i += 2 {
-			if ret[m.values[i].string], err = m.values[i+1].AsXRange(); err != nil {
+		ret = make(map[string][]XRangeEntry, len(m.values())/2)
+		for i := 0; i < len(m.values()); i += 2 {
+			if ret[m.values()[i].string()], err = m.values()[i+1].AsXRange(); err != nil {
 				return nil, err
 			}
 		}
 		return ret, nil
 	}
 	if m.IsArray() {
-		ret = make(map[string][]XRangeEntry, len(m.values))
-		for _, v := range m.values {
-			if !v.IsArray() || len(v.values) != 2 {
-				return nil, fmt.Errorf("got %d, wanted 2", len(v.values))
+		ret = make(map[string][]XRangeEntry, len(m.values()))
+		for _, v := range m.values() {
+			if !v.IsArray() || len(v.values()) != 2 {
+				return nil, fmt.Errorf("got %d, wanted 2", len(v.values()))
 			}
-			if ret[v.values[0].string], err = v.values[1].AsXRange(); err != nil {
+			if ret[v.values()[0].string()], err = v.values()[1].AsXRange(); err != nil {
 				return nil, err
 			}
 		}
@@ -1004,7 +1040,7 @@ func (m *RedisMessage) AsZScores() ([]ZScore, error) {
 	if len(arr) > 0 && arr[0].IsArray() {
 		scores := make([]ZScore, len(arr))
 		for i, v := range arr {
-			if scores[i], err = toZScore(v.values); err != nil {
+			if scores[i], err = toZScore(v.values()); err != nil {
 				return nil, err
 			}
 		}
@@ -1047,8 +1083,8 @@ func (m *RedisMessage) AsMap() (map[string]RedisMessage, error) {
 	if err := m.Error(); err != nil {
 		return nil, err
 	}
-	if (m.IsMap() || m.IsArray()) && len(m.values)%2 == 0 {
-		return toMap(m.values)
+	if (m.IsMap() || m.IsArray()) && len(m.values())%2 == 0 {
+		return toMap(m.values())
 	}
 	typ := m.typ
 	return nil, fmt.Errorf("%w: redis message type %s is not a map/array/set or its length is not even", errParse, typeNames[typ])
@@ -1060,12 +1096,12 @@ func (m *RedisMessage) AsStrMap() (map[string]string, error) {
 	if err := m.Error(); err != nil {
 		return nil, err
 	}
-	if (m.IsMap() || m.IsArray()) && len(m.values)%2 == 0 {
-		r := make(map[string]string, len(m.values)/2)
-		for i := 0; i < len(m.values); i += 2 {
-			k := m.values[i]
-			v := m.values[i+1]
-			r[k.string] = v.string
+	if (m.IsMap() || m.IsArray()) && len(m.values())%2 == 0 {
+		r := make(map[string]string, len(m.values())/2)
+		for i := 0; i < len(m.values()); i += 2 {
+			k := m.values()[i]
+			v := m.values()[i+1]
+			r[k.string()] = v.string()
 		}
 		return r, nil
 	}
@@ -1079,19 +1115,19 @@ func (m *RedisMessage) AsIntMap() (map[string]int64, error) {
 	if err := m.Error(); err != nil {
 		return nil, err
 	}
-	if (m.IsMap() || m.IsArray()) && len(m.values)%2 == 0 {
+	if (m.IsMap() || m.IsArray()) && len(m.values())%2 == 0 {
 		var err error
-		r := make(map[string]int64, len(m.values)/2)
-		for i := 0; i < len(m.values); i += 2 {
-			k := m.values[i]
-			v := m.values[i+1]
+		r := make(map[string]int64, len(m.values())/2)
+		for i := 0; i < len(m.values()); i += 2 {
+			k := m.values()[i]
+			v := m.values()[i+1]
 			if k.typ == typeBlobString || k.typ == typeSimpleString {
-				if len(v.string) != 0 {
-					if r[k.string], err = strconv.ParseInt(v.string, 0, 64); err != nil {
+				if len(v.string()) != 0 {
+					if r[k.string()], err = strconv.ParseInt(v.string(), 0, 64); err != nil {
 						return nil, err
 					}
 				} else if v.typ == typeInteger || v.typ == typeNull {
-					r[k.string] = v.integer
+					r[k.string()] = v.integer
 				}
 			}
 		}
@@ -1110,9 +1146,9 @@ func (m *RedisMessage) AsLMPop() (kvs KeyValues, err error) {
 	if err = m.Error(); err != nil {
 		return KeyValues{}, err
 	}
-	if len(m.values) >= 2 {
-		kvs.Key = m.values[0].string
-		kvs.Values, err = m.values[1].AsStrSlice()
+	if len(m.values()) >= 2 {
+		kvs.Key = m.values()[0].string()
+		kvs.Values, err = m.values()[1].AsStrSlice()
 		return
 	}
 	typ := m.typ
@@ -1128,9 +1164,9 @@ func (m *RedisMessage) AsZMPop() (kvs KeyZScores, err error) {
 	if err = m.Error(); err != nil {
 		return KeyZScores{}, err
 	}
-	if len(m.values) >= 2 {
-		kvs.Key = m.values[0].string
-		kvs.Values, err = m.values[1].AsZScores()
+	if len(m.values()) >= 2 {
+		kvs.Key = m.values()[0].string()
+		kvs.Values, err = m.values()[1].AsZScores()
 		return
 	}
 	typ := m.typ
@@ -1148,27 +1184,27 @@ func (m *RedisMessage) AsFtSearch() (total int64, docs []FtSearchDoc, err error)
 		return 0, nil, err
 	}
 	if m.IsMap() {
-		for i := 0; i < len(m.values); i += 2 {
-			switch m.values[i].string {
+		for i := 0; i < len(m.values()); i += 2 {
+			switch m.values()[i].string() {
 			case "total_results":
-				total = m.values[i+1].integer
+				total = m.values()[i+1].integer
 			case "results":
-				records := m.values[i+1].values
+				records := m.values()[i+1].values()
 				docs = make([]FtSearchDoc, len(records))
 				for d, record := range records {
-					for j := 0; j < len(record.values); j += 2 {
-						switch record.values[j].string {
+					for j := 0; j < len(record.values()); j += 2 {
+						switch record.values()[j].string() {
 						case "id":
-							docs[d].Key = record.values[j+1].string
+							docs[d].Key = record.values()[j+1].string()
 						case "extra_attributes":
-							docs[d].Doc, _ = record.values[j+1].AsStrMap()
+							docs[d].Doc, _ = record.values()[j+1].AsStrMap()
 						case "score":
-							docs[d].Score, _ = strconv.ParseFloat(record.values[j+1].string, 64)
+							docs[d].Score, _ = strconv.ParseFloat(record.values()[j+1].string(), 64)
 						}
 					}
 				}
 			case "error":
-				for _, e := range m.values[i+1].values {
+				for _, e := range m.values()[i+1].values() {
 					e := e
 					return 0, nil, (*RedisError)(&e)
 				}
@@ -1176,36 +1212,36 @@ func (m *RedisMessage) AsFtSearch() (total int64, docs []FtSearchDoc, err error)
 		}
 		return
 	}
-	if len(m.values) > 0 {
-		total = m.values[0].integer
+	if len(m.values()) > 0 {
+		total = m.values()[0].integer
 		wscore := false
 		wattrs := false
 		offset := 1
-		if len(m.values) > 2 {
-			if m.values[2].string == "" {
+		if len(m.values()) > 2 {
+			if m.values()[2].string() == "" {
 				wattrs = true
 				offset++
 			} else {
-				_, err1 := strconv.ParseFloat(m.values[1].string, 64)
-				_, err2 := strconv.ParseFloat(m.values[2].string, 64)
+				_, err1 := strconv.ParseFloat(m.values()[1].string(), 64)
+				_, err2 := strconv.ParseFloat(m.values()[2].string(), 64)
 				wscore = err1 != nil && err2 == nil
 				offset++
 			}
 		}
-		if len(m.values) > 3 && m.values[3].string == "" {
+		if len(m.values()) > 3 && m.values()[3].string() == "" {
 			wattrs = true
 			offset++
 		}
-		docs = make([]FtSearchDoc, 0, (len(m.values)-1)/offset)
-		for i := 1; i < len(m.values); i++ {
-			doc := FtSearchDoc{Key: m.values[i].string}
+		docs = make([]FtSearchDoc, 0, (len(m.values())-1)/offset)
+		for i := 1; i < len(m.values()); i++ {
+			doc := FtSearchDoc{Key: m.values()[i].string()}
 			if wscore {
 				i++
-				doc.Score, _ = strconv.ParseFloat(m.values[i].string, 64)
+				doc.Score, _ = strconv.ParseFloat(m.values()[i].string(), 64)
 			}
 			if wattrs {
 				i++
-				doc.Doc, _ = m.values[i].AsStrMap()
+				doc.Doc, _ = m.values()[i].AsStrMap()
 			}
 			docs = append(docs, doc)
 		}
@@ -1220,23 +1256,23 @@ func (m *RedisMessage) AsFtAggregate() (total int64, docs []map[string]string, e
 		return 0, nil, err
 	}
 	if m.IsMap() {
-		for i := 0; i < len(m.values); i += 2 {
-			switch m.values[i].string {
+		for i := 0; i < len(m.values()); i += 2 {
+			switch m.values()[i].string() {
 			case "total_results":
-				total = m.values[i+1].integer
+				total = m.values()[i+1].integer
 			case "results":
-				records := m.values[i+1].values
+				records := m.values()[i+1].values()
 				docs = make([]map[string]string, len(records))
 				for d, record := range records {
-					for j := 0; j < len(record.values); j += 2 {
-						switch record.values[j].string {
+					for j := 0; j < len(record.values()); j += 2 {
+						switch record.values()[j].string() {
 						case "extra_attributes":
-							docs[d], _ = record.values[j+1].AsStrMap()
+							docs[d], _ = record.values()[j+1].AsStrMap()
 						}
 					}
 				}
 			case "error":
-				for _, e := range m.values[i+1].values {
+				for _, e := range m.values()[i+1].values() {
 					e := e
 					return 0, nil, (*RedisError)(&e)
 				}
@@ -1244,10 +1280,10 @@ func (m *RedisMessage) AsFtAggregate() (total int64, docs []map[string]string, e
 		}
 		return
 	}
-	if len(m.values) > 0 {
-		total = m.values[0].integer
-		docs = make([]map[string]string, len(m.values)-1)
-		for d, record := range m.values[1:] {
+	if len(m.values()) > 0 {
+		total = m.values()[0].integer
+		docs = make([]map[string]string, len(m.values())-1)
+		for d, record := range m.values()[1:] {
 			docs[d], _ = record.AsStrMap()
 		}
 		return
@@ -1257,9 +1293,9 @@ func (m *RedisMessage) AsFtAggregate() (total int64, docs []map[string]string, e
 }
 
 func (m *RedisMessage) AsFtAggregateCursor() (cursor, total int64, docs []map[string]string, err error) {
-	if m.IsArray() && len(m.values) == 2 && (m.values[0].IsArray() || m.values[0].IsMap()) {
-		total, docs, err = m.values[0].AsFtAggregate()
-		cursor = m.values[1].integer
+	if m.IsArray() && len(m.values()) == 2 && (m.values()[0].IsArray() || m.values()[0].IsMap()) {
+		total, docs, err = m.values()[0].AsFtAggregate()
+		cursor = m.values()[1].integer
 	} else {
 		total, docs, err = m.AsFtAggregate()
 	}
@@ -1281,17 +1317,17 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 	for _, v := range arr {
 		var loc GeoLocation
 		if v.IsString() {
-			loc.Name = v.string
+			loc.Name = v.string()
 		} else {
-			info := v.values
+			info := v.values()
 			var i int
 
 			//name
-			loc.Name = info[i].string
+			loc.Name = info[i].string()
 			i++
 			//distance
-			if i < len(info) && info[i].string != "" {
-				loc.Dist, err = util.ToFloat64(info[i].string)
+			if i < len(info) && info[i].string() != "" {
+				loc.Dist, err = util.ToFloat64(info[i].string())
 				if err != nil {
 					return nil, err
 				}
@@ -1303,8 +1339,8 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 				i++
 			}
 			//coordinates
-			if i < len(info) && info[i].values != nil {
-				cord := info[i].values
+			if i < len(info) && info[i].values() != nil {
+				cord := info[i].values()
 				if len(cord) < 2 {
 					return nil, fmt.Errorf("got %d, expected 2", len(info))
 				}
@@ -1320,7 +1356,7 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 // ToMap check if message is a redis RESP3 map response, and return it
 func (m *RedisMessage) ToMap() (map[string]RedisMessage, error) {
 	if m.IsMap() {
-		return toMap(m.values)
+		return toMap(m.values())
 	}
 	if err := m.Error(); err != nil {
 		return nil, err
@@ -1336,27 +1372,27 @@ func (m *RedisMessage) ToAny() (any, error) {
 	}
 	switch m.typ {
 	case typeFloat:
-		return util.ToFloat64(m.string)
+		return util.ToFloat64(m.string())
 	case typeBlobString, typeSimpleString, typeVerbatimString, typeBigNumber:
-		return m.string, nil
+		return m.string(), nil
 	case typeBool:
 		return m.integer == 1, nil
 	case typeInteger:
 		return m.integer, nil
 	case typeMap:
-		vs := make(map[string]any, len(m.values)/2)
-		for i := 0; i < len(m.values); i += 2 {
-			if v, err := m.values[i+1].ToAny(); err != nil && !IsRedisNil(err) {
-				vs[m.values[i].string] = err
+		vs := make(map[string]any, len(m.values())/2)
+		for i := 0; i < len(m.values()); i += 2 {
+			if v, err := m.values()[i+1].ToAny(); err != nil && !IsRedisNil(err) {
+				vs[m.values()[i].string()] = err
 			} else {
-				vs[m.values[i].string] = v
+				vs[m.values()[i].string()] = v
 			}
 		}
 		return vs, nil
 	case typeSet, typeArray:
-		vs := make([]any, len(m.values))
-		for i := 0; i < len(m.values); i++ {
-			if v, err := m.values[i].ToAny(); err != nil && !IsRedisNil(err) {
+		vs := make([]any, len(m.values()))
+		for i := 0; i < len(m.values()); i++ {
+			if v, err := m.values()[i].ToAny(); err != nil && !IsRedisNil(err) {
 				vs[i] = err
 			} else {
 				vs[i] = v
@@ -1429,7 +1465,7 @@ func toMap(values []RedisMessage) (map[string]RedisMessage, error) {
 	r := make(map[string]RedisMessage, len(values)/2)
 	for i := 0; i < len(values); i += 2 {
 		if values[i].typ == typeBlobString || values[i].typ == typeSimpleString {
-			r[values[i].string] = values[i+1]
+			r[values[i].string()] = values[i+1]
 			continue
 		}
 		typ := values[i].typ
@@ -1440,8 +1476,8 @@ func toMap(values []RedisMessage) (map[string]RedisMessage, error) {
 
 func (m *RedisMessage) approximateSize() (s int) {
 	s += messageStructSize
-	s += len(m.string)
-	for _, v := range m.values {
+	s += len(m.string())
+	for _, v := range m.values() {
 		s += v.approximateSize()
 	}
 	return
@@ -1454,6 +1490,20 @@ func (m *RedisMessage) String() string {
 }
 
 type prettyRedisMessage RedisMessage
+
+func (m *prettyRedisMessage) string() string {
+	if m.bytes == nil {
+		return ""
+	}
+	return unsafe.String(m.bytes, m.integer)
+}
+
+func (m *prettyRedisMessage) values() []RedisMessage {
+	if m.array == nil {
+		return nil
+	}
+	return unsafe.Slice(m.array, m.integer)
+}
 
 // MarshalJSON implements json.Marshaler interface
 func (m *prettyRedisMessage) MarshalJSON() ([]byte, error) {
@@ -1477,17 +1527,33 @@ func (m *prettyRedisMessage) MarshalJSON() ([]byte, error) {
 	}
 	switch m.typ {
 	case typeFloat, typeBlobString, typeSimpleString, typeVerbatimString, typeBigNumber:
-		obj.Value = m.string
+		obj.Value = m.string()
 	case typeBool:
 		obj.Value = m.integer == 1
 	case typeInteger:
 		obj.Value = m.integer
 	case typeMap, typeSet, typeArray:
-		values := make([]prettyRedisMessage, len(m.values))
-		for i, value := range m.values {
+		values := make([]prettyRedisMessage, len(m.values()))
+		for i, value := range m.values() {
 			values[i] = prettyRedisMessage(value)
 		}
 		obj.Value = values
 	}
 	return json.Marshal(obj)
+}
+
+func redisMessageContainSlice(typ byte, values []RedisMessage) RedisMessage {
+	return RedisMessage{
+		typ:     typ,
+		array:   unsafe.SliceData(values),
+		integer: int64(len(values)),
+	}
+}
+
+func redisMessageContainString(typ byte, value string) RedisMessage {
+	return RedisMessage{
+		typ:     typ,
+		bytes:   unsafe.StringData(value),
+		integer: int64(len(value)),
+	}
 }

--- a/message.go
+++ b/message.go
@@ -52,7 +52,7 @@ func IsRedisErr(err error) (ret *RedisError, ok bool) {
 // RedisError is an error response or a nil message from redis instance
 type RedisError RedisMessage
 
-// string retrives the contained string of the RedisMessage
+// string retrives the contained string of the RedisError
 func (m *RedisError) string() string {
 	if m.bytes == nil {
 		return ""
@@ -616,7 +616,6 @@ func (m *RedisMessage) unmarshalView(c int64, buf []byte) (int64, error) {
 		m.integer = size
 	case typeArray, typeMap, typeSet:
 		m.setValues(make([]RedisMessage, size))
-		size = 0
 		for i := range m.values() {
 			if c, err = m.values()[i].unmarshalView(c, buf); err != nil {
 				break
@@ -628,7 +627,6 @@ func (m *RedisMessage) unmarshalView(c int64, buf []byte) (int64, error) {
 		}
 		m.setString(BinaryString(buf[c : c+size]))
 		c += size
-		size = 0
 	}
 	return c, err
 }

--- a/message.go
+++ b/message.go
@@ -1540,7 +1540,7 @@ func (m *prettyRedisMessage) MarshalJSON() ([]byte, error) {
 	return json.Marshal(obj)
 }
 
-func redisMessageContainSlice(typ byte, values []RedisMessage) RedisMessage {
+func slicemsg(typ byte, values []RedisMessage) RedisMessage {
 	return RedisMessage{
 		typ:     typ,
 		array:   unsafe.SliceData(values),
@@ -1548,7 +1548,7 @@ func redisMessageContainSlice(typ byte, values []RedisMessage) RedisMessage {
 	}
 }
 
-func redisMessageContainString(typ byte, value string) RedisMessage {
+func strmsg(typ byte, value string) RedisMessage {
 	return RedisMessage{
 		typ:     typ,
 		bytes:   unsafe.StringData(value),

--- a/message.go
+++ b/message.go
@@ -717,7 +717,7 @@ func (m *RedisMessage) ToString() (val string, err error) {
 	if m.IsString() {
 		return m.string(), nil
 	}
-	if m.IsInt64() || m.values() != nil {
+	if m.IsInt64() || m.array != nil {
 		typ := m.typ
 		return "", fmt.Errorf("%w: redis message type %s is not a string", errParse, typeNames[typ])
 	}
@@ -1337,7 +1337,7 @@ func (m *RedisMessage) AsGeosearch() ([]GeoLocation, error) {
 				i++
 			}
 			//coordinates
-			if i < len(info) && info[i].values() != nil {
+			if i < len(info) && info[i].array != nil {
 				cord := info[i].values()
 				if len(cord) < 2 {
 					return nil, fmt.Errorf("got %d, expected 2", len(info))

--- a/message_test.go
+++ b/message_test.go
@@ -86,7 +86,7 @@ func TestRedisErrorIsMoved(t *testing.T) {
 		{err: "MOVED 1 [::1]:1", addr: "[::1]:1"},
 		{err: "MOVED 1 ::1:1", addr: "[::1]:1"},
 	} {
-		e := RedisError(redisMessageContainString('-', c.err))
+		e := RedisError(strmsg('-', c.err))
 		if addr, ok := e.IsMoved(); !ok || addr != c.addr {
 			t.Fail()
 		}
@@ -102,7 +102,7 @@ func TestRedisErrorIsAsk(t *testing.T) {
 		{err: "ASK 1 [::1]:1", addr: "[::1]:1"},
 		{err: "ASK 1 ::1:1", addr: "[::1]:1"},
 	} {
-		e := RedisError(redisMessageContainString('-', c.err))
+		e := RedisError(strmsg('-', c.err))
 		if addr, ok := e.IsAsk(); !ok || addr != c.addr {
 			t.Fail()
 		}
@@ -115,7 +115,7 @@ func TestIsRedisBusyGroup(t *testing.T) {
 		t.Fatal("TestIsRedisBusyGroup fail")
 	}
 
-	redisErr := RedisError(redisMessageContainString('-', "BUSYGROUP Consumer Group name already exists"))
+	redisErr := RedisError(strmsg('-', "BUSYGROUP Consumer Group name already exists"))
 	err = &redisErr
 	if !IsRedisBusyGroup(err) {
 		t.Fatal("TestIsRedisBusyGroup fail")
@@ -164,10 +164,10 @@ func TestRedisResult(t *testing.T) {
 		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 1}}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString('+', "OK")}).AsBool(); !v {
+		if v, _ := (RedisResult{val: strmsg('+', "OK")}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString('$', "OK")}).AsBool(); !v {
+		if v, _ := (RedisResult{val: strmsg('$', "OK")}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
 	})
@@ -179,7 +179,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToFloat64(); err == nil {
 			t.Fatal("ToFloat64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString(',', "0.1")}).ToFloat64(); v != 0.1 {
+		if v, _ := (RedisResult{val: strmsg(',', "0.1")}).ToFloat64(); v != 0.1 {
 			t.Fatal("ToFloat64 not get value as expected")
 		}
 	})
@@ -191,7 +191,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToString(); err == nil {
 			t.Fatal("ToString not failed as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString('+', "0.1")}).ToString(); v != "0.1" {
+		if v, _ := (RedisResult{val: strmsg('+', "0.1")}).ToString(); v != "0.1" {
 			t.Fatal("ToString not get value as expected")
 		}
 	})
@@ -203,7 +203,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsReader(); err == nil {
 			t.Fatal("AsReader not failed as expected")
 		}
-		r, _ := (RedisResult{val: redisMessageContainString('+', "0.1")}).AsReader()
+		r, _ := (RedisResult{val: strmsg('+', "0.1")}).AsReader()
 		bs, _ := io.ReadAll(r)
 		if !bytes.Equal(bs, []byte("0.1")) {
 			t.Fatalf("AsReader not get value as expected %v", bs)
@@ -217,7 +217,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsBytes(); err == nil {
 			t.Fatal("AsBytes not failed as expected")
 		}
-		bs, _ := (RedisResult{val: redisMessageContainString('+', "0.1")}).AsBytes()
+		bs, _ := (RedisResult{val: strmsg('+', "0.1")}).AsBytes()
 		if !bytes.Equal(bs, []byte("0.1")) {
 			t.Fatalf("AsBytes not get value as expected %v", bs)
 		}
@@ -231,7 +231,7 @@ func TestRedisResult(t *testing.T) {
 		if err := (RedisResult{val: RedisMessage{typ: '-'}}).DecodeJSON(&v); err == nil {
 			t.Fatal("DecodeJSON not failed as expected")
 		}
-		if _ = (RedisResult{val: redisMessageContainString('+', `{"k":"v"}`)}).DecodeJSON(&v); v["k"] != "v" {
+		if _ = (RedisResult{val: strmsg('+', `{"k":"v"}`)}).DecodeJSON(&v); v["k"] != "v" {
 			t.Fatalf("DecodeJSON not get value as expected %v", v)
 		}
 	})
@@ -243,7 +243,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsInt64(); err == nil {
 			t.Fatal("AsInt64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString('+', "1")}).AsInt64(); v != 1 {
+		if v, _ := (RedisResult{val: strmsg('+', "1")}).AsInt64(); v != 1 {
 			t.Fatal("AsInt64 not get value as expected")
 		}
 		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 2}}).AsInt64(); v != 2 {
@@ -258,7 +258,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsUint64(); err == nil {
 			t.Fatal("AsUint64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString('+', "1")}).AsUint64(); v != 1 {
+		if v, _ := (RedisResult{val: strmsg('+', "1")}).AsUint64(); v != 1 {
 			t.Fatal("AsUint64 not get value as expected")
 		}
 		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 2}}).AsUint64(); v != 2 {
@@ -273,10 +273,10 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFloat64(); err == nil {
 			t.Fatal("AsFloat64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString('+', "1.1")}).AsFloat64(); v != 1.1 {
+		if v, _ := (RedisResult{val: strmsg('+', "1.1")}).AsFloat64(); v != 1.1 {
 			t.Fatal("AsFloat64 not get value as expected")
 		}
-		if v, _ := (RedisResult{val: redisMessageContainString(',', "2.2")}).AsFloat64(); v != 2.2 {
+		if v, _ := (RedisResult{val: strmsg(',', "2.2")}).AsFloat64(); v != 2.2 {
 			t.Fatal("AsFloat64 not get value as expected")
 		}
 	})
@@ -288,8 +288,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToArray(); err == nil {
 			t.Fatal("ToArray not failed as expected")
 		}
-		values := []RedisMessage{redisMessageContainString('+', "item")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).ToArray(); !reflect.DeepEqual(ret, values) {
+		values := []RedisMessage{strmsg('+', "item")}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).ToArray(); !reflect.DeepEqual(ret, values) {
 			t.Fatal("ToArray not get value as expected")
 		}
 	})
@@ -301,8 +301,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsStrSlice(); err == nil {
 			t.Fatal("AsStrSlice not failed as expected")
 		}
-		values := []RedisMessage{redisMessageContainString('+', "item")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsStrSlice(); !reflect.DeepEqual(ret, []string{"item"}) {
+		values := []RedisMessage{strmsg('+', "item")}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsStrSlice(); !reflect.DeepEqual(ret, []string{"item"}) {
 			t.Fatal("AsStrSlice not get value as expected")
 		}
 	})
@@ -315,15 +315,15 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsIntSlice not failed as expected")
 		}
 		values := []RedisMessage{{integer: 2, typ: ':'}}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{2}) {
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{2}) {
 			t.Fatal("AsIntSlice not get value as expected")
 		}
-		values = []RedisMessage{redisMessageContainString('+', "3")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{3}) {
+		values = []RedisMessage{strmsg('+', "3")}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{3}) {
 			t.Fatal("AsIntSlice not get value as expected")
 		}
-		values = []RedisMessage{redisMessageContainString('+', "ab")}
-		if _, err := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntSlice(); err == nil {
+		values = []RedisMessage{strmsg('+', "ab")}
+		if _, err := (RedisResult{val: slicemsg('*', values)}).AsIntSlice(); err == nil {
 			t.Fatal("AsIntSlice not failed as expected")
 		}
 	})
@@ -335,11 +335,11 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFloatSlice(); err == nil {
 			t.Fatal("AsFloatSlice not failed as expected")
 		}
-		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString(',', "fff")})}).AsFloatSlice(); err == nil {
+		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg(',', "fff")})}).AsFloatSlice(); err == nil {
 			t.Fatal("AsFloatSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 1, typ: ':'}, redisMessageContainString('+', "2"), redisMessageContainString('$', "3"), redisMessageContainString(',', "4")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsFloatSlice(); !reflect.DeepEqual(ret, []float64{1, 2, 3, 4}) {
+		values := []RedisMessage{{integer: 1, typ: ':'}, strmsg('+', "2"), strmsg('$', "3"), strmsg(',', "4")}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsFloatSlice(); !reflect.DeepEqual(ret, []float64{1, 2, 3, 4}) {
 			t.Fatal("AsFloatSlice not get value as expected")
 		}
 	})
@@ -351,8 +351,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsBoolSlice(); err == nil {
 			t.Fatal("AsBoolSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 1, typ: ':'}, redisMessageContainString('+', "0"), {integer: 1, typ: typeBool}}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsBoolSlice(); !reflect.DeepEqual(ret, []bool{true, false, true}) {
+		values := []RedisMessage{{integer: 1, typ: ':'}, strmsg('+', "0"), {integer: 1, typ: typeBool}}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsBoolSlice(); !reflect.DeepEqual(ret, []bool{true, false, true}) {
 			t.Fatal("AsBoolSlice not get value as expected")
 		}
 	})
@@ -364,8 +364,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsMap(); err == nil {
 			t.Fatal("AsMap not failed as expected")
 		}
-		values := []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsMap(); !reflect.DeepEqual(map[string]RedisMessage{
+		values := []RedisMessage{strmsg('+', "key"), strmsg('+', "value")}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsMap(); !reflect.DeepEqual(map[string]RedisMessage{
 			values[0].string(): values[1],
 		}, ret) {
 			t.Fatal("AsMap not get value as expected")
@@ -379,8 +379,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsStrMap(); err == nil {
 			t.Fatal("AsStrMap not failed as expected")
 		}
-		values := []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsStrMap(); !reflect.DeepEqual(map[string]string{
+		values := []RedisMessage{strmsg('+', "key"), strmsg('+', "value")}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsStrMap(); !reflect.DeepEqual(map[string]string{
 			values[0].string(): values[1].string(),
 		}, ret) {
 			t.Fatal("AsStrMap not get value as expected")
@@ -394,11 +394,11 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsIntMap(); err == nil {
 			t.Fatal("AsIntMap not failed as expected")
 		}
-		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")})}).AsIntMap(); err == nil {
+		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "key"), strmsg('+', "value")})}).AsIntMap(); err == nil {
 			t.Fatal("AsIntMap not failed as expected")
 		}
-		values := []RedisMessage{redisMessageContainString('+', "k1"), redisMessageContainString('+', "1"), redisMessageContainString('+', "k2"), {integer: 2, typ: ':'}}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntMap(); !reflect.DeepEqual(map[string]int64{
+		values := []RedisMessage{strmsg('+', "k1"), strmsg('+', "1"), strmsg('+', "k2"), {integer: 2, typ: ':'}}
+		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsIntMap(); !reflect.DeepEqual(map[string]int64{
 			"k1": 1,
 			"k2": 2,
 		}, ret) {
@@ -413,8 +413,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToMap(); err == nil {
 			t.Fatal("ToMap not failed as expected")
 		}
-		values := []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('%', values)}).ToMap(); !reflect.DeepEqual(map[string]RedisMessage{
+		values := []RedisMessage{strmsg('+', "key"), strmsg('+', "value")}
+		if ret, _ := (RedisResult{val: slicemsg('%', values)}).ToMap(); !reflect.DeepEqual(map[string]RedisMessage{
 			values[0].string(): values[1],
 		}, ret) {
 			t.Fatal("ToMap not get value as expected")
@@ -428,15 +428,15 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToAny(); err == nil {
 			t.Fatal("ToAny not failed as expected")
 		}
-		redisErr := RedisError(redisMessageContainString('-', "err"))
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('%', []RedisMessage{redisMessageContainString('+', "key"), {typ: ':', integer: 1}}),
-			redisMessageContainSlice('%', []RedisMessage{redisMessageContainString('+', "nil"), {typ: '_'}}),
-			redisMessageContainSlice('%', []RedisMessage{redisMessageContainString('+', "err"), redisMessageContainString('-', "err")}),
-			redisMessageContainString(',', "1.2"),
-			redisMessageContainString('+', "str"),
+		redisErr := RedisError(strmsg('-', "err"))
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('%', []RedisMessage{strmsg('+', "key"), {typ: ':', integer: 1}}),
+			slicemsg('%', []RedisMessage{strmsg('+', "nil"), {typ: '_'}}),
+			slicemsg('%', []RedisMessage{strmsg('+', "err"), strmsg('-', "err")}),
+			strmsg(',', "1.2"),
+			strmsg('+', "str"),
 			{typ: '#', integer: 0},
-			redisMessageContainString('-', "err"),
+			strmsg('-', "err"),
 			{typ: '_'},
 		})}).ToAny(); !reflect.DeepEqual([]any{
 			map[string]any{"key": int64(1)},
@@ -459,13 +459,13 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})})}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "id"), slicemsg('*', []RedisMessage{strmsg('+', "a"), strmsg('+', "b")})})}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
 			ID:          "id",
 			FieldValues: map[string]string{"a": "b"},
 		}, ret) {
 			t.Fatal("AsXRangeEntry not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id"), {typ: '_'}})}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "id"), {typ: '_'}})}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
 			ID:          "id",
 			FieldValues: nil,
 		}, ret) {
@@ -480,9 +480,9 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsXRange(); err == nil {
 			t.Fatal("AsXRange not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})}),
-			redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id2"), {typ: '_'}}),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{strmsg('+', "id1"), slicemsg('*', []RedisMessage{strmsg('+', "a"), strmsg('+', "b")})}),
+			slicemsg('*', []RedisMessage{strmsg('+', "id2"), {typ: '_'}}),
 		})}).AsXRange(); !reflect.DeepEqual([]XRangeEntry{{
 			ID:          "id1",
 			FieldValues: map[string]string{"a": "b"},
@@ -501,15 +501,15 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsXRead(); err == nil {
 			t.Fatal("AsXRead not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
-			redisMessageContainString('+', "stream1"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})}),
-				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id2"), {typ: '_'}}),
+		if ret, _ := (RedisResult{val: slicemsg('%', []RedisMessage{
+			strmsg('+', "stream1"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{strmsg('+', "id1"), slicemsg('*', []RedisMessage{strmsg('+', "a"), strmsg('+', "b")})}),
+				slicemsg('*', []RedisMessage{strmsg('+', "id2"), {typ: '_'}}),
 			}),
-			redisMessageContainString('+', "stream2"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id3"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "c"), redisMessageContainString('+', "d")})}),
+			strmsg('+', "stream2"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{strmsg('+', "id3"), slicemsg('*', []RedisMessage{strmsg('+', "c"), strmsg('+', "d")})}),
 			}),
 		})}).AsXRead(); !reflect.DeepEqual(map[string][]XRangeEntry{
 			"stream1": {
@@ -521,18 +521,18 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsXRead not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "stream1"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})}),
-					redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id2"), {typ: '_'}}),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "stream1"),
+				slicemsg('*', []RedisMessage{
+					slicemsg('*', []RedisMessage{strmsg('+', "id1"), slicemsg('*', []RedisMessage{strmsg('+', "a"), strmsg('+', "b")})}),
+					slicemsg('*', []RedisMessage{strmsg('+', "id2"), {typ: '_'}}),
 				}),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "stream2"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id3"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "c"), redisMessageContainString('+', "d")})}),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "stream2"),
+				slicemsg('*', []RedisMessage{
+					slicemsg('*', []RedisMessage{strmsg('+', "id3"), slicemsg('*', []RedisMessage{strmsg('+', "c"), strmsg('+', "d")})}),
 				}),
 			}),
 		})}).AsXRead(); !reflect.DeepEqual(map[string][]XRangeEntry{
@@ -554,15 +554,15 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsZScore(); err == nil {
 			t.Fatal("AsZScore not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "m1"),
-			redisMessageContainString('+', "1"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			strmsg('+', "m1"),
+			strmsg('+', "1"),
 		})}).AsZScore(); !reflect.DeepEqual(ZScore{Member: "m1", Score: 1}, ret) {
 			t.Fatal("AsZScore not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "m1"),
-			redisMessageContainString(',', "1"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			strmsg('+', "m1"),
+			strmsg(',', "1"),
 		})}).AsZScore(); !reflect.DeepEqual(ZScore{Member: "m1", Score: 1}, ret) {
 			t.Fatal("AsZScore not get value as expected")
 		}
@@ -575,25 +575,25 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsZScores(); err == nil {
 			t.Fatal("AsZScores not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "m1"),
-			redisMessageContainString('+', "1"),
-			redisMessageContainString('+', "m2"),
-			redisMessageContainString('+', "2"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			strmsg('+', "m1"),
+			strmsg('+', "1"),
+			strmsg('+', "m2"),
+			strmsg('+', "2"),
 		})}).AsZScores(); !reflect.DeepEqual([]ZScore{
 			{Member: "m1", Score: 1},
 			{Member: "m2", Score: 2},
 		}, ret) {
 			t.Fatal("AsZScores not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "m1"),
-				redisMessageContainString(',', "1"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "m1"),
+				strmsg(',', "1"),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "m2"),
-				redisMessageContainString(',', "2"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "m2"),
+				strmsg(',', "2"),
 			}),
 		})}).AsZScores(); !reflect.DeepEqual([]ZScore{
 			{Member: "m1", Score: 1},
@@ -610,11 +610,11 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsLMPop(); err == nil {
 			t.Fatal("AsLMPop not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "k"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "1"),
-				redisMessageContainString('+', "2"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			strmsg('+', "k"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "1"),
+				strmsg('+', "2"),
 			}),
 		})}).AsLMPop(); !reflect.DeepEqual(KeyValues{
 			Key:    "k",
@@ -631,16 +631,16 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsZMPop(); err == nil {
 			t.Fatal("AsZMPop not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "k"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "1"),
-					redisMessageContainString(',', "1"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			strmsg('+', "k"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{
+					strmsg('+', "1"),
+					strmsg(',', "1"),
 				}),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "2"),
-					redisMessageContainString(',', "2"),
+				slicemsg('*', []RedisMessage{
+					strmsg('+', "2"),
+					strmsg(',', "2"),
 				}),
 			}),
 		})}).AsZMPop(); !reflect.DeepEqual(KeyZScores{
@@ -661,21 +661,21 @@ func TestRedisResult(t *testing.T) {
 		if _, _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFtSearch(); err == nil {
 			t.Fatal("AsFtSearch not failed as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "a"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k1"),
-				redisMessageContainString('+', "v1"),
-				redisMessageContainString('+', "kk"),
-				redisMessageContainString('+', "vv"),
+			strmsg('+', "a"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k1"),
+				strmsg('+', "v1"),
+				strmsg('+', "kk"),
+				strmsg('+', "vv"),
 			}),
-			redisMessageContainString('+', "b"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k2"),
-				redisMessageContainString('+', "v2"),
-				redisMessageContainString('+', "kk"),
-				redisMessageContainString('+', "vv"),
+			strmsg('+', "b"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k2"),
+				strmsg('+', "v2"),
+				strmsg('+', "kk"),
+				strmsg('+', "vv"),
 			}),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: map[string]string{"k1": "v1", "kk": "vv"}},
@@ -683,19 +683,19 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "a"),
-			redisMessageContainString('+', "1"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k1"),
-				redisMessageContainString('+', "v1"),
+			strmsg('+', "a"),
+			strmsg('+', "1"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k1"),
+				strmsg('+', "v1"),
 			}),
-			redisMessageContainString('+', "b"),
-			redisMessageContainString('+', "2"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k2"),
-				redisMessageContainString('+', "v2"),
+			strmsg('+', "b"),
+			strmsg('+', "2"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k2"),
+				strmsg('+', "v2"),
 			}),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: map[string]string{"k1": "v1"}, Score: 1},
@@ -703,61 +703,61 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "a"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k1"),
-				redisMessageContainString('+', "v1"),
-				redisMessageContainString('+', "kk"),
-				redisMessageContainString('+', "vv"),
+			strmsg('+', "a"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k1"),
+				strmsg('+', "v1"),
+				strmsg('+', "kk"),
+				strmsg('+', "vv"),
 			}),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: map[string]string{"k1": "v1", "kk": "vv"}},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "a"),
-			redisMessageContainString('+', "b"),
+			strmsg('+', "a"),
+			strmsg('+', "b"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil},
 			{Key: "b", Doc: nil},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "a"),
-			redisMessageContainString('+', "1"),
-			redisMessageContainString('+', "b"),
-			redisMessageContainString('+', "2"),
+			strmsg('+', "a"),
+			strmsg('+', "1"),
+			strmsg('+', "b"),
+			strmsg('+', "2"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil, Score: 1},
 			{Key: "b", Doc: nil, Score: 2},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "1"),
-			redisMessageContainString('+', "2"),
+			strmsg('+', "1"),
+			strmsg('+', "2"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "1", Doc: nil},
 			{Key: "2", Doc: nil},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "a"),
+			strmsg('+', "a"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
@@ -765,62 +765,62 @@ func TestRedisResult(t *testing.T) {
 	})
 
 	t.Run("AsFtSearch RESP3", func(t *testing.T) {
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
-			redisMessageContainString('+', "total_results"),
+		if n, ret, _ := (RedisResult{val: slicemsg('%', []RedisMessage{
+			strmsg('+', "total_results"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "results"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('+', "id"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "extra_attributes"),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "$"),
-						redisMessageContainString('+', "1"),
+			strmsg('+', "results"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('%', []RedisMessage{
+					strmsg('+', "id"),
+					strmsg('+', "1"),
+					strmsg('+', "extra_attributes"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "$"),
+						strmsg('+', "1"),
 					}),
-					redisMessageContainString('+', "score"),
-					redisMessageContainString(',', "1"),
+					strmsg('+', "score"),
+					strmsg(',', "1"),
 				}),
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('+', "id"),
-					redisMessageContainString('+', "2"),
-					redisMessageContainString('+', "extra_attributes"),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "$"),
-						redisMessageContainString('+', "2"),
+				slicemsg('%', []RedisMessage{
+					strmsg('+', "id"),
+					strmsg('+', "2"),
+					strmsg('+', "extra_attributes"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "$"),
+						strmsg('+', "2"),
 					}),
-					redisMessageContainString('+', "score"),
-					redisMessageContainString(',', "2"),
+					strmsg('+', "score"),
+					strmsg(',', "2"),
 				}),
 			}),
-			redisMessageContainString('+', "error"),
-			redisMessageContainSlice('*', []RedisMessage{}),
+			strmsg('+', "error"),
+			slicemsg('*', []RedisMessage{}),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "1", Doc: map[string]string{"$": "1"}, Score: 1},
 			{Key: "2", Doc: map[string]string{"$": "2"}, Score: 2},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if _, _, err := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
-			redisMessageContainString('+', "total_results"),
+		if _, _, err := (RedisResult{val: slicemsg('%', []RedisMessage{
+			strmsg('+', "total_results"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "results"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('+', "id"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "extra_attributes"),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "$"),
-						redisMessageContainString('+', "1"),
+			strmsg('+', "results"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('%', []RedisMessage{
+					strmsg('+', "id"),
+					strmsg('+', "1"),
+					strmsg('+', "extra_attributes"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "$"),
+						strmsg('+', "1"),
 					}),
-					redisMessageContainString('+', "score"),
-					redisMessageContainString(',', "1"),
+					strmsg('+', "score"),
+					strmsg(',', "1"),
 				}),
 			}),
-			redisMessageContainString('+', "error"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "mytimeout"),
+			strmsg('+', "error"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "mytimeout"),
 			}),
 		})}).AsFtSearch(); err == nil || err.Error() != "mytimeout" {
 			t.Fatal("AsFtSearch not get value as expected")
@@ -834,19 +834,19 @@ func TestRedisResult(t *testing.T) {
 		if _, _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFtAggregate(); err == nil {
 			t.Fatal("AsFtAggregate not failed as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k1"),
-				redisMessageContainString('+', "v1"),
-				redisMessageContainString('+', "kk"),
-				redisMessageContainString('+', "vv"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k1"),
+				strmsg('+', "v1"),
+				strmsg('+', "kk"),
+				strmsg('+', "vv"),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k2"),
-				redisMessageContainString('+', "v2"),
-				redisMessageContainString('+', "kk"),
-				redisMessageContainString('+', "vv"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k2"),
+				strmsg('+', "v2"),
+				strmsg('+', "kk"),
+				strmsg('+', "vv"),
 			}),
 		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
@@ -854,20 +854,20 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "k1"),
-				redisMessageContainString('+', "v1"),
-				redisMessageContainString('+', "kk"),
-				redisMessageContainString('+', "vv"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "k1"),
+				strmsg('+', "v1"),
+				strmsg('+', "kk"),
+				strmsg('+', "vv"),
 			}),
 		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			{typ: ':', integer: 3},
 		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
@@ -875,50 +875,50 @@ func TestRedisResult(t *testing.T) {
 	})
 
 	t.Run("AsFtAggregate RESP3", func(t *testing.T) {
-		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
-			redisMessageContainString('+', "total_results"),
+		if n, ret, _ := (RedisResult{val: slicemsg('%', []RedisMessage{
+			strmsg('+', "total_results"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "results"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('+', "extra_attributes"),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "$"),
-						redisMessageContainString('+', "1"),
+			strmsg('+', "results"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('%', []RedisMessage{
+					strmsg('+', "extra_attributes"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "$"),
+						strmsg('+', "1"),
 					}),
 				}),
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('+', "extra_attributes"),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "$"),
-						redisMessageContainString('+', "2"),
+				slicemsg('%', []RedisMessage{
+					strmsg('+', "extra_attributes"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "$"),
+						strmsg('+', "2"),
 					}),
 				}),
 			}),
-			redisMessageContainString('+', "error"),
-			redisMessageContainSlice('*', []RedisMessage{}),
+			strmsg('+', "error"),
+			slicemsg('*', []RedisMessage{}),
 		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"$": "1"},
 			{"$": "2"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if _, _, err := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
-			redisMessageContainString('+', "total_results"),
+		if _, _, err := (RedisResult{val: slicemsg('%', []RedisMessage{
+			strmsg('+', "total_results"),
 			{typ: ':', integer: 3},
-			redisMessageContainString('+', "results"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('+', "extra_attributes"),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "$"),
-						redisMessageContainString('+', "1"),
+			strmsg('+', "results"),
+			slicemsg('*', []RedisMessage{
+				slicemsg('%', []RedisMessage{
+					strmsg('+', "extra_attributes"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "$"),
+						strmsg('+', "1"),
 					}),
 				}),
 			}),
-			redisMessageContainString('+', "error"),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "mytimeout"),
+			strmsg('+', "error"),
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "mytimeout"),
 			}),
 		})}).AsFtAggregate(); err == nil || err.Error() != "mytimeout" {
 			t.Fatal("AsFtAggregate not get value as expected")
@@ -932,20 +932,20 @@ func TestRedisResult(t *testing.T) {
 		if _, _, _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFtAggregateCursor(); err == nil {
 			t.Fatal("AsFtAggregate not failed as expected")
 		}
-		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
+		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 3},
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "k1"),
-					redisMessageContainString('+', "v1"),
-					redisMessageContainString('+', "kk"),
-					redisMessageContainString('+', "vv"),
+				slicemsg('*', []RedisMessage{
+					strmsg('+', "k1"),
+					strmsg('+', "v1"),
+					strmsg('+', "kk"),
+					strmsg('+', "vv"),
 				}),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "k2"),
-					redisMessageContainString('+', "v2"),
-					redisMessageContainString('+', "kk"),
-					redisMessageContainString('+', "vv"),
+				slicemsg('*', []RedisMessage{
+					strmsg('+', "k2"),
+					strmsg('+', "v2"),
+					strmsg('+', "kk"),
+					strmsg('+', "vv"),
 				}),
 			}),
 			{typ: ':', integer: 1},
@@ -955,14 +955,14 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
+		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 3},
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "k1"),
-					redisMessageContainString('+', "v1"),
-					redisMessageContainString('+', "kk"),
-					redisMessageContainString('+', "vv"),
+				slicemsg('*', []RedisMessage{
+					strmsg('+', "k1"),
+					strmsg('+', "v1"),
+					strmsg('+', "kk"),
+					strmsg('+', "vv"),
 				}),
 			}),
 			{typ: ':', integer: 1},
@@ -971,8 +971,8 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
+		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 3},
 			}),
 			{typ: ':', integer: 1},
@@ -982,29 +982,29 @@ func TestRedisResult(t *testing.T) {
 	})
 
 	t.Run("AsFtAggregate Cursor RESP3", func(t *testing.T) {
-		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('%', []RedisMessage{
-				redisMessageContainString('+', "total_results"),
+		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('%', []RedisMessage{
+				strmsg('+', "total_results"),
 				{typ: ':', integer: 3},
-				redisMessageContainString('+', "results"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "extra_attributes"),
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "$"),
-							redisMessageContainString('+', "1"),
+				strmsg('+', "results"),
+				slicemsg('*', []RedisMessage{
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "extra_attributes"),
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "$"),
+							strmsg('+', "1"),
 						}),
 					}),
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "extra_attributes"),
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "$"),
-							redisMessageContainString('+', "2"),
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "extra_attributes"),
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "$"),
+							strmsg('+', "2"),
 						}),
 					}),
 				}),
-				redisMessageContainString('+', "error"),
-				redisMessageContainSlice('*', []RedisMessage{}),
+				strmsg('+', "error"),
+				slicemsg('*', []RedisMessage{}),
 			}),
 			{typ: ':', integer: 1},
 		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
@@ -1013,23 +1013,23 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if _, _, _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('%', []RedisMessage{
-				redisMessageContainString('+', "total_results"),
+		if _, _, _, err := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('%', []RedisMessage{
+				strmsg('+', "total_results"),
 				{typ: ':', integer: 3},
-				redisMessageContainString('+', "results"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainSlice('%', []RedisMessage{
-						redisMessageContainString('+', "extra_attributes"),
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "$"),
-							redisMessageContainString('+', "1"),
+				strmsg('+', "results"),
+				slicemsg('*', []RedisMessage{
+					slicemsg('%', []RedisMessage{
+						strmsg('+', "extra_attributes"),
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "$"),
+							strmsg('+', "1"),
 						}),
 					}),
 				}),
-				redisMessageContainString('+', "error"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "mytimeout"),
+				strmsg('+', "error"),
+				slicemsg('*', []RedisMessage{
+					strmsg('+', "mytimeout"),
 				}),
 			}),
 			{typ: ':', integer: 1},
@@ -1046,23 +1046,23 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not failed as expected")
 		}
 		//WithDist, WithHash, WithCoord
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
-				redisMessageContainString(',', "2.5"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
+				strmsg(',', "2.5"),
 				{typ: ':', integer: 1},
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "28.0473"),
-					redisMessageContainString(',', "26.2041"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "28.0473"),
+					strmsg(',', "26.2041"),
 				}),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
-				redisMessageContainString(',', "4.5"),
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
+				strmsg(',', "4.5"),
 				{typ: ':', integer: 4},
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "72.4973"),
-					redisMessageContainString(',', "13.2263"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "72.4973"),
+					strmsg(',', "13.2263"),
 				}),
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
@@ -1072,21 +1072,21 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithHash, WithCoord
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
 				{typ: ':', integer: 1},
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "84.3877"),
-					redisMessageContainString(',', "33.7488"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "84.3877"),
+					strmsg(',', "33.7488"),
 				}),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
 				{typ: ':', integer: 4},
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "115.8613"),
-					redisMessageContainString(',', "31.9523"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "115.8613"),
+					strmsg(',', "31.9523"),
 				}),
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
@@ -1096,21 +1096,21 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithDist, WithCoord
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
-				redisMessageContainString(',', "2.50076"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "84.3877"),
-					redisMessageContainString(',', "33.7488"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
+				strmsg(',', "2.50076"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "84.3877"),
+					strmsg(',', "33.7488"),
 				}),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
-				redisMessageContainString(',', "1024.96"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "115.8613"),
-					redisMessageContainString(',', "31.9523"),
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
+				strmsg(',', "1024.96"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "115.8613"),
+					strmsg(',', "31.9523"),
 				}),
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
@@ -1120,19 +1120,19 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithCoord
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "122.4194"),
-					redisMessageContainString(',', "37.7749"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "122.4194"),
+					strmsg(',', "37.7749"),
 				}),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "35.6762"),
-					redisMessageContainString(',', "139.6503"),
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "35.6762"),
+					strmsg(',', "139.6503"),
 				}),
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
@@ -1142,14 +1142,14 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithDist
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
-				redisMessageContainString(',', "2.50076"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
+				strmsg(',', "2.50076"),
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
-				redisMessageContainString(',', strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)),
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
+				strmsg(',', strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)),
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", Dist: 2.50076},
@@ -1158,13 +1158,13 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithHash
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
 				{typ: ':', integer: math.MaxInt64},
 			}),
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
 				{typ: ':', integer: 22296},
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
@@ -1174,9 +1174,9 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//With no additional options
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('$', "k1"),
-			redisMessageContainString('$', "k2"),
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
+			strmsg('$', "k1"),
+			strmsg('$', "k2"),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1"},
 			{Name: "k2"},
@@ -1184,20 +1184,20 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//With wrong distance
-		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k1"),
-				redisMessageContainString(',', "wrong distance"),
+		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k1"),
+				strmsg(',', "wrong distance"),
 			}),
 		})}).AsGeosearch(); err == nil {
 			t.Fatal("AsGeosearch not failed as expected")
 		}
 		//With wrong coordinates
-		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('$', "k2"),
-				redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString(',', "35.6762"),
+		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('$', "k2"),
+				slicemsg('*', []RedisMessage{
+					strmsg(',', "35.6762"),
 				}),
 			}),
 		})}).AsGeosearch(); err == nil {
@@ -1262,14 +1262,14 @@ func TestRedisResult(t *testing.T) {
 		}{
 			{
 				input: RedisResult{
-					val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('*', []RedisMessage{
+					val: slicemsg('*', []RedisMessage{
+						slicemsg('*', []RedisMessage{
 							{typ: ':', integer: 0},
 							{typ: ':', integer: 0},
-							redisMessageContainSlice('*', []RedisMessage{ // master
-								redisMessageContainString('+', "127.0.3.1"),
+							slicemsg('*', []RedisMessage{ // master
+								strmsg('+', "127.0.3.1"),
 								{typ: ':', integer: 3},
-								redisMessageContainString('+', ""),
+								strmsg('+', ""),
 							}),
 						}),
 					}),
@@ -1302,7 +1302,7 @@ func TestRedisMessage(t *testing.T) {
 	})
 	t.Run("Trim ERR prefix", func(t *testing.T) {
 		// kvrocks: https://github.com/redis/rueidis/issues/152#issuecomment-1333923750
-		redisMessageError := redisMessageContainString('-', "ERR no_prefix")
+		redisMessageError := strmsg('-', "ERR no_prefix")
 		if (&redisMessageError).Error().Error() != "no_prefix" {
 			t.Fatal("fail to trim ERR")
 		}
@@ -1456,7 +1456,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		// Test case where the message type is '*', which is not a RESP3 string
-		redisMessageArrayWithEmptyMessage := redisMessageContainSlice('*', []RedisMessage{{}})
+		redisMessageArrayWithEmptyMessage := slicemsg('*', []RedisMessage{{}})
 		if val, err := (&redisMessageArrayWithEmptyMessage).AsInt64(); err == nil {
 			t.Fatal("AsInt64 did not fail as expected")
 		} else if val != 0 {
@@ -1475,7 +1475,7 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		// Test case where the message type is '*', which is not a RESP3 string
-		redisMessageArrayWithEmptyMessage := redisMessageContainSlice('*', []RedisMessage{{}})
+		redisMessageArrayWithEmptyMessage := slicemsg('*', []RedisMessage{{}})
 		if val, err := (&redisMessageArrayWithEmptyMessage).AsUint64(); err == nil {
 			t.Fatal("AsUint64 did not fail as expected")
 		} else if val != 0 {
@@ -1676,12 +1676,12 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		redisMessageNullAndMap := redisMessageContainSlice('*', []RedisMessage{{typ: '_'}, {typ: '%'}})
+		redisMessageNullAndMap := slicemsg('*', []RedisMessage{{typ: '_'}, {typ: '%'}})
 		if _, err := (&redisMessageNullAndMap).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		redisMessageIntAndMap := redisMessageContainSlice('*', []RedisMessage{{typ: ':'}, {typ: '%'}})
+		redisMessageIntAndMap := slicemsg('*', []RedisMessage{{typ: ':'}, {typ: '%'}})
 		if _, err := (&redisMessageIntAndMap).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		} else if !strings.Contains(err.Error(), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
@@ -1698,12 +1698,12 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		redisMessageStringAndErr := redisMessageContainSlice('*', []RedisMessage{{typ: '+'}, {typ: '-'}})
+		redisMessageStringAndErr := slicemsg('*', []RedisMessage{{typ: '+'}, {typ: '-'}})
 		if _, err := (&redisMessageStringAndErr).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		redisMessageStringAndUnknown := redisMessageContainSlice('*', []RedisMessage{{typ: '+'}, {typ: 't'}})
+		redisMessageStringAndUnknown := slicemsg('*', []RedisMessage{{typ: '+'}, {typ: 't'}})
 		if _, err := (&redisMessageStringAndUnknown).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		} else if !strings.Contains(err.Error(), "redis message type t is not a map/array/set") {
@@ -1716,7 +1716,7 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRange not failed as expected")
 		}
 
-		redisMessageArrayWithNull := redisMessageContainSlice('*', []RedisMessage{{typ: '_'}})
+		redisMessageArrayWithNull := slicemsg('*', []RedisMessage{{typ: '_'}})
 		if _, err := (&redisMessageArrayWithNull).AsXRange(); err == nil {
 			t.Fatal("AsXRange not failed as expected")
 		}
@@ -1727,27 +1727,27 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
-		redisMessageMapIncorrectLen := redisMessageContainSlice('%', []RedisMessage{
-			redisMessageContainString('+', "stream1"),
-			redisMessageContainSlice('*', []RedisMessage{redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1")})}),
+		redisMessageMapIncorrectLen := slicemsg('%', []RedisMessage{
+			strmsg('+', "stream1"),
+			slicemsg('*', []RedisMessage{slicemsg('*', []RedisMessage{strmsg('+', "id1")})}),
 		})
 		if _, err := (&redisMessageMapIncorrectLen).AsXRead(); err == nil {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
-		redisMessageArrayIncorrectLen := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "stream1"),
+		redisMessageArrayIncorrectLen := slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "stream1"),
 			}),
 		})
 		if _, err := (&redisMessageArrayIncorrectLen).AsXRead(); err == nil {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
-		redisMessageArrayIncorrectLen2 := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "stream1"),
-				redisMessageContainSlice('*', []RedisMessage{redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1")})}),
+		redisMessageArrayIncorrectLen2 := slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "stream1"),
+				slicemsg('*', []RedisMessage{slicemsg('*', []RedisMessage{strmsg('+', "id1")})}),
 			}),
 		})
 		if _, err := (&redisMessageArrayIncorrectLen2).AsXRead(); err == nil {
@@ -1777,17 +1777,17 @@ func TestRedisMessage(t *testing.T) {
 		if _, err := (&RedisMessage{typ: '_'}).AsZScores(); err == nil {
 			t.Fatal("AsZScore not failed as expected")
 		}
-		redisMessageStringArray := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "m1"),
-			redisMessageContainString('+', "m2"),
+		redisMessageStringArray := slicemsg('*', []RedisMessage{
+			strmsg('+', "m1"),
+			strmsg('+', "m2"),
 		})
 		if _, err := (&redisMessageStringArray).AsZScores(); err == nil {
 			t.Fatal("AsZScores not fails as expected")
 		}
-		redisMessageNestedStringArray := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainString('+', "m1"),
-				redisMessageContainString('+', "m2"),
+		redisMessageNestedStringArray := slicemsg('*', []RedisMessage{
+			slicemsg('*', []RedisMessage{
+				strmsg('+', "m1"),
+				strmsg('+', "m2"),
 			}),
 		})
 		if _, err := (&redisMessageNestedStringArray).AsZScores(); err == nil {
@@ -1800,16 +1800,16 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsLMPop did not fail as expected")
 		}
 
-		redisMessageStringAndNull := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "k"),
+		redisMessageStringAndNull := slicemsg('*', []RedisMessage{
+			strmsg('+', "k"),
 			{typ: '_'},
 		})
 		if _, err := (&redisMessageStringAndNull).AsLMPop(); err == nil {
 			t.Fatal("AsLMPop did not fail as expected")
 		}
 
-		redisMessageStringArray := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "k"),
+		redisMessageStringArray := slicemsg('*', []RedisMessage{
+			strmsg('+', "k"),
 		})
 		if _, err := (&redisMessageStringArray).AsLMPop(); err == nil {
 			t.Fatal("AsLMPop did not fail as expected")
@@ -1823,16 +1823,16 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsZMPop did not fail as expected")
 		}
 
-		redisMessageStringAndNull := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "k"),
+		redisMessageStringAndNull := slicemsg('*', []RedisMessage{
+			strmsg('+', "k"),
 			{typ: '_'},
 		})
 		if _, err := (&redisMessageStringAndNull).AsZMPop(); err == nil {
 			t.Fatal("AsZMPop did not fail as expected")
 		}
 
-		redisMessageStringArray := redisMessageContainSlice('*', []RedisMessage{
-			redisMessageContainString('+', "k"),
+		redisMessageStringArray := slicemsg('*', []RedisMessage{
+			strmsg('+', "k"),
 		})
 		if _, err := (&redisMessageStringArray).AsZMPop(); err == nil {
 			t.Fatal("AsZMPop did not fail as expected")
@@ -1884,22 +1884,22 @@ func TestRedisMessage(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsScanEntry(); err == nil {
 			t.Fatal("AsScanEntry not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})})}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "1"), slicemsg('*', []RedisMessage{strmsg('+', "a"), strmsg('+', "b")})})}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{
 			Cursor:   1,
 			Elements: []string{"a", "b"},
 		}, ret) {
 			t.Fatal("AsScanEntry not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "0"), {typ: '_'}})}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{}, ret) {
+		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "0"), {typ: '_'}})}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{}, ret) {
 			t.Fatal("AsScanEntry not get value as expected")
 		}
-		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "0")})}).AsScanEntry(); err == nil || !strings.Contains(err.Error(), "a scan response or its length is not at least 2") {
+		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "0")})}).AsScanEntry(); err == nil || !strings.Contains(err.Error(), "a scan response or its length is not at least 2") {
 			t.Fatal("AsScanEntry not get value as expected")
 		}
 	})
 
 	t.Run("ToMap with non-string key", func(t *testing.T) {
-		redisMessageSet := redisMessageContainSlice('~', []RedisMessage{{typ: ':'}, {typ: ':'}})
+		redisMessageSet := slicemsg('~', []RedisMessage{{typ: ':'}, {typ: ':'}})
 		_, err := (&redisMessageSet).ToMap()
 		if err == nil {
 			t.Fatal("ToMap did not fail as expected")
@@ -1907,7 +1907,7 @@ func TestRedisMessage(t *testing.T) {
 		if !strings.Contains(err.Error(), "redis message type set is not a RESP3 map") {
 			t.Fatalf("ToMap failed with unexpected error: %v", err)
 		}
-		redisMessageMap := redisMessageContainSlice('%', []RedisMessage{{typ: ':'}, {typ: ':'}})
+		redisMessageMap := slicemsg('%', []RedisMessage{{typ: ':'}, {typ: ':'}})
 		_, err = (&redisMessageMap).ToMap()
 		if err == nil {
 			t.Fatal("ToMap did not fail as expected")
@@ -1973,14 +1973,14 @@ func TestRedisMessage(t *testing.T) {
 			expected string
 		}{
 			{
-				input: redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainSlice('*', []RedisMessage{
+				input: slicemsg('*', []RedisMessage{
+					slicemsg('*', []RedisMessage{
 						{typ: ':', integer: 0},
 						{typ: ':', integer: 0},
-						redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "127.0.3.1"),
+						slicemsg('*', []RedisMessage{
+							strmsg('+', "127.0.3.1"),
 							{typ: ':', integer: 3},
-							redisMessageContainString('+', ""),
+							strmsg('+', ""),
 						}),
 					}),
 				}),
@@ -2008,11 +2008,11 @@ func TestRedisMessage(t *testing.T) {
 				expected: `{"Type":"null","Error":"redis nil message"}`,
 			},
 			{
-				input:    redisMessageContainString(typeSimpleErr, "ERR foo"),
+				input:    strmsg(typeSimpleErr, "ERR foo"),
 				expected: `{"Type":"simple error","Error":"foo"}`,
 			},
 			{
-				input:    redisMessageContainString(typeBlobErr, "ERR foo"),
+				input:    strmsg(typeBlobErr, "ERR foo"),
 				expected: `{"Type":"blob error","Error":"foo"}`,
 			},
 		}
@@ -2026,13 +2026,13 @@ func TestRedisMessage(t *testing.T) {
 
 	t.Run("CacheMarshal and CacheUnmarshalView", func(t *testing.T) {
 		m1 := RedisMessage{typ: '_'}
-		m2 := redisMessageContainString('+', "random")
+		m2 := strmsg('+', "random")
 		m3 := RedisMessage{typ: '#', integer: 1}
 		m4 := RedisMessage{typ: ':', integer: -1234}
-		m5 := redisMessageContainString(',', "-1.5")
-		m6 := redisMessageContainSlice('%', nil)
-		m7 := redisMessageContainSlice('~', []RedisMessage{m1, m2, m3, m4, m5, m6})
-		m8 := redisMessageContainSlice('*', []RedisMessage{m1, m2, m3, m4, m5, m6, m7})
+		m5 := strmsg(',', "-1.5")
+		m6 := slicemsg('%', nil)
+		m7 := slicemsg('~', []RedisMessage{m1, m2, m3, m4, m5, m6})
+		m8 := slicemsg('*', []RedisMessage{m1, m2, m3, m4, m5, m6, m7})
 		msgs := []RedisMessage{m1, m2, m3, m4, m5, m6, m7, m8}
 		now := time.Now()
 		for i := range msgs {

--- a/message_test.go
+++ b/message_test.go
@@ -134,7 +134,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToInt64(); err == nil {
 			t.Fatal("ToInt64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 1}}).ToInt64(); v != 1 {
+		if v, _ := (RedisResult{val: RedisMessage{typ: ':', intlen: 1}}).ToInt64(); v != 1 {
 			t.Fatal("ToInt64 not get value as expected")
 		}
 	})
@@ -146,7 +146,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToBool(); err == nil {
 			t.Fatal("ToBool not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '#', integer: 1}}).ToBool(); !v {
+		if v, _ := (RedisResult{val: RedisMessage{typ: '#', intlen: 1}}).ToBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
 	})
@@ -158,10 +158,10 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsBool(); err == nil {
 			t.Fatal("ToBool not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '#', integer: 1}}).AsBool(); !v {
+		if v, _ := (RedisResult{val: RedisMessage{typ: '#', intlen: 1}}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 1}}).AsBool(); !v {
+		if v, _ := (RedisResult{val: RedisMessage{typ: ':', intlen: 1}}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
 		if v, _ := (RedisResult{val: strmsg('+', "OK")}).AsBool(); !v {
@@ -246,7 +246,7 @@ func TestRedisResult(t *testing.T) {
 		if v, _ := (RedisResult{val: strmsg('+', "1")}).AsInt64(); v != 1 {
 			t.Fatal("AsInt64 not get value as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 2}}).AsInt64(); v != 2 {
+		if v, _ := (RedisResult{val: RedisMessage{typ: ':', intlen: 2}}).AsInt64(); v != 2 {
 			t.Fatal("AsInt64 not get value as expected")
 		}
 	})
@@ -261,7 +261,7 @@ func TestRedisResult(t *testing.T) {
 		if v, _ := (RedisResult{val: strmsg('+', "1")}).AsUint64(); v != 1 {
 			t.Fatal("AsUint64 not get value as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 2}}).AsUint64(); v != 2 {
+		if v, _ := (RedisResult{val: RedisMessage{typ: ':', intlen: 2}}).AsUint64(); v != 2 {
 			t.Fatal("AsUint64 not get value as expected")
 		}
 	})
@@ -314,7 +314,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsIntSlice(); err == nil {
 			t.Fatal("AsIntSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 2, typ: ':'}}
+		values := []RedisMessage{{intlen: 2, typ: ':'}}
 		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{2}) {
 			t.Fatal("AsIntSlice not get value as expected")
 		}
@@ -338,7 +338,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg(',', "fff")})}).AsFloatSlice(); err == nil {
 			t.Fatal("AsFloatSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 1, typ: ':'}, strmsg('+', "2"), strmsg('$', "3"), strmsg(',', "4")}
+		values := []RedisMessage{{intlen: 1, typ: ':'}, strmsg('+', "2"), strmsg('$', "3"), strmsg(',', "4")}
 		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsFloatSlice(); !reflect.DeepEqual(ret, []float64{1, 2, 3, 4}) {
 			t.Fatal("AsFloatSlice not get value as expected")
 		}
@@ -351,7 +351,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsBoolSlice(); err == nil {
 			t.Fatal("AsBoolSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 1, typ: ':'}, strmsg('+', "0"), {integer: 1, typ: typeBool}}
+		values := []RedisMessage{{intlen: 1, typ: ':'}, strmsg('+', "0"), {intlen: 1, typ: typeBool}}
 		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsBoolSlice(); !reflect.DeepEqual(ret, []bool{true, false, true}) {
 			t.Fatal("AsBoolSlice not get value as expected")
 		}
@@ -397,7 +397,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "key"), strmsg('+', "value")})}).AsIntMap(); err == nil {
 			t.Fatal("AsIntMap not failed as expected")
 		}
-		values := []RedisMessage{strmsg('+', "k1"), strmsg('+', "1"), strmsg('+', "k2"), {integer: 2, typ: ':'}}
+		values := []RedisMessage{strmsg('+', "k1"), strmsg('+', "1"), strmsg('+', "k2"), {intlen: 2, typ: ':'}}
 		if ret, _ := (RedisResult{val: slicemsg('*', values)}).AsIntMap(); !reflect.DeepEqual(map[string]int64{
 			"k1": 1,
 			"k2": 2,
@@ -430,12 +430,12 @@ func TestRedisResult(t *testing.T) {
 		}
 		redisErr := RedisError(strmsg('-', "err"))
 		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			slicemsg('%', []RedisMessage{strmsg('+', "key"), {typ: ':', integer: 1}}),
+			slicemsg('%', []RedisMessage{strmsg('+', "key"), {typ: ':', intlen: 1}}),
 			slicemsg('%', []RedisMessage{strmsg('+', "nil"), {typ: '_'}}),
 			slicemsg('%', []RedisMessage{strmsg('+', "err"), strmsg('-', "err")}),
 			strmsg(',', "1.2"),
 			strmsg('+', "str"),
-			{typ: '#', integer: 0},
+			{typ: '#', intlen: 0},
 			strmsg('-', "err"),
 			{typ: '_'},
 		})}).ToAny(); !reflect.DeepEqual([]any{
@@ -662,7 +662,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not failed as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "a"),
 			slicemsg('*', []RedisMessage{
 				strmsg('+', "k1"),
@@ -684,7 +684,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "a"),
 			strmsg('+', "1"),
 			slicemsg('*', []RedisMessage{
@@ -704,7 +704,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "a"),
 			slicemsg('*', []RedisMessage{
 				strmsg('+', "k1"),
@@ -718,7 +718,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "a"),
 			strmsg('+', "b"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
@@ -728,7 +728,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "a"),
 			strmsg('+', "1"),
 			strmsg('+', "b"),
@@ -740,7 +740,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "1"),
 			strmsg('+', "2"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
@@ -750,7 +750,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "a"),
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil},
@@ -758,7 +758,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
@@ -767,7 +767,7 @@ func TestRedisResult(t *testing.T) {
 	t.Run("AsFtSearch RESP3", func(t *testing.T) {
 		if n, ret, _ := (RedisResult{val: slicemsg('%', []RedisMessage{
 			strmsg('+', "total_results"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "results"),
 			slicemsg('*', []RedisMessage{
 				slicemsg('%', []RedisMessage{
@@ -803,7 +803,7 @@ func TestRedisResult(t *testing.T) {
 		}
 		if _, _, err := (RedisResult{val: slicemsg('%', []RedisMessage{
 			strmsg('+', "total_results"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "results"),
 			slicemsg('*', []RedisMessage{
 				slicemsg('%', []RedisMessage{
@@ -835,7 +835,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtAggregate not failed as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			slicemsg('*', []RedisMessage{
 				strmsg('+', "k1"),
 				strmsg('+', "v1"),
@@ -855,7 +855,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			slicemsg('*', []RedisMessage{
 				strmsg('+', "k1"),
 				strmsg('+', "v1"),
@@ -868,7 +868,7 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
 		if n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
@@ -877,7 +877,7 @@ func TestRedisResult(t *testing.T) {
 	t.Run("AsFtAggregate RESP3", func(t *testing.T) {
 		if n, ret, _ := (RedisResult{val: slicemsg('%', []RedisMessage{
 			strmsg('+', "total_results"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "results"),
 			slicemsg('*', []RedisMessage{
 				slicemsg('%', []RedisMessage{
@@ -905,7 +905,7 @@ func TestRedisResult(t *testing.T) {
 		}
 		if _, _, err := (RedisResult{val: slicemsg('%', []RedisMessage{
 			strmsg('+', "total_results"),
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 			strmsg('+', "results"),
 			slicemsg('*', []RedisMessage{
 				slicemsg('%', []RedisMessage{
@@ -934,7 +934,7 @@ func TestRedisResult(t *testing.T) {
 		}
 		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 3},
+				{typ: ':', intlen: 3},
 				slicemsg('*', []RedisMessage{
 					strmsg('+', "k1"),
 					strmsg('+', "v1"),
@@ -948,7 +948,7 @@ func TestRedisResult(t *testing.T) {
 					strmsg('+', "vv"),
 				}),
 			}),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 			{"k2": "v2", "kk": "vv"},
@@ -957,7 +957,7 @@ func TestRedisResult(t *testing.T) {
 		}
 		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 3},
+				{typ: ':', intlen: 3},
 				slicemsg('*', []RedisMessage{
 					strmsg('+', "k1"),
 					strmsg('+', "v1"),
@@ -965,7 +965,7 @@ func TestRedisResult(t *testing.T) {
 					strmsg('+', "vv"),
 				}),
 			}),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 		}, ret) {
@@ -973,9 +973,9 @@ func TestRedisResult(t *testing.T) {
 		}
 		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 3},
+				{typ: ':', intlen: 3},
 			}),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
@@ -985,7 +985,7 @@ func TestRedisResult(t *testing.T) {
 		if c, n, ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('%', []RedisMessage{
 				strmsg('+', "total_results"),
-				{typ: ':', integer: 3},
+				{typ: ':', intlen: 3},
 				strmsg('+', "results"),
 				slicemsg('*', []RedisMessage{
 					slicemsg('%', []RedisMessage{
@@ -1006,7 +1006,7 @@ func TestRedisResult(t *testing.T) {
 				strmsg('+', "error"),
 				slicemsg('*', []RedisMessage{}),
 			}),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"$": "1"},
 			{"$": "2"},
@@ -1016,7 +1016,7 @@ func TestRedisResult(t *testing.T) {
 		if _, _, _, err := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('%', []RedisMessage{
 				strmsg('+', "total_results"),
-				{typ: ':', integer: 3},
+				{typ: ':', intlen: 3},
 				strmsg('+', "results"),
 				slicemsg('*', []RedisMessage{
 					slicemsg('%', []RedisMessage{
@@ -1032,7 +1032,7 @@ func TestRedisResult(t *testing.T) {
 					strmsg('+', "mytimeout"),
 				}),
 			}),
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		})}).AsFtAggregateCursor(); err == nil || err.Error() != "mytimeout" {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
@@ -1050,7 +1050,7 @@ func TestRedisResult(t *testing.T) {
 			slicemsg('*', []RedisMessage{
 				strmsg('$', "k1"),
 				strmsg(',', "2.5"),
-				{typ: ':', integer: 1},
+				{typ: ':', intlen: 1},
 				slicemsg('*', []RedisMessage{
 					strmsg(',', "28.0473"),
 					strmsg(',', "26.2041"),
@@ -1059,7 +1059,7 @@ func TestRedisResult(t *testing.T) {
 			slicemsg('*', []RedisMessage{
 				strmsg('$', "k2"),
 				strmsg(',', "4.5"),
-				{typ: ':', integer: 4},
+				{typ: ':', intlen: 4},
 				slicemsg('*', []RedisMessage{
 					strmsg(',', "72.4973"),
 					strmsg(',', "13.2263"),
@@ -1075,7 +1075,7 @@ func TestRedisResult(t *testing.T) {
 		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('*', []RedisMessage{
 				strmsg('$', "k1"),
-				{typ: ':', integer: 1},
+				{typ: ':', intlen: 1},
 				slicemsg('*', []RedisMessage{
 					strmsg(',', "84.3877"),
 					strmsg(',', "33.7488"),
@@ -1083,7 +1083,7 @@ func TestRedisResult(t *testing.T) {
 			}),
 			slicemsg('*', []RedisMessage{
 				strmsg('$', "k2"),
-				{typ: ':', integer: 4},
+				{typ: ':', intlen: 4},
 				slicemsg('*', []RedisMessage{
 					strmsg(',', "115.8613"),
 					strmsg(',', "31.9523"),
@@ -1161,11 +1161,11 @@ func TestRedisResult(t *testing.T) {
 		if ret, _ := (RedisResult{val: slicemsg('*', []RedisMessage{
 			slicemsg('*', []RedisMessage{
 				strmsg('$', "k1"),
-				{typ: ':', integer: math.MaxInt64},
+				{typ: ':', intlen: math.MaxInt64},
 			}),
 			slicemsg('*', []RedisMessage{
 				strmsg('$', "k2"),
-				{typ: ':', integer: 22296},
+				{typ: ':', intlen: 22296},
 			}),
 		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", GeoHash: math.MaxInt64},
@@ -1264,11 +1264,11 @@ func TestRedisResult(t *testing.T) {
 				input: RedisResult{
 					val: slicemsg('*', []RedisMessage{
 						slicemsg('*', []RedisMessage{
-							{typ: ':', integer: 0},
-							{typ: ':', integer: 0},
+							{typ: ':', intlen: 0},
+							{typ: ':', intlen: 0},
 							slicemsg('*', []RedisMessage{ // master
 								strmsg('+', "127.0.3.1"),
-								{typ: ':', integer: 3},
+								{typ: ':', intlen: 3},
 								strmsg('+', ""),
 							}),
 						}),
@@ -1975,11 +1975,11 @@ func TestRedisMessage(t *testing.T) {
 			{
 				input: slicemsg('*', []RedisMessage{
 					slicemsg('*', []RedisMessage{
-						{typ: ':', integer: 0},
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
+						{typ: ':', intlen: 0},
 						slicemsg('*', []RedisMessage{
 							strmsg('+', "127.0.3.1"),
-							{typ: ':', integer: 3},
+							{typ: ':', intlen: 3},
 							strmsg('+', ""),
 						}),
 					}),
@@ -1988,10 +1988,10 @@ func TestRedisMessage(t *testing.T) {
 			},
 			{
 				input: RedisMessage{
-					typ:     '+',
-					bytes:   unsafe.StringData("127.0.3.1"),
-					integer: int64(len("127.0.3.1")),
-					ttl:     [7]byte{97, 77, 74, 61, 138, 1, 0},
+					typ:    '+',
+					bytes:  unsafe.StringData("127.0.3.1"),
+					intlen: int64(len("127.0.3.1")),
+					ttl:    [7]byte{97, 77, 74, 61, 138, 1, 0},
 				},
 				expected: `{"Value":"127.0.3.1","Type":"simple string","TTL":"2023-08-28 17:56:34.273 +0000 UTC"}`,
 			},
@@ -2000,7 +2000,7 @@ func TestRedisMessage(t *testing.T) {
 				expected: `{"Type":"unknown"}`,
 			},
 			{
-				input:    RedisMessage{typ: typeBool, integer: 1},
+				input:    RedisMessage{typ: typeBool, intlen: 1},
 				expected: `{"Value":true,"Type":"boolean"}`,
 			},
 			{
@@ -2027,8 +2027,8 @@ func TestRedisMessage(t *testing.T) {
 	t.Run("CacheMarshal and CacheUnmarshalView", func(t *testing.T) {
 		m1 := RedisMessage{typ: '_'}
 		m2 := strmsg('+', "random")
-		m3 := RedisMessage{typ: '#', integer: 1}
-		m4 := RedisMessage{typ: ':', integer: -1234}
+		m3 := RedisMessage{typ: '#', intlen: 1}
+		m4 := RedisMessage{typ: ':', intlen: -1234}
 		m5 := strmsg(',', "-1.5")
 		m6 := slicemsg('%', nil)
 		m7 := slicemsg('~', []RedisMessage{m1, m2, m3, m4, m5, m6})

--- a/message_test.go
+++ b/message_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 type wrapped struct {
@@ -85,7 +86,7 @@ func TestRedisErrorIsMoved(t *testing.T) {
 		{err: "MOVED 1 [::1]:1", addr: "[::1]:1"},
 		{err: "MOVED 1 ::1:1", addr: "[::1]:1"},
 	} {
-		e := RedisError{typ: '-', string: c.err}
+		e := RedisError(redisMessageContainString('-', c.err))
 		if addr, ok := e.IsMoved(); !ok || addr != c.addr {
 			t.Fail()
 		}
@@ -101,7 +102,7 @@ func TestRedisErrorIsAsk(t *testing.T) {
 		{err: "ASK 1 [::1]:1", addr: "[::1]:1"},
 		{err: "ASK 1 ::1:1", addr: "[::1]:1"},
 	} {
-		e := RedisError{typ: '-', string: c.err}
+		e := RedisError(redisMessageContainString('-', c.err))
 		if addr, ok := e.IsAsk(); !ok || addr != c.addr {
 			t.Fail()
 		}
@@ -114,7 +115,8 @@ func TestIsRedisBusyGroup(t *testing.T) {
 		t.Fatal("TestIsRedisBusyGroup fail")
 	}
 
-	err = &RedisError{string: "BUSYGROUP Consumer Group name already exists"}
+	redisErr := RedisError(redisMessageContainString('-', "BUSYGROUP Consumer Group name already exists"))
+	err = &redisErr
 	if !IsRedisBusyGroup(err) {
 		t.Fatal("TestIsRedisBusyGroup fail")
 	}
@@ -162,10 +164,10 @@ func TestRedisResult(t *testing.T) {
 		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 1}}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '+', string: "OK"}}).AsBool(); !v {
+		if v, _ := (RedisResult{val: redisMessageContainString('+', "OK")}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '$', string: "OK"}}).AsBool(); !v {
+		if v, _ := (RedisResult{val: redisMessageContainString('$', "OK")}).AsBool(); !v {
 			t.Fatal("ToBool not get value as expected")
 		}
 	})
@@ -177,7 +179,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToFloat64(); err == nil {
 			t.Fatal("ToFloat64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: ',', string: "0.1"}}).ToFloat64(); v != 0.1 {
+		if v, _ := (RedisResult{val: redisMessageContainString(',', "0.1")}).ToFloat64(); v != 0.1 {
 			t.Fatal("ToFloat64 not get value as expected")
 		}
 	})
@@ -189,7 +191,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToString(); err == nil {
 			t.Fatal("ToString not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '+', string: "0.1"}}).ToString(); v != "0.1" {
+		if v, _ := (RedisResult{val: redisMessageContainString('+', "0.1")}).ToString(); v != "0.1" {
 			t.Fatal("ToString not get value as expected")
 		}
 	})
@@ -201,7 +203,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsReader(); err == nil {
 			t.Fatal("AsReader not failed as expected")
 		}
-		r, _ := (RedisResult{val: RedisMessage{typ: '+', string: "0.1"}}).AsReader()
+		r, _ := (RedisResult{val: redisMessageContainString('+', "0.1")}).AsReader()
 		bs, _ := io.ReadAll(r)
 		if !bytes.Equal(bs, []byte("0.1")) {
 			t.Fatalf("AsReader not get value as expected %v", bs)
@@ -215,7 +217,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsBytes(); err == nil {
 			t.Fatal("AsBytes not failed as expected")
 		}
-		bs, _ := (RedisResult{val: RedisMessage{typ: '+', string: "0.1"}}).AsBytes()
+		bs, _ := (RedisResult{val: redisMessageContainString('+', "0.1")}).AsBytes()
 		if !bytes.Equal(bs, []byte("0.1")) {
 			t.Fatalf("AsBytes not get value as expected %v", bs)
 		}
@@ -229,7 +231,7 @@ func TestRedisResult(t *testing.T) {
 		if err := (RedisResult{val: RedisMessage{typ: '-'}}).DecodeJSON(&v); err == nil {
 			t.Fatal("DecodeJSON not failed as expected")
 		}
-		if _ = (RedisResult{val: RedisMessage{typ: '+', string: `{"k":"v"}`}}).DecodeJSON(&v); v["k"] != "v" {
+		if _ = (RedisResult{val: redisMessageContainString('+', `{"k":"v"}`)}).DecodeJSON(&v); v["k"] != "v" {
 			t.Fatalf("DecodeJSON not get value as expected %v", v)
 		}
 	})
@@ -241,7 +243,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsInt64(); err == nil {
 			t.Fatal("AsInt64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '+', string: "1"}}).AsInt64(); v != 1 {
+		if v, _ := (RedisResult{val: redisMessageContainString('+', "1")}).AsInt64(); v != 1 {
 			t.Fatal("AsInt64 not get value as expected")
 		}
 		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 2}}).AsInt64(); v != 2 {
@@ -256,7 +258,7 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsUint64(); err == nil {
 			t.Fatal("AsUint64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '+', string: "1"}}).AsUint64(); v != 1 {
+		if v, _ := (RedisResult{val: redisMessageContainString('+', "1")}).AsUint64(); v != 1 {
 			t.Fatal("AsUint64 not get value as expected")
 		}
 		if v, _ := (RedisResult{val: RedisMessage{typ: ':', integer: 2}}).AsUint64(); v != 2 {
@@ -271,10 +273,10 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFloat64(); err == nil {
 			t.Fatal("AsFloat64 not failed as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: '+', string: "1.1"}}).AsFloat64(); v != 1.1 {
+		if v, _ := (RedisResult{val: redisMessageContainString('+', "1.1")}).AsFloat64(); v != 1.1 {
 			t.Fatal("AsFloat64 not get value as expected")
 		}
-		if v, _ := (RedisResult{val: RedisMessage{typ: ',', string: "2.2"}}).AsFloat64(); v != 2.2 {
+		if v, _ := (RedisResult{val: redisMessageContainString(',', "2.2")}).AsFloat64(); v != 2.2 {
 			t.Fatal("AsFloat64 not get value as expected")
 		}
 	})
@@ -286,8 +288,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToArray(); err == nil {
 			t.Fatal("ToArray not failed as expected")
 		}
-		values := []RedisMessage{{string: "item", typ: '+'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).ToArray(); !reflect.DeepEqual(ret, values) {
+		values := []RedisMessage{redisMessageContainString('+', "item")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).ToArray(); !reflect.DeepEqual(ret, values) {
 			t.Fatal("ToArray not get value as expected")
 		}
 	})
@@ -299,8 +301,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsStrSlice(); err == nil {
 			t.Fatal("AsStrSlice not failed as expected")
 		}
-		values := []RedisMessage{{string: "item", typ: '+'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsStrSlice(); !reflect.DeepEqual(ret, []string{"item"}) {
+		values := []RedisMessage{redisMessageContainString('+', "item")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsStrSlice(); !reflect.DeepEqual(ret, []string{"item"}) {
 			t.Fatal("AsStrSlice not get value as expected")
 		}
 	})
@@ -313,15 +315,15 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsIntSlice not failed as expected")
 		}
 		values := []RedisMessage{{integer: 2, typ: ':'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{2}) {
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{2}) {
 			t.Fatal("AsIntSlice not get value as expected")
 		}
-		values = []RedisMessage{{string: "3", typ: '+'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{3}) {
+		values = []RedisMessage{redisMessageContainString('+', "3")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntSlice(); !reflect.DeepEqual(ret, []int64{3}) {
 			t.Fatal("AsIntSlice not get value as expected")
 		}
-		values = []RedisMessage{{string: "ab", typ: '+'}}
-		if _, err := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsIntSlice(); err == nil {
+		values = []RedisMessage{redisMessageContainString('+', "ab")}
+		if _, err := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntSlice(); err == nil {
 			t.Fatal("AsIntSlice not failed as expected")
 		}
 	})
@@ -333,11 +335,11 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFloatSlice(); err == nil {
 			t.Fatal("AsFloatSlice not failed as expected")
 		}
-		if _, err := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "fff", typ: ','}}}}).AsFloatSlice(); err == nil {
+		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString(',', "fff")})}).AsFloatSlice(); err == nil {
 			t.Fatal("AsFloatSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 1, typ: ':'}, {string: "2", typ: '+'}, {string: "3", typ: '$'}, {string: "4", typ: ','}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsFloatSlice(); !reflect.DeepEqual(ret, []float64{1, 2, 3, 4}) {
+		values := []RedisMessage{{integer: 1, typ: ':'}, redisMessageContainString('+', "2"), redisMessageContainString('$', "3"), redisMessageContainString(',', "4")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsFloatSlice(); !reflect.DeepEqual(ret, []float64{1, 2, 3, 4}) {
 			t.Fatal("AsFloatSlice not get value as expected")
 		}
 	})
@@ -349,8 +351,8 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsBoolSlice(); err == nil {
 			t.Fatal("AsBoolSlice not failed as expected")
 		}
-		values := []RedisMessage{{integer: 1, typ: ':'}, {string: "0", typ: '+'}, {integer: 1, typ: typeBool}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsBoolSlice(); !reflect.DeepEqual(ret, []bool{true, false, true}) {
+		values := []RedisMessage{{integer: 1, typ: ':'}, redisMessageContainString('+', "0"), {integer: 1, typ: typeBool}}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsBoolSlice(); !reflect.DeepEqual(ret, []bool{true, false, true}) {
 			t.Fatal("AsBoolSlice not get value as expected")
 		}
 	})
@@ -362,9 +364,9 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsMap(); err == nil {
 			t.Fatal("AsMap not failed as expected")
 		}
-		values := []RedisMessage{{string: "key", typ: '+'}, {string: "value", typ: '+'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsMap(); !reflect.DeepEqual(map[string]RedisMessage{
-			values[0].string: values[1],
+		values := []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsMap(); !reflect.DeepEqual(map[string]RedisMessage{
+			values[0].string(): values[1],
 		}, ret) {
 			t.Fatal("AsMap not get value as expected")
 		}
@@ -377,9 +379,9 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsStrMap(); err == nil {
 			t.Fatal("AsStrMap not failed as expected")
 		}
-		values := []RedisMessage{{string: "key", typ: '+'}, {string: "value", typ: '+'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsStrMap(); !reflect.DeepEqual(map[string]string{
-			values[0].string: values[1].string,
+		values := []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsStrMap(); !reflect.DeepEqual(map[string]string{
+			values[0].string(): values[1].string(),
 		}, ret) {
 			t.Fatal("AsStrMap not get value as expected")
 		}
@@ -392,11 +394,11 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsIntMap(); err == nil {
 			t.Fatal("AsIntMap not failed as expected")
 		}
-		if _, err := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "key", typ: '+'}, {string: "value", typ: '+'}}}}).AsIntMap(); err == nil {
+		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")})}).AsIntMap(); err == nil {
 			t.Fatal("AsIntMap not failed as expected")
 		}
-		values := []RedisMessage{{string: "k1", typ: '+'}, {string: "1", typ: '+'}, {string: "k2", typ: '+'}, {integer: 2, typ: ':'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: values}}).AsIntMap(); !reflect.DeepEqual(map[string]int64{
+		values := []RedisMessage{redisMessageContainString('+', "k1"), redisMessageContainString('+', "1"), redisMessageContainString('+', "k2"), {integer: 2, typ: ':'}}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', values)}).AsIntMap(); !reflect.DeepEqual(map[string]int64{
 			"k1": 1,
 			"k2": 2,
 		}, ret) {
@@ -411,9 +413,9 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToMap(); err == nil {
 			t.Fatal("ToMap not failed as expected")
 		}
-		values := []RedisMessage{{string: "key", typ: '+'}, {string: "value", typ: '+'}}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '%', values: values}}).ToMap(); !reflect.DeepEqual(map[string]RedisMessage{
-			values[0].string: values[1],
+		values := []RedisMessage{redisMessageContainString('+', "key"), redisMessageContainString('+', "value")}
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('%', values)}).ToMap(); !reflect.DeepEqual(map[string]RedisMessage{
+			values[0].string(): values[1],
 		}, ret) {
 			t.Fatal("ToMap not get value as expected")
 		}
@@ -426,23 +428,24 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).ToAny(); err == nil {
 			t.Fatal("ToAny not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '%', values: []RedisMessage{{typ: '+', string: "key"}, {typ: ':', integer: 1}}},
-			{typ: '%', values: []RedisMessage{{typ: '+', string: "nil"}, {typ: '_'}}},
-			{typ: '%', values: []RedisMessage{{typ: '+', string: "err"}, {typ: '-', string: "err"}}},
-			{typ: ',', string: "1.2"},
-			{typ: '+', string: "str"},
+		redisErr := RedisError(redisMessageContainString('-', "err"))
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('%', []RedisMessage{redisMessageContainString('+', "key"), {typ: ':', integer: 1}}),
+			redisMessageContainSlice('%', []RedisMessage{redisMessageContainString('+', "nil"), {typ: '_'}}),
+			redisMessageContainSlice('%', []RedisMessage{redisMessageContainString('+', "err"), redisMessageContainString('-', "err")}),
+			redisMessageContainString(',', "1.2"),
+			redisMessageContainString('+', "str"),
 			{typ: '#', integer: 0},
-			{typ: '-', string: "err"},
+			redisMessageContainString('-', "err"),
 			{typ: '_'},
-		}}}).ToAny(); !reflect.DeepEqual([]any{
+		})}).ToAny(); !reflect.DeepEqual([]any{
 			map[string]any{"key": int64(1)},
 			map[string]any{"nil": nil},
-			map[string]any{"err": &RedisError{typ: '-', string: "err"}},
+			map[string]any{"err": &redisErr},
 			1.2,
 			"str",
 			false,
-			&RedisError{typ: '-', string: "err"},
+			&redisErr,
 			nil,
 		}, ret) {
 			t.Fatal("ToAny not get value as expected")
@@ -456,13 +459,13 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "id", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "a"}, {typ: '+', string: "b"}}}}}}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})})}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
 			ID:          "id",
 			FieldValues: map[string]string{"a": "b"},
 		}, ret) {
 			t.Fatal("AsXRangeEntry not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "id", typ: '+'}, {typ: '_'}}}}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id"), {typ: '_'}})}).AsXRangeEntry(); !reflect.DeepEqual(XRangeEntry{
 			ID:          "id",
 			FieldValues: nil,
 		}, ret) {
@@ -477,10 +480,10 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsXRange(); err == nil {
 			t.Fatal("AsXRange not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{{string: "id1", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "a"}, {typ: '+', string: "b"}}}}},
-			{typ: '*', values: []RedisMessage{{string: "id2", typ: '+'}, {typ: '_'}}},
-		}}}).AsXRange(); !reflect.DeepEqual([]XRangeEntry{{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})}),
+			redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id2"), {typ: '_'}}),
+		})}).AsXRange(); !reflect.DeepEqual([]XRangeEntry{{
 			ID:          "id1",
 			FieldValues: map[string]string{"a": "b"},
 		}, {
@@ -498,17 +501,17 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsXRead(); err == nil {
 			t.Fatal("AsXRead not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '%', values: []RedisMessage{
-			{typ: '+', string: "stream1"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '*', values: []RedisMessage{{string: "id1", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "a"}, {typ: '+', string: "b"}}}}},
-				{typ: '*', values: []RedisMessage{{string: "id2", typ: '+'}, {typ: '_'}}},
-			}},
-			{typ: '+', string: "stream2"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '*', values: []RedisMessage{{string: "id3", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "c"}, {typ: '+', string: "d"}}}}},
-			}},
-		}}}).AsXRead(); !reflect.DeepEqual(map[string][]XRangeEntry{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
+			redisMessageContainString('+', "stream1"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})}),
+				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id2"), {typ: '_'}}),
+			}),
+			redisMessageContainString('+', "stream2"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id3"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "c"), redisMessageContainString('+', "d")})}),
+			}),
+		})}).AsXRead(); !reflect.DeepEqual(map[string][]XRangeEntry{
 			"stream1": {
 				{ID: "id1", FieldValues: map[string]string{"a": "b"}},
 				{ID: "id2", FieldValues: nil}},
@@ -518,21 +521,21 @@ func TestRedisResult(t *testing.T) {
 		}, ret) {
 			t.Fatal("AsXRead not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "stream1"},
-				{typ: '*', values: []RedisMessage{
-					{typ: '*', values: []RedisMessage{{string: "id1", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "a"}, {typ: '+', string: "b"}}}}},
-					{typ: '*', values: []RedisMessage{{string: "id2", typ: '+'}, {typ: '_'}}},
-				}},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "stream2"},
-				{typ: '*', values: []RedisMessage{
-					{typ: '*', values: []RedisMessage{{string: "id3", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "c"}, {typ: '+', string: "d"}}}}},
-				}},
-			}},
-		}}}).AsXRead(); !reflect.DeepEqual(map[string][]XRangeEntry{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "stream1"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})}),
+					redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id2"), {typ: '_'}}),
+				}),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "stream2"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id3"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "c"), redisMessageContainString('+', "d")})}),
+				}),
+			}),
+		})}).AsXRead(); !reflect.DeepEqual(map[string][]XRangeEntry{
 			"stream1": {
 				{ID: "id1", FieldValues: map[string]string{"a": "b"}},
 				{ID: "id2", FieldValues: nil}},
@@ -551,16 +554,16 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsZScore(); err == nil {
 			t.Fatal("AsZScore not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "m1"},
-			{typ: '+', string: "1"},
-		}}}).AsZScore(); !reflect.DeepEqual(ZScore{Member: "m1", Score: 1}, ret) {
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "m1"),
+			redisMessageContainString('+', "1"),
+		})}).AsZScore(); !reflect.DeepEqual(ZScore{Member: "m1", Score: 1}, ret) {
 			t.Fatal("AsZScore not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "m1"},
-			{typ: ',', string: "1"},
-		}}}).AsZScore(); !reflect.DeepEqual(ZScore{Member: "m1", Score: 1}, ret) {
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "m1"),
+			redisMessageContainString(',', "1"),
+		})}).AsZScore(); !reflect.DeepEqual(ZScore{Member: "m1", Score: 1}, ret) {
 			t.Fatal("AsZScore not get value as expected")
 		}
 	})
@@ -572,27 +575,27 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsZScores(); err == nil {
 			t.Fatal("AsZScores not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "m1"},
-			{typ: '+', string: "1"},
-			{typ: '+', string: "m2"},
-			{typ: '+', string: "2"},
-		}}}).AsZScores(); !reflect.DeepEqual([]ZScore{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "m1"),
+			redisMessageContainString('+', "1"),
+			redisMessageContainString('+', "m2"),
+			redisMessageContainString('+', "2"),
+		})}).AsZScores(); !reflect.DeepEqual([]ZScore{
 			{Member: "m1", Score: 1},
 			{Member: "m2", Score: 2},
 		}, ret) {
 			t.Fatal("AsZScores not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "m1"},
-				{typ: ',', string: "1"},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "m2"},
-				{typ: ',', string: "2"},
-			}},
-		}}}).AsZScores(); !reflect.DeepEqual([]ZScore{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "m1"),
+				redisMessageContainString(',', "1"),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "m2"),
+				redisMessageContainString(',', "2"),
+			}),
+		})}).AsZScores(); !reflect.DeepEqual([]ZScore{
 			{Member: "m1", Score: 1},
 			{Member: "m2", Score: 2},
 		}, ret) {
@@ -607,13 +610,13 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsLMPop(); err == nil {
 			t.Fatal("AsLMPop not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "k"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "1"},
-				{typ: '+', string: "2"},
-			}},
-		}}}).AsLMPop(); !reflect.DeepEqual(KeyValues{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "k"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "1"),
+				redisMessageContainString('+', "2"),
+			}),
+		})}).AsLMPop(); !reflect.DeepEqual(KeyValues{
 			Key:    "k",
 			Values: []string{"1", "2"},
 		}, ret) {
@@ -628,19 +631,19 @@ func TestRedisResult(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsZMPop(); err == nil {
 			t.Fatal("AsZMPop not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "k"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "1"},
-					{typ: ',', string: "1"},
-				}},
-				{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "2"},
-					{typ: ',', string: "2"},
-				}},
-			}},
-		}}}).AsZMPop(); !reflect.DeepEqual(KeyZScores{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "k"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "1"),
+					redisMessageContainString(',', "1"),
+				}),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "2"),
+					redisMessageContainString(',', "2"),
+				}),
+			}),
+		})}).AsZMPop(); !reflect.DeepEqual(KeyZScores{
 			Key: "k",
 			Values: []ZScore{
 				{Member: "1", Score: 1},
@@ -658,168 +661,168 @@ func TestRedisResult(t *testing.T) {
 		if _, _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFtSearch(); err == nil {
 			t.Fatal("AsFtSearch not failed as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "a"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: '+', string: "v1"},
-				{typ: '+', string: "kk"},
-				{typ: '+', string: "vv"},
-			}},
-			{typ: '+', string: "b"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
-				{typ: '+', string: "v2"},
-				{typ: '+', string: "kk"},
-				{typ: '+', string: "vv"},
-			}},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "a"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k1"),
+				redisMessageContainString('+', "v1"),
+				redisMessageContainString('+', "kk"),
+				redisMessageContainString('+', "vv"),
+			}),
+			redisMessageContainString('+', "b"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k2"),
+				redisMessageContainString('+', "v2"),
+				redisMessageContainString('+', "kk"),
+				redisMessageContainString('+', "vv"),
+			}),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: map[string]string{"k1": "v1", "kk": "vv"}},
 			{Key: "b", Doc: map[string]string{"k2": "v2", "kk": "vv"}},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "a"},
-			{typ: '+', string: "1"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: '+', string: "v1"},
-			}},
-			{typ: '+', string: "b"},
-			{typ: '+', string: "2"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
-				{typ: '+', string: "v2"},
-			}},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "a"),
+			redisMessageContainString('+', "1"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k1"),
+				redisMessageContainString('+', "v1"),
+			}),
+			redisMessageContainString('+', "b"),
+			redisMessageContainString('+', "2"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k2"),
+				redisMessageContainString('+', "v2"),
+			}),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: map[string]string{"k1": "v1"}, Score: 1},
 			{Key: "b", Doc: map[string]string{"k2": "v2"}, Score: 2},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "a"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: '+', string: "v1"},
-				{typ: '+', string: "kk"},
-				{typ: '+', string: "vv"},
-			}},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "a"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k1"),
+				redisMessageContainString('+', "v1"),
+				redisMessageContainString('+', "kk"),
+				redisMessageContainString('+', "vv"),
+			}),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: map[string]string{"k1": "v1", "kk": "vv"}},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "a"},
-			{typ: '+', string: "b"},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "a"),
+			redisMessageContainString('+', "b"),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil},
 			{Key: "b", Doc: nil},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "a"},
-			{typ: '+', string: "1"},
-			{typ: '+', string: "b"},
-			{typ: '+', string: "2"},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "a"),
+			redisMessageContainString('+', "1"),
+			redisMessageContainString('+', "b"),
+			redisMessageContainString('+', "2"),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil, Score: 1},
 			{Key: "b", Doc: nil, Score: 2},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "1"},
-			{typ: '+', string: "2"},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "1"),
+			redisMessageContainString('+', "2"),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "1", Doc: nil},
 			{Key: "2", Doc: nil},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '+', string: "a"},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "a"),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "a", Doc: nil},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{}, ret) {
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 	})
 
 	t.Run("AsFtSearch RESP3", func(t *testing.T) {
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '%', values: []RedisMessage{
-			{typ: '+', string: "total_results"},
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
+			redisMessageContainString('+', "total_results"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: "results"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '%', values: []RedisMessage{
-					{typ: '+', string: "id"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "extra_attributes"},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "$"},
-						{typ: '+', string: "1"},
-					}},
-					{typ: '+', string: "score"},
-					{typ: ',', string: "1"},
-				}},
-				{typ: '%', values: []RedisMessage{
-					{typ: '+', string: "id"},
-					{typ: '+', string: "2"},
-					{typ: '+', string: "extra_attributes"},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "$"},
-						{typ: '+', string: "2"},
-					}},
-					{typ: '+', string: "score"},
-					{typ: ',', string: "2"},
-				}},
-			}},
-			{typ: '+', string: "error"},
-			{typ: '*', values: []RedisMessage{}},
-		}}}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
+			redisMessageContainString('+', "results"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('+', "id"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "extra_attributes"),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "$"),
+						redisMessageContainString('+', "1"),
+					}),
+					redisMessageContainString('+', "score"),
+					redisMessageContainString(',', "1"),
+				}),
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('+', "id"),
+					redisMessageContainString('+', "2"),
+					redisMessageContainString('+', "extra_attributes"),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "$"),
+						redisMessageContainString('+', "2"),
+					}),
+					redisMessageContainString('+', "score"),
+					redisMessageContainString(',', "2"),
+				}),
+			}),
+			redisMessageContainString('+', "error"),
+			redisMessageContainSlice('*', []RedisMessage{}),
+		})}).AsFtSearch(); n != 3 || !reflect.DeepEqual([]FtSearchDoc{
 			{Key: "1", Doc: map[string]string{"$": "1"}, Score: 1},
 			{Key: "2", Doc: map[string]string{"$": "2"}, Score: 2},
 		}, ret) {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
-		if _, _, err := (RedisResult{val: RedisMessage{typ: '%', values: []RedisMessage{
-			{typ: '+', string: "total_results"},
+		if _, _, err := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
+			redisMessageContainString('+', "total_results"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: "results"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '%', values: []RedisMessage{
-					{typ: '+', string: "id"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "extra_attributes"},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "$"},
-						{typ: '+', string: "1"},
-					}},
-					{typ: '+', string: "score"},
-					{typ: ',', string: "1"},
-				}},
-			}},
-			{typ: '+', string: "error"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "mytimeout"},
-			}},
-		}}}).AsFtSearch(); err == nil || err.Error() != "mytimeout" {
+			redisMessageContainString('+', "results"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('+', "id"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "extra_attributes"),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "$"),
+						redisMessageContainString('+', "1"),
+					}),
+					redisMessageContainString('+', "score"),
+					redisMessageContainString(',', "1"),
+				}),
+			}),
+			redisMessageContainString('+', "error"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "mytimeout"),
+			}),
+		})}).AsFtSearch(); err == nil || err.Error() != "mytimeout" {
 			t.Fatal("AsFtSearch not get value as expected")
 		}
 	})
@@ -831,93 +834,93 @@ func TestRedisResult(t *testing.T) {
 		if _, _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFtAggregate(); err == nil {
 			t.Fatal("AsFtAggregate not failed as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: '+', string: "v1"},
-				{typ: '+', string: "kk"},
-				{typ: '+', string: "vv"},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k2"},
-				{typ: '+', string: "v2"},
-				{typ: '+', string: "kk"},
-				{typ: '+', string: "vv"},
-			}},
-		}}}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k1"),
+				redisMessageContainString('+', "v1"),
+				redisMessageContainString('+', "kk"),
+				redisMessageContainString('+', "vv"),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k2"),
+				redisMessageContainString('+', "v2"),
+				redisMessageContainString('+', "kk"),
+				redisMessageContainString('+', "vv"),
+			}),
+		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 			{"k2": "v2", "kk": "vv"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "k1"},
-				{typ: '+', string: "v1"},
-				{typ: '+', string: "kk"},
-				{typ: '+', string: "vv"},
-			}},
-		}}}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "k1"),
+				redisMessageContainString('+', "v1"),
+				redisMessageContainString('+', "kk"),
+				redisMessageContainString('+', "vv"),
+			}),
+		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
 			{typ: ':', integer: 3},
-		}}}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
+		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
 	})
 
 	t.Run("AsFtAggregate RESP3", func(t *testing.T) {
-		if n, ret, _ := (RedisResult{val: RedisMessage{typ: '%', values: []RedisMessage{
-			{typ: '+', string: "total_results"},
+		if n, ret, _ := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
+			redisMessageContainString('+', "total_results"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: "results"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '%', values: []RedisMessage{
-					{typ: '+', string: "extra_attributes"},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "$"},
-						{typ: '+', string: "1"},
-					}},
-				}},
-				{typ: '%', values: []RedisMessage{
-					{typ: '+', string: "extra_attributes"},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "$"},
-						{typ: '+', string: "2"},
-					}},
-				}},
-			}},
-			{typ: '+', string: "error"},
-			{typ: '*', values: []RedisMessage{}},
-		}}}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
+			redisMessageContainString('+', "results"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('+', "extra_attributes"),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "$"),
+						redisMessageContainString('+', "1"),
+					}),
+				}),
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('+', "extra_attributes"),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "$"),
+						redisMessageContainString('+', "2"),
+					}),
+				}),
+			}),
+			redisMessageContainString('+', "error"),
+			redisMessageContainSlice('*', []RedisMessage{}),
+		})}).AsFtAggregate(); n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"$": "1"},
 			{"$": "2"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if _, _, err := (RedisResult{val: RedisMessage{typ: '%', values: []RedisMessage{
-			{typ: '+', string: "total_results"},
+		if _, _, err := (RedisResult{val: redisMessageContainSlice('%', []RedisMessage{
+			redisMessageContainString('+', "total_results"),
 			{typ: ':', integer: 3},
-			{typ: '+', string: "results"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '%', values: []RedisMessage{
-					{typ: '+', string: "extra_attributes"},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "$"},
-						{typ: '+', string: "1"},
-					}},
-				}},
-			}},
-			{typ: '+', string: "error"},
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "mytimeout"},
-			}},
-		}}}).AsFtAggregate(); err == nil || err.Error() != "mytimeout" {
+			redisMessageContainString('+', "results"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('+', "extra_attributes"),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "$"),
+						redisMessageContainString('+', "1"),
+					}),
+				}),
+			}),
+			redisMessageContainString('+', "error"),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "mytimeout"),
+			}),
+		})}).AsFtAggregate(); err == nil || err.Error() != "mytimeout" {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
 	})
@@ -929,108 +932,108 @@ func TestRedisResult(t *testing.T) {
 		if _, _, _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsFtAggregateCursor(); err == nil {
 			t.Fatal("AsFtAggregate not failed as expected")
 		}
-		if c, n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
+		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 3},
-				{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "k1"},
-					{typ: '+', string: "v1"},
-					{typ: '+', string: "kk"},
-					{typ: '+', string: "vv"},
-				}},
-				{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "k2"},
-					{typ: '+', string: "v2"},
-					{typ: '+', string: "kk"},
-					{typ: '+', string: "vv"},
-				}},
-			}},
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "k1"),
+					redisMessageContainString('+', "v1"),
+					redisMessageContainString('+', "kk"),
+					redisMessageContainString('+', "vv"),
+				}),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "k2"),
+					redisMessageContainString('+', "v2"),
+					redisMessageContainString('+', "kk"),
+					redisMessageContainString('+', "vv"),
+				}),
+			}),
 			{typ: ':', integer: 1},
-		}}}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
+		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 			{"k2": "v2", "kk": "vv"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if c, n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
+		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 3},
-				{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "k1"},
-					{typ: '+', string: "v1"},
-					{typ: '+', string: "kk"},
-					{typ: '+', string: "vv"},
-				}},
-			}},
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "k1"),
+					redisMessageContainString('+', "v1"),
+					redisMessageContainString('+', "kk"),
+					redisMessageContainString('+', "vv"),
+				}),
+			}),
 			{typ: ':', integer: 1},
-		}}}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
+		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"k1": "v1", "kk": "vv"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if c, n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
+		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 3},
-			}},
+			}),
 			{typ: ':', integer: 1},
-		}}}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
+		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
 	})
 
 	t.Run("AsFtAggregate Cursor RESP3", func(t *testing.T) {
-		if c, n, ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '%', values: []RedisMessage{
-				{typ: '+', string: "total_results"},
+		if c, n, ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('%', []RedisMessage{
+				redisMessageContainString('+', "total_results"),
 				{typ: ':', integer: 3},
-				{typ: '+', string: "results"},
-				{typ: '*', values: []RedisMessage{
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "extra_attributes"},
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "$"},
-							{typ: '+', string: "1"},
-						}},
-					}},
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "extra_attributes"},
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "$"},
-							{typ: '+', string: "2"},
-						}},
-					}},
-				}},
-				{typ: '+', string: "error"},
-				{typ: '*', values: []RedisMessage{}},
-			}},
+				redisMessageContainString('+', "results"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "extra_attributes"),
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "$"),
+							redisMessageContainString('+', "1"),
+						}),
+					}),
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "extra_attributes"),
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "$"),
+							redisMessageContainString('+', "2"),
+						}),
+					}),
+				}),
+				redisMessageContainString('+', "error"),
+				redisMessageContainSlice('*', []RedisMessage{}),
+			}),
 			{typ: ':', integer: 1},
-		}}}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
+		})}).AsFtAggregateCursor(); c != 1 || n != 3 || !reflect.DeepEqual([]map[string]string{
 			{"$": "1"},
 			{"$": "2"},
 		}, ret) {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
-		if _, _, _, err := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '%', values: []RedisMessage{
-				{typ: '+', string: "total_results"},
+		if _, _, _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('%', []RedisMessage{
+				redisMessageContainString('+', "total_results"),
 				{typ: ':', integer: 3},
-				{typ: '+', string: "results"},
-				{typ: '*', values: []RedisMessage{
-					{typ: '%', values: []RedisMessage{
-						{typ: '+', string: "extra_attributes"},
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "$"},
-							{typ: '+', string: "1"},
-						}},
-					}},
-				}},
-				{typ: '+', string: "error"},
-				{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "mytimeout"},
-				}},
-			}},
+				redisMessageContainString('+', "results"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainSlice('%', []RedisMessage{
+						redisMessageContainString('+', "extra_attributes"),
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "$"),
+							redisMessageContainString('+', "1"),
+						}),
+					}),
+				}),
+				redisMessageContainString('+', "error"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "mytimeout"),
+				}),
+			}),
 			{typ: ':', integer: 1},
-		}}}).AsFtAggregateCursor(); err == nil || err.Error() != "mytimeout" {
+		})}).AsFtAggregateCursor(); err == nil || err.Error() != "mytimeout" {
 			t.Fatal("AsFtAggregate not get value as expected")
 		}
 	})
@@ -1043,161 +1046,161 @@ func TestRedisResult(t *testing.T) {
 			t.Fatal("AsGeosearch not failed as expected")
 		}
 		//WithDist, WithHash, WithCoord
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
-				{typ: ',', string: "2.5"},
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
+				redisMessageContainString(',', "2.5"),
 				{typ: ':', integer: 1},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "28.0473"},
-					{typ: ',', string: "26.2041"},
-				}},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
-				{typ: ',', string: "4.5"},
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "28.0473"),
+					redisMessageContainString(',', "26.2041"),
+				}),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
+				redisMessageContainString(',', "4.5"),
 				{typ: ':', integer: 4},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "72.4973"},
-					{typ: ',', string: "13.2263"},
-				}},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "72.4973"),
+					redisMessageContainString(',', "13.2263"),
+				}),
+			}),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", Dist: 2.5, GeoHash: 1, Longitude: 28.0473, Latitude: 26.2041},
 			{Name: "k2", Dist: 4.5, GeoHash: 4, Longitude: 72.4973, Latitude: 13.2263},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithHash, WithCoord
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
 				{typ: ':', integer: 1},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "84.3877"},
-					{typ: ',', string: "33.7488"},
-				}},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "84.3877"),
+					redisMessageContainString(',', "33.7488"),
+				}),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
 				{typ: ':', integer: 4},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "115.8613"},
-					{typ: ',', string: "31.9523"},
-				}},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "115.8613"),
+					redisMessageContainString(',', "31.9523"),
+				}),
+			}),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", GeoHash: 1, Longitude: 84.3877, Latitude: 33.7488},
 			{Name: "k2", GeoHash: 4, Longitude: 115.8613, Latitude: 31.9523},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithDist, WithCoord
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
-				{typ: ',', string: "2.50076"},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "84.3877"},
-					{typ: ',', string: "33.7488"},
-				}},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
-				{typ: ',', string: "1024.96"},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "115.8613"},
-					{typ: ',', string: "31.9523"},
-				}},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
+				redisMessageContainString(',', "2.50076"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "84.3877"),
+					redisMessageContainString(',', "33.7488"),
+				}),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
+				redisMessageContainString(',', "1024.96"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "115.8613"),
+					redisMessageContainString(',', "31.9523"),
+				}),
+			}),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", Dist: 2.50076, Longitude: 84.3877, Latitude: 33.7488},
 			{Name: "k2", Dist: 1024.96, Longitude: 115.8613, Latitude: 31.9523},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithCoord
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "122.4194"},
-					{typ: ',', string: "37.7749"},
-				}},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "35.6762"},
-					{typ: ',', string: "139.6503"},
-				}},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "122.4194"),
+					redisMessageContainString(',', "37.7749"),
+				}),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "35.6762"),
+					redisMessageContainString(',', "139.6503"),
+				}),
+			}),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", Longitude: 122.4194, Latitude: 37.7749},
 			{Name: "k2", Longitude: 35.6762, Latitude: 139.6503},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithDist
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
-				{typ: ',', string: "2.50076"},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
-				{typ: ',', string: strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
+				redisMessageContainString(',', "2.50076"),
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
+				redisMessageContainString(',', strconv.FormatFloat(math.MaxFloat64, 'E', -1, 64)),
+			}),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", Dist: 2.50076},
 			{Name: "k2", Dist: math.MaxFloat64},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//WithHash
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
 				{typ: ':', integer: math.MaxInt64},
-			}},
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
+			}),
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
 				{typ: ':', integer: 22296},
-			}},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+			}),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1", GeoHash: math.MaxInt64},
 			{Name: "k2", GeoHash: 22296},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//With no additional options
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '$', string: "k1"},
-			{typ: '$', string: "k2"},
-		}}}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('$', "k1"),
+			redisMessageContainString('$', "k2"),
+		})}).AsGeosearch(); !reflect.DeepEqual([]GeoLocation{
 			{Name: "k1"},
 			{Name: "k2"},
 		}, ret) {
 			t.Fatal("AsGeosearch not get value as expected")
 		}
 		//With wrong distance
-		if _, err := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k1"},
-				{typ: ',', string: "wrong distance"},
-			}},
-		}}}).AsGeosearch(); err == nil {
+		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k1"),
+				redisMessageContainString(',', "wrong distance"),
+			}),
+		})}).AsGeosearch(); err == nil {
 			t.Fatal("AsGeosearch not failed as expected")
 		}
 		//With wrong coordinates
-		if _, err := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '$', string: "k2"},
-				{typ: '*', values: []RedisMessage{
-					{typ: ',', string: "35.6762"},
-				}},
-			}},
-		}}}).AsGeosearch(); err == nil {
+		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('$', "k2"),
+				redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString(',', "35.6762"),
+				}),
+			}),
+		})}).AsGeosearch(); err == nil {
 			t.Fatal("AsGeosearch not failed as expected")
 		}
 	})
@@ -1259,17 +1262,17 @@ func TestRedisResult(t *testing.T) {
 		}{
 			{
 				input: RedisResult{
-					val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '*', values: []RedisMessage{
+					val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('*', []RedisMessage{
 							{typ: ':', integer: 0},
 							{typ: ':', integer: 0},
-							{typ: '*', values: []RedisMessage{ // master
-								{typ: '+', string: "127.0.3.1"},
+							redisMessageContainSlice('*', []RedisMessage{ // master
+								redisMessageContainString('+', "127.0.3.1"),
 								{typ: ':', integer: 3},
-								{typ: '+', string: ""},
-							}},
-						}},
-					}},
+								redisMessageContainString('+', ""),
+							}),
+						}),
+					}),
 				},
 				expected: `{"Message":{"Value":[{"Value":[{"Value":0,"Type":"int64"},{"Value":0,"Type":"int64"},{"Value":[{"Value":"127.0.3.1","Type":"simple string"},{"Value":3,"Type":"int64"},{"Value":"","Type":"simple string"}],"Type":"array"}],"Type":"array"}],"Type":"array"}}`,
 			},
@@ -1299,7 +1302,8 @@ func TestRedisMessage(t *testing.T) {
 	})
 	t.Run("Trim ERR prefix", func(t *testing.T) {
 		// kvrocks: https://github.com/redis/rueidis/issues/152#issuecomment-1333923750
-		if (&RedisMessage{typ: '-', string: "ERR no_prefix"}).Error().Error() != "no_prefix" {
+		redisMessageError := redisMessageContainString('-', "ERR no_prefix")
+		if (&redisMessageError).Error().Error() != "no_prefix" {
 			t.Fatal("fail to trim ERR")
 		}
 	})
@@ -1452,7 +1456,8 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		// Test case where the message type is '*', which is not a RESP3 string
-		if val, err := (&RedisMessage{typ: '*', values: []RedisMessage{{}}}).AsInt64(); err == nil {
+		redisMessageArrayWithEmptyMessage := redisMessageContainSlice('*', []RedisMessage{{}})
+		if val, err := (&redisMessageArrayWithEmptyMessage).AsInt64(); err == nil {
 			t.Fatal("AsInt64 did not fail as expected")
 		} else if val != 0 {
 			t.Fatalf("expected 0, got %d", val)
@@ -1470,7 +1475,8 @@ func TestRedisMessage(t *testing.T) {
 		}
 
 		// Test case where the message type is '*', which is not a RESP3 string
-		if val, err := (&RedisMessage{typ: '*', values: []RedisMessage{{}}}).AsUint64(); err == nil {
+		redisMessageArrayWithEmptyMessage := redisMessageContainSlice('*', []RedisMessage{{}})
+		if val, err := (&redisMessageArrayWithEmptyMessage).AsUint64(); err == nil {
 			t.Fatal("AsUint64 did not fail as expected")
 		} else if val != 0 {
 			t.Fatalf("expected 0, got %d", val)
@@ -1670,11 +1676,13 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{{typ: '_'}, {typ: '%'}}}).AsXRangeEntry(); err == nil {
+		redisMessageNullAndMap := redisMessageContainSlice('*', []RedisMessage{{typ: '_'}, {typ: '%'}})
+		if _, err := (&redisMessageNullAndMap).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{{typ: ':'}, {typ: '%'}}}).AsXRangeEntry(); err == nil {
+		redisMessageIntAndMap := redisMessageContainSlice('*', []RedisMessage{{typ: ':'}, {typ: '%'}})
+		if _, err := (&redisMessageIntAndMap).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		} else if !strings.Contains(err.Error(), fmt.Sprintf("redis message type %s is not a string", typeNames[':'])) {
 			t.Fatalf("unexpected error: %v", err)
@@ -1690,11 +1698,13 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{{typ: '+'}, {typ: '-'}}}).AsXRangeEntry(); err == nil {
+		redisMessageStringAndErr := redisMessageContainSlice('*', []RedisMessage{{typ: '+'}, {typ: '-'}})
+		if _, err := (&redisMessageStringAndErr).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{{typ: '+'}, {typ: 't'}}}).AsXRangeEntry(); err == nil {
+		redisMessageStringAndUnknown := redisMessageContainSlice('*', []RedisMessage{{typ: '+'}, {typ: 't'}})
+		if _, err := (&redisMessageStringAndUnknown).AsXRangeEntry(); err == nil {
 			t.Fatal("AsXRangeEntry did not fail as expected")
 		} else if !strings.Contains(err.Error(), "redis message type t is not a map/array/set") {
 			t.Fatalf("unexpected error: %v", err)
@@ -1706,7 +1716,8 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRange not failed as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{{typ: '_'}}}).AsXRange(); err == nil {
+		redisMessageArrayWithNull := redisMessageContainSlice('*', []RedisMessage{{typ: '_'}})
+		if _, err := (&redisMessageArrayWithNull).AsXRange(); err == nil {
 			t.Fatal("AsXRange not failed as expected")
 		}
 	})
@@ -1716,27 +1727,30 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '%', values: []RedisMessage{
-			{typ: '+', string: "stream1"},
-			{typ: '*', values: []RedisMessage{{typ: '*', values: []RedisMessage{{string: "id1", typ: '+'}}}}},
-		}}).AsXRead(); err == nil {
+		redisMessageMapIncorrectLen := redisMessageContainSlice('%', []RedisMessage{
+			redisMessageContainString('+', "stream1"),
+			redisMessageContainSlice('*', []RedisMessage{redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1")})}),
+		})
+		if _, err := (&redisMessageMapIncorrectLen).AsXRead(); err == nil {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "stream1"},
-			}},
-		}}).AsXRead(); err == nil {
+		redisMessageArrayIncorrectLen := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "stream1"),
+			}),
+		})
+		if _, err := (&redisMessageArrayIncorrectLen).AsXRead(); err == nil {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "stream1"},
-				{typ: '*', values: []RedisMessage{{typ: '*', values: []RedisMessage{{string: "id1", typ: '+'}}}}},
-			}},
-		}}).AsXRead(); err == nil {
+		redisMessageArrayIncorrectLen2 := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "stream1"),
+				redisMessageContainSlice('*', []RedisMessage{redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "id1")})}),
+			}),
+		})
+		if _, err := (&redisMessageArrayIncorrectLen2).AsXRead(); err == nil {
 			t.Fatal("AsXRead did not fail as expected")
 		}
 
@@ -1763,18 +1777,20 @@ func TestRedisMessage(t *testing.T) {
 		if _, err := (&RedisMessage{typ: '_'}).AsZScores(); err == nil {
 			t.Fatal("AsZScore not failed as expected")
 		}
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "m1"},
-			{typ: '+', string: "m2"},
-		}}).AsZScores(); err == nil {
+		redisMessageStringArray := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "m1"),
+			redisMessageContainString('+', "m2"),
+		})
+		if _, err := (&redisMessageStringArray).AsZScores(); err == nil {
 			t.Fatal("AsZScores not fails as expected")
 		}
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '*', values: []RedisMessage{
-				{typ: '+', string: "m1"},
-				{typ: '+', string: "m2"},
-			}},
-		}}).AsZScores(); err == nil {
+		redisMessageNestedStringArray := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainString('+', "m1"),
+				redisMessageContainString('+', "m2"),
+			}),
+		})
+		if _, err := (&redisMessageNestedStringArray).AsZScores(); err == nil {
 			t.Fatal("AsZScores not fails as expected")
 		}
 	})
@@ -1784,16 +1800,18 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsLMPop did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "k"},
+		redisMessageStringAndNull := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "k"),
 			{typ: '_'},
-		}}).AsLMPop(); err == nil {
+		})
+		if _, err := (&redisMessageStringAndNull).AsLMPop(); err == nil {
 			t.Fatal("AsLMPop did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "k"},
-		}}).AsLMPop(); err == nil {
+		redisMessageStringArray := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "k"),
+		})
+		if _, err := (&redisMessageStringArray).AsLMPop(); err == nil {
 			t.Fatal("AsLMPop did not fail as expected")
 		} else if !strings.Contains(err.Error(), fmt.Sprintf("redis message type %s is not a LMPOP response", typeNames['*'])) {
 			t.Fatalf("unexpected error: %v", err)
@@ -1805,16 +1823,18 @@ func TestRedisMessage(t *testing.T) {
 			t.Fatal("AsZMPop did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "k"},
+		redisMessageStringAndNull := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "k"),
 			{typ: '_'},
-		}}).AsZMPop(); err == nil {
+		})
+		if _, err := (&redisMessageStringAndNull).AsZMPop(); err == nil {
 			t.Fatal("AsZMPop did not fail as expected")
 		}
 
-		if _, err := (&RedisMessage{typ: '*', values: []RedisMessage{
-			{typ: '+', string: "k"},
-		}}).AsZMPop(); err == nil {
+		redisMessageStringArray := redisMessageContainSlice('*', []RedisMessage{
+			redisMessageContainString('+', "k"),
+		})
+		if _, err := (&redisMessageStringArray).AsZMPop(); err == nil {
 			t.Fatal("AsZMPop did not fail as expected")
 		} else if !strings.Contains(err.Error(), fmt.Sprintf("redis message type %s is not a ZMPOP response", typeNames['*'])) {
 			t.Fatalf("unexpected error: %v", err)
@@ -1864,29 +1884,31 @@ func TestRedisMessage(t *testing.T) {
 		if _, err := (RedisResult{val: RedisMessage{typ: '-'}}).AsScanEntry(); err == nil {
 			t.Fatal("AsScanEntry not failed as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "1", typ: '+'}, {typ: '*', values: []RedisMessage{{typ: '+', string: "a"}, {typ: '+', string: "b"}}}}}}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "1"), redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a"), redisMessageContainString('+', "b")})})}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{
 			Cursor:   1,
 			Elements: []string{"a", "b"},
 		}, ret) {
 			t.Fatal("AsScanEntry not get value as expected")
 		}
-		if ret, _ := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "0", typ: '+'}, {typ: '_'}}}}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{}, ret) {
+		if ret, _ := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "0"), {typ: '_'}})}).AsScanEntry(); !reflect.DeepEqual(ScanEntry{}, ret) {
 			t.Fatal("AsScanEntry not get value as expected")
 		}
-		if _, err := (RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{string: "0", typ: '+'}}}}).AsScanEntry(); err == nil || !strings.Contains(err.Error(), "a scan response or its length is not at least 2") {
+		if _, err := (RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "0")})}).AsScanEntry(); err == nil || !strings.Contains(err.Error(), "a scan response or its length is not at least 2") {
 			t.Fatal("AsScanEntry not get value as expected")
 		}
 	})
 
 	t.Run("ToMap with non-string key", func(t *testing.T) {
-		_, err := (&RedisMessage{typ: '~', values: []RedisMessage{{typ: ':'}, {typ: ':'}}}).ToMap()
+		redisMessageSet := redisMessageContainSlice('~', []RedisMessage{{typ: ':'}, {typ: ':'}})
+		_, err := (&redisMessageSet).ToMap()
 		if err == nil {
 			t.Fatal("ToMap did not fail as expected")
 		}
 		if !strings.Contains(err.Error(), "redis message type set is not a RESP3 map") {
 			t.Fatalf("ToMap failed with unexpected error: %v", err)
 		}
-		_, err = (&RedisMessage{typ: '%', values: []RedisMessage{{typ: ':'}, {typ: ':'}}}).ToMap()
+		redisMessageMap := redisMessageContainSlice('%', []RedisMessage{{typ: ':'}, {typ: ':'}})
+		_, err = (&redisMessageMap).ToMap()
 		if err == nil {
 			t.Fatal("ToMap did not fail as expected")
 		}
@@ -1951,21 +1973,26 @@ func TestRedisMessage(t *testing.T) {
 			expected string
 		}{
 			{
-				input: RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '*', values: []RedisMessage{
+				input: redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainSlice('*', []RedisMessage{
 						{typ: ':', integer: 0},
 						{typ: ':', integer: 0},
-						{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "127.0.3.1"},
+						redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "127.0.3.1"),
 							{typ: ':', integer: 3},
-							{typ: '+', string: ""},
-						}},
-					}},
-				}},
+							redisMessageContainString('+', ""),
+						}),
+					}),
+				}),
 				expected: `{"Value":[{"Value":[{"Value":0,"Type":"int64"},{"Value":0,"Type":"int64"},{"Value":[{"Value":"127.0.3.1","Type":"simple string"},{"Value":3,"Type":"int64"},{"Value":"","Type":"simple string"}],"Type":"array"}],"Type":"array"}],"Type":"array"}`,
 			},
 			{
-				input:    RedisMessage{typ: '+', string: "127.0.3.1", ttl: [7]byte{97, 77, 74, 61, 138, 1, 0}},
+				input: RedisMessage{
+					typ:     '+',
+					bytes:   unsafe.StringData("127.0.3.1"),
+					integer: int64(len("127.0.3.1")),
+					ttl:     [7]byte{97, 77, 74, 61, 138, 1, 0},
+				},
 				expected: `{"Value":"127.0.3.1","Type":"simple string","TTL":"2023-08-28 17:56:34.273 +0000 UTC"}`,
 			},
 			{
@@ -1981,11 +2008,11 @@ func TestRedisMessage(t *testing.T) {
 				expected: `{"Type":"null","Error":"redis nil message"}`,
 			},
 			{
-				input:    RedisMessage{typ: typeSimpleErr, string: "ERR foo"},
+				input:    redisMessageContainString(typeSimpleErr, "ERR foo"),
 				expected: `{"Type":"simple error","Error":"foo"}`,
 			},
 			{
-				input:    RedisMessage{typ: typeBlobErr, string: "ERR foo"},
+				input:    redisMessageContainString(typeBlobErr, "ERR foo"),
 				expected: `{"Type":"blob error","Error":"foo"}`,
 			},
 		}
@@ -1999,13 +2026,13 @@ func TestRedisMessage(t *testing.T) {
 
 	t.Run("CacheMarshal and CacheUnmarshalView", func(t *testing.T) {
 		m1 := RedisMessage{typ: '_'}
-		m2 := RedisMessage{typ: '+', string: "random"}
+		m2 := redisMessageContainString('+', "random")
 		m3 := RedisMessage{typ: '#', integer: 1}
 		m4 := RedisMessage{typ: ':', integer: -1234}
-		m5 := RedisMessage{typ: ',', string: "-1.5"}
-		m6 := RedisMessage{typ: '%', values: nil}
-		m7 := RedisMessage{typ: '~', values: []RedisMessage{m1, m2, m3, m4, m5, m6}}
-		m8 := RedisMessage{typ: '*', values: []RedisMessage{m1, m2, m3, m4, m5, m6, m7}}
+		m5 := redisMessageContainString(',', "-1.5")
+		m6 := redisMessageContainSlice('%', nil)
+		m7 := redisMessageContainSlice('~', []RedisMessage{m1, m2, m3, m4, m5, m6})
+		m8 := redisMessageContainSlice('*', []RedisMessage{m1, m2, m3, m4, m5, m6, m7})
 		msgs := []RedisMessage{m1, m2, m3, m4, m5, m6, m7, m8}
 		now := time.Now()
 		for i := range msgs {

--- a/mock/result.go
+++ b/mock/result.go
@@ -25,17 +25,17 @@ func ErrorResult(err error) rueidis.RedisResult {
 }
 
 func RedisString(v string) rueidis.RedisMessage {
-	m := message{typ: '+', string: v}
+	m := strmsg('+', v)
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
 func RedisBlobString(v string) rueidis.RedisMessage {
-	m := message{typ: '$', string: v}
+	m := strmsg('$', v)
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
 func RedisError(v string) rueidis.RedisMessage {
-	m := message{typ: '-', string: v}
+	m := strmsg('-', v)
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
@@ -45,7 +45,7 @@ func RedisInt64(v int64) rueidis.RedisMessage {
 }
 
 func RedisFloat64(v float64) rueidis.RedisMessage {
-	m := message{typ: ',', string: strconv.FormatFloat(v, 'f', -1, 64)}
+	m := strmsg(',', strconv.FormatFloat(v, 'f', -1, 64))
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
@@ -63,7 +63,7 @@ func RedisNil() rueidis.RedisMessage {
 }
 
 func RedisArray(values ...rueidis.RedisMessage) rueidis.RedisMessage {
-	m := message{typ: '*', values: values}
+	m := slicemsg('*', values)
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
@@ -73,29 +73,29 @@ func RedisMap(kv map[string]rueidis.RedisMessage) rueidis.RedisMessage {
 		values = append(values, RedisString(k))
 		values = append(values, v)
 	}
-	m := message{typ: '%', values: values}
+	m := slicemsg('%', values)
 	return *(*rueidis.RedisMessage)(unsafe.Pointer(&m))
 }
 
 func serialize(m message, buf *bytes.Buffer) {
 	switch m.typ {
 	case '$', '!', '=':
-		buf.WriteString(fmt.Sprintf("%s%d\r\n%s\r\n", string(m.typ), len(m.string), m.string))
+		buf.WriteString(fmt.Sprintf("%s%d\r\n%s\r\n", string(m.typ), len(m.string()), m.string()))
 	case '+', '-', ',', '(':
-		buf.WriteString(fmt.Sprintf("%s%s\r\n", string(m.typ), m.string))
+		buf.WriteString(fmt.Sprintf("%s%s\r\n", string(m.typ), m.string()))
 	case ':', '#':
 		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), m.integer))
 	case '_':
 		buf.WriteString(fmt.Sprintf("%s\r\n", string(m.typ)))
 	case '*':
-		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), len(m.values)))
-		for _, v := range m.values {
+		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), len(m.values())))
+		for _, v := range m.values() {
 			pv := *(*message)(unsafe.Pointer(&v))
 			serialize(pv, buf)
 		}
 	case '%':
-		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), len(m.values)/2))
-		for _, v := range m.values {
+		buf.WriteString(fmt.Sprintf("%s%d\r\n", string(m.typ), len(m.values())/2))
+		for _, v := range m.values() {
 			pv := *(*message)(unsafe.Pointer(&v))
 			serialize(pv, buf)
 		}
@@ -127,11 +127,41 @@ func MultiRedisResultStreamError(err error) rueidis.RedisResultStream {
 
 type message struct {
 	attrs   *rueidis.RedisMessage
-	string  string
-	values  []rueidis.RedisMessage
+	bytes   *byte
+	array   *rueidis.RedisMessage
 	integer int64
 	typ     byte
 	ttl     [7]byte
+}
+
+func (m *message) string() string {
+	if m.bytes == nil {
+		return ""
+	}
+	return unsafe.String(m.bytes, m.integer)
+}
+
+func (m *message) values() []rueidis.RedisMessage {
+	if m.array == nil {
+		return nil
+	}
+	return unsafe.Slice(m.array, m.integer)
+}
+
+func slicemsg(typ byte, values []rueidis.RedisMessage) message {
+	return message{
+		typ:     typ,
+		array:   unsafe.SliceData(values),
+		integer: int64(len(values)),
+	}
+}
+
+func strmsg(typ byte, value string) message {
+	return message{
+		typ:     typ,
+		bytes:   unsafe.StringData(value),
+		integer: int64(len(value)),
+	}
 }
 
 type result struct {

--- a/mux_test.go
+++ b/mux_test.go
@@ -44,7 +44,7 @@ func TestNewMuxDailErr(t *testing.T) {
 	c := 0
 	e := errors.New("any")
 	m := makeMux("", &ClientOption{}, func(ctx context.Context, dst string, opt *ClientOption) (net.Conn, error) {
-		timer := time.NewTimer(time.Millisecond*10) // delay time
+		timer := time.NewTimer(time.Millisecond * 10) // delay time
 		defer timer.Stop()
 		select {
 		case <-ctx.Done():
@@ -101,13 +101,13 @@ func TestNewMux(t *testing.T) {
 	mock := &redisMock{t: t, buf: bufio.NewReader(n2), conn: n2}
 	go func() {
 		mock.Expect("HELLO", "3").
-			Reply(RedisMessage{
-				typ: '%',
-				values: []RedisMessage{
-					{typ: '+', string: "proto"},
+			Reply(redisMessageContainSlice(
+				'%',
+				[]RedisMessage{
+					redisMessageContainString('+', "proto"),
 					{typ: ':', integer: 3},
 				},
-			})
+			))
 		mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 			ReplyString("OK")
 		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
@@ -211,7 +211,7 @@ func TestMuxReuseWire(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "PONG"}, nil)
+					return newResult(redisMessageContainString('+', "PONG"), nil)
 				},
 			},
 		})
@@ -234,7 +234,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "ACQUIRED"}, nil)
+					return newResult(redisMessageContainString('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -271,7 +271,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(RedisMessage{typ: '+', string: "BLOCK_RESPONSE"}, nil)
+		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -282,12 +282,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "PIPELINED"}, nil)
+					return newResult(redisMessageContainString('+', "PIPELINED"), nil)
 				},
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "ACQUIRED"}, nil)
+					return newResult(redisMessageContainString('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -332,7 +332,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(RedisMessage{typ: '+', string: "BLOCK_RESPONSE"}, nil)
+		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -343,12 +343,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoMultiFn: func(cmd ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "PIPELINED"}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "PIPELINED"), nil)}}
 				},
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "ACQUIRED"}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -393,7 +393,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(RedisMessage{typ: '+', string: "BLOCK_RESPONSE"}, nil)
+		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -406,7 +406,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "ACQUIRED"}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -443,7 +443,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(RedisMessage{typ: '+', string: "BLOCK_RESPONSE"}, nil)
+		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -482,13 +482,15 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				InfoFn: func() map[string]RedisMessage {
-					return map[string]RedisMessage{"key": {typ: '+', string: "value"}}
+					return map[string]RedisMessage{"key": redisMessageContainString('+', "value")}
 				},
 			},
 		})
 		defer checkClean(t)
 		defer m.Close()
-		if info := m.Info(); info == nil || info["key"].string != "value" {
+		if info := m.Info(); info == nil {
+			t.Fatalf("unexpected info %v", info)
+		} else if infoKey := info["key"]; infoKey.string() != "value" {
 			t.Fatalf("unexpected info %v", info)
 		}
 	})
@@ -554,7 +556,7 @@ func TestMuxDelegation(t *testing.T) {
 					if cmd.Commands()[0] != "READONLY_COMMAND" {
 						t.Fatalf("command should be READONLY_COMMAND")
 					}
-					return newResult(RedisMessage{typ: '+', string: "READONLY_COMMAND_RESPONSE"}, nil)
+					return newResult(redisMessageContainString('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -597,7 +599,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(multi ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "MULTI_COMMANDS_RESPONSE"}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -640,7 +642,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "READONLY_COMMAND_RESPONSE"}, nil)
+					return newResult(redisMessageContainString('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -668,7 +670,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "MULTI_COMMANDS_RESPONSE"}, nil)}}
+					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -696,7 +698,7 @@ func TestMuxDelegation(t *testing.T) {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
 							result[j] = newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
 						} else {
-							result[j] = newResult(RedisMessage{typ: '+', string: cmd.Cmd.Commands()[1]}, nil)
+							result[j] = newResult(redisMessageContainString('+', cmd.Cmd.Commands()[1]), nil)
 						}
 					}
 					return &redisresults{s: result}
@@ -836,7 +838,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for i := 0; i < 2; i++ {
-			responses <- newResult(RedisMessage{typ: '+', string: "BLOCK_COMMANDS_RESPONSE"}, nil)
+			responses <- newResult(redisMessageContainString('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -860,7 +862,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+					return newResult(redisMessageContainString('+', "OK"), nil)
 				},
 			},
 		})
@@ -928,7 +930,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for i := 0; i < 2; i++ {
-			responses <- newResult(RedisMessage{typ: '+', string: "BLOCK_COMMANDS_RESPONSE"}, nil)
+			responses <- newResult(redisMessageContainString('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -981,7 +983,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for i := 0; i < 2; i++ {
-			responses <- newResult(RedisMessage{typ: '+', string: "BLOCK_COMMANDS_RESPONSE"}, nil)
+			responses <- newResult(redisMessageContainString('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1005,7 +1007,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+					return newResult(redisMessageContainString('+', "OK"), nil)
 				},
 			},
 		})
@@ -1038,7 +1040,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "PONG1"}, nil)
+					return newResult(redisMessageContainString('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)
@@ -1046,7 +1048,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "PONG2"}, nil)
+					return newResult(redisMessageContainString('+', "PONG2"), nil)
 				},
 			},
 		})
@@ -1065,7 +1067,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(RedisMessage{typ: '+', string: "PONG1"}, nil)
+					return newResult(redisMessageContainString('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)

--- a/mux_test.go
+++ b/mux_test.go
@@ -101,10 +101,10 @@ func TestNewMux(t *testing.T) {
 	mock := &redisMock{t: t, buf: bufio.NewReader(n2), conn: n2}
 	go func() {
 		mock.Expect("HELLO", "3").
-			Reply(redisMessageContainSlice(
+			Reply(slicemsg(
 				'%',
 				[]RedisMessage{
-					redisMessageContainString('+', "proto"),
+					strmsg('+', "proto"),
 					{typ: ':', integer: 3},
 				},
 			))
@@ -211,7 +211,7 @@ func TestMuxReuseWire(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "PONG"), nil)
+					return newResult(strmsg('+', "PONG"), nil)
 				},
 			},
 		})
@@ -234,7 +234,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "ACQUIRED"), nil)
+					return newResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -271,7 +271,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -282,12 +282,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "PIPELINED"), nil)
+					return newResult(strmsg('+', "PIPELINED"), nil)
 				},
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "ACQUIRED"), nil)
+					return newResult(strmsg('+', "ACQUIRED"), nil)
 				},
 			},
 			{
@@ -332,7 +332,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -343,12 +343,12 @@ func TestMuxReuseWire(t *testing.T) {
 			{
 				// leave first wire for pipeline calls
 				DoMultiFn: func(cmd ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "PIPELINED"), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', "PIPELINED"), nil)}}
 				},
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "ACQUIRED"), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -393,7 +393,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -406,7 +406,7 @@ func TestMuxReuseWire(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(cmd ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "ACQUIRED"), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', "ACQUIRED"), nil)}}
 				},
 			},
 			{
@@ -443,7 +443,7 @@ func TestMuxReuseWire(t *testing.T) {
 			t.Fatalf("unexpected response %v", val)
 		}
 
-		response <- newResult(redisMessageContainString('+', "BLOCK_RESPONSE"), nil)
+		response <- newResult(strmsg('+', "BLOCK_RESPONSE"), nil)
 		<-blocking
 	})
 
@@ -482,7 +482,7 @@ func TestMuxDelegation(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				InfoFn: func() map[string]RedisMessage {
-					return map[string]RedisMessage{"key": redisMessageContainString('+', "value")}
+					return map[string]RedisMessage{"key": strmsg('+', "value")}
 				},
 			},
 		})
@@ -556,7 +556,7 @@ func TestMuxDelegation(t *testing.T) {
 					if cmd.Commands()[0] != "READONLY_COMMAND" {
 						t.Fatalf("command should be READONLY_COMMAND")
 					}
-					return newResult(redisMessageContainString('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -599,7 +599,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiFn: func(multi ...Completed) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -642,7 +642,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
-					return newResult(redisMessageContainString('+', "READONLY_COMMAND_RESPONSE"), nil)
+					return newResult(strmsg('+', "READONLY_COMMAND_RESPONSE"), nil)
 				},
 			},
 		})
@@ -670,7 +670,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
-					return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
+					return &redisresults{s: []RedisResult{newResult(strmsg('+', "MULTI_COMMANDS_RESPONSE"), nil)}}
 				},
 			},
 		})
@@ -698,7 +698,7 @@ func TestMuxDelegation(t *testing.T) {
 						if s := cmd.Cmd.Slot() & uint16(len(wires)-1); s != idx {
 							result[j] = newErrResult(fmt.Errorf("wrong slot %v %v", s, idx))
 						} else {
-							result[j] = newResult(redisMessageContainString('+', cmd.Cmd.Commands()[1]), nil)
+							result[j] = newResult(strmsg('+', cmd.Cmd.Commands()[1]), nil)
 						}
 					}
 					return &redisresults{s: result}
@@ -838,7 +838,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for i := 0; i < 2; i++ {
-			responses <- newResult(redisMessageContainString('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -862,7 +862,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "OK"), nil)
+					return newResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -930,7 +930,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for i := 0; i < 2; i++ {
-			responses <- newResult(redisMessageContainString('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -983,7 +983,7 @@ func TestMuxDelegation(t *testing.T) {
 			<-blocked
 		}
 		for i := 0; i < 2; i++ {
-			responses <- newResult(redisMessageContainString('+', "BLOCK_COMMANDS_RESPONSE"), nil)
+			responses <- newResult(strmsg('+', "BLOCK_COMMANDS_RESPONSE"), nil)
 		}
 		wg.Wait()
 	})
@@ -1007,7 +1007,7 @@ func TestMuxDelegation(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "OK"), nil)
+					return newResult(strmsg('+', "OK"), nil)
 				},
 			},
 		})
@@ -1040,7 +1040,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "PONG1"), nil)
+					return newResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)
@@ -1048,7 +1048,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 			},
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "PONG2"), nil)
+					return newResult(strmsg('+', "PONG2"), nil)
 				},
 			},
 		})
@@ -1067,7 +1067,7 @@ func TestMuxRegisterCloseHook(t *testing.T) {
 		m, checkClean := setupMux([]*mockWire{
 			{
 				DoFn: func(cmd Completed) RedisResult {
-					return newResult(redisMessageContainString('+', "PONG1"), nil)
+					return newResult(strmsg('+', "PONG1"), nil)
 				},
 				SetOnCloseHookFn: func(fn func(error)) {
 					hook.Store(fn)

--- a/mux_test.go
+++ b/mux_test.go
@@ -105,7 +105,7 @@ func TestNewMux(t *testing.T) {
 				'%',
 				[]RedisMessage{
 					strmsg('+', "proto"),
-					{typ: ':', integer: 3},
+					{typ: ':', intlen: 3},
 				},
 			))
 		mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").

--- a/pipe.go
+++ b/pipe.go
@@ -30,12 +30,12 @@ func isUnsubReply(msg *RedisMessage) bool {
 	// ex. NOPERM User limiteduser has no permissions to run the 'ping' command
 	// ex. LOADING server is loading the dataset in memory
 	// ex. BUSY
-	if msg.typ == '-' && (strings.HasPrefix(msg.string, "LOADING") || strings.HasPrefix(msg.string, "BUSY") || strings.Contains(msg.string, "'ping'")) {
+	if msg.typ == '-' && (strings.HasPrefix(msg.string(), "LOADING") || strings.HasPrefix(msg.string(), "BUSY") || strings.Contains(msg.string(), "'ping'")) {
 		msg.typ = '+'
-		msg.string = "PONG"
+		msg.setString("PONG")
 		return true
 	}
-	return msg.string == "PONG" || (len(msg.values) != 0 && msg.values[0].string == "pong")
+	return msg.string() == "PONG" || (len(msg.values()) != 0 && msg.values()[0].string() == "pong")
 }
 
 type wire interface {
@@ -230,11 +230,11 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 					continue
 				}
 				if re, ok := err.(*RedisError); ok {
-					if !r2 && noHello.MatchString(re.string) {
+					if !r2 && noHello.MatchString(re.string()) {
 						r2 = true
 						continue
 					} else if init[i][0] == "CLIENT" {
-						err = fmt.Errorf("%s: %v\n%w", re.string, init[i], ErrNoCache)
+						err = fmt.Errorf("%s: %v\n%w", re.string(), init[i], ErrNoCache)
 					} else if r2 {
 						continue
 					}
@@ -249,7 +249,7 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 	}
 	if !r2 && !r2ps {
 		if ver, ok := p.info["version"]; ok {
-			if v := strings.Split(ver.string, "."); len(v) != 0 {
+			if v := strings.Split(ver.string(), "."); len(v) != 0 {
 				vv, _ := strconv.ParseInt(v[0], 10, 32)
 				p.version = int32(vv)
 			}
@@ -310,7 +310,7 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 					continue
 				}
 				if err = r.Error(); err != nil {
-					if re, ok := err.(*RedisError); ok && noHello.MatchString(re.string) {
+					if re, ok := err.(*RedisError); ok && noHello.MatchString(re.string()) {
 						continue
 					}
 					p.Close()
@@ -511,8 +511,8 @@ func (p *pipe) _backgroundRead() (err error) {
 		if msg, err = readNextMessage(p.r); err != nil {
 			return
 		}
-		if msg.typ == '>' || (r2ps && len(msg.values) != 0 && msg.values[0].string != "pong") {
-			if prply, unsub = p.handlePush(msg.values); !prply {
+		if msg.typ == '>' || (r2ps && len(msg.values()) != 0 && msg.values()[0].string() != "pong") {
+			if prply, unsub = p.handlePush(msg.values()); !prply {
 				continue
 			}
 			if skip > 0 {
@@ -521,24 +521,24 @@ func (p *pipe) _backgroundRead() (err error) {
 				unsub = false
 				continue
 			}
-		} else if ver == 6 && len(msg.values) != 0 {
+		} else if ver == 6 && len(msg.values()) != 0 {
 			// This is a workaround for Redis 6's broken invalidation protocol: https://github.com/redis/redis/issues/8935
 			// When Redis 6 handles MULTI, MGET, or other multi-keys command,
 			// it will send invalidation message immediately if it finds the keys are expired, thus causing the multi-keys command response to be broken.
 			// We fix this by fetching the next message and patch it back to the response.
 			i := 0
-			for j, v := range msg.values {
+			for j, v := range msg.values() {
 				if v.typ == '>' {
-					p.handlePush(v.values)
+					p.handlePush(v.values())
 				} else {
 					if i != j {
-						msg.values[i] = v
+						msg.values()[i] = v
 					}
 					i++
 				}
 			}
-			for ; i < len(msg.values); i++ {
-				if msg.values[i], err = readNextMessage(p.r); err != nil {
+			for ; i < len(msg.values()); i++ {
+				if msg.values()[i], err = readNextMessage(p.r); err != nil {
 					return
 				}
 			}
@@ -567,28 +567,28 @@ func (p *pipe) _backgroundRead() (err error) {
 			if multi == nil {
 				multi = ones
 			}
-		} else if ff >= 4 && len(msg.values) >= 2 && multi[0].IsOptIn() { // if unfulfilled multi commands are lead by opt-in and get success response
+		} else if ff >= 4 && len(msg.values()) >= 2 && multi[0].IsOptIn() { // if unfulfilled multi commands are lead by opt-in and get success response
 			now := time.Now()
 			if cacheable := Cacheable(multi[ff-1]); cacheable.IsMGet() {
 				cc := cmds.MGetCacheCmd(cacheable)
-				msgs := msg.values[len(msg.values)-1].values
+				msgs := msg.values()[len(msg.values())-1].values()
 				for i, cp := range msgs {
 					ck := cmds.MGetCacheKey(cacheable, i)
 					cp.attrs = cacheMark
-					if pttl := msg.values[i].integer; pttl >= 0 {
+					if pttl := msg.values()[i].integer; pttl >= 0 {
 						cp.setExpireAt(now.Add(time.Duration(pttl) * time.Millisecond).UnixMilli())
 					}
 					msgs[i].setExpireAt(p.cache.Update(ck, cc, cp))
 				}
 			} else {
 				ck, cc := cmds.CacheKey(cacheable)
-				ci := len(msg.values) - 1
-				cp := msg.values[ci]
+				ci := len(msg.values()) - 1
+				cp := msg.values()[ci]
 				cp.attrs = cacheMark
-				if pttl := msg.values[ci-1].integer; pttl >= 0 {
+				if pttl := msg.values()[ci-1].integer; pttl >= 0 {
 					cp.setExpireAt(now.Add(time.Duration(pttl) * time.Millisecond).UnixMilli())
 				}
-				msg.values[ci].setExpireAt(p.cache.Update(ck, cc, cp))
+				msg.values()[ci].setExpireAt(p.cache.Update(ck, cc, cp))
 			}
 		}
 		if prply {
@@ -609,7 +609,7 @@ func (p *pipe) _backgroundRead() (err error) {
 			}
 			skip = len(multi[ff].Commands()) - 2
 			msg = RedisMessage{} // override successful subscribe/unsubscribe response to empty
-		} else if multi[ff].NoReply() && msg.string == "QUEUED" {
+		} else if multi[ff].NoReply() && msg.string() == "QUEUED" {
 			panic(multiexecsub)
 		} else if multi[ff].IsUnsub() && !isUnsubReply(&msg) {
 			// See https://github.com/redis/rueidis/pull/691
@@ -675,61 +675,61 @@ func (p *pipe) handlePush(values []RedisMessage) (reply bool, unsubscribe bool) 
 	// TODO: handle other push data
 	// tracking-redir-broken
 	// server-cpu-usage
-	switch values[0].string {
+	switch values[0].string() {
 	case "invalidate":
 		if p.cache != nil {
 			if values[1].IsNil() {
 				p.cache.Delete(nil)
 			} else {
-				p.cache.Delete(values[1].values)
+				p.cache.Delete(values[1].values())
 			}
 		}
 		if p.onInvalidations != nil {
 			if values[1].IsNil() {
 				p.onInvalidations(nil)
 			} else {
-				p.onInvalidations(values[1].values)
+				p.onInvalidations(values[1].values())
 			}
 		}
 	case "message":
 		if len(values) >= 3 {
-			m := PubSubMessage{Channel: values[1].string, Message: values[2].string}
-			p.nsubs.Publish(values[1].string, m)
+			m := PubSubMessage{Channel: values[1].string(), Message: values[2].string()}
+			p.nsubs.Publish(values[1].string(), m)
 			p.pshks.Load().(*pshks).hooks.OnMessage(m)
 		}
 	case "pmessage":
 		if len(values) >= 4 {
-			m := PubSubMessage{Pattern: values[1].string, Channel: values[2].string, Message: values[3].string}
-			p.psubs.Publish(values[1].string, m)
+			m := PubSubMessage{Pattern: values[1].string(), Channel: values[2].string(), Message: values[3].string()}
+			p.psubs.Publish(values[1].string(), m)
 			p.pshks.Load().(*pshks).hooks.OnMessage(m)
 		}
 	case "smessage":
 		if len(values) >= 3 {
-			m := PubSubMessage{Channel: values[1].string, Message: values[2].string}
-			p.ssubs.Publish(values[1].string, m)
+			m := PubSubMessage{Channel: values[1].string(), Message: values[2].string()}
+			p.ssubs.Publish(values[1].string(), m)
 			p.pshks.Load().(*pshks).hooks.OnMessage(m)
 		}
 	case "unsubscribe":
-		p.nsubs.Unsubscribe(values[1].string)
+		p.nsubs.Unsubscribe(values[1].string())
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string, Channel: values[1].string, Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
 		}
 		return true, true
 	case "punsubscribe":
-		p.psubs.Unsubscribe(values[1].string)
+		p.psubs.Unsubscribe(values[1].string())
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string, Channel: values[1].string, Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
 		}
 		return true, true
 	case "sunsubscribe":
-		p.ssubs.Unsubscribe(values[1].string)
+		p.ssubs.Unsubscribe(values[1].string())
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string, Channel: values[1].string, Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
 		}
 		return true, true
 	case "subscribe", "psubscribe", "ssubscribe":
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string, Channel: values[1].string, Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
 		}
 		return true, false
 	}
@@ -860,7 +860,8 @@ func (p *pipe) Version() int {
 }
 
 func (p *pipe) AZ() string {
-	return p.info["availability_zone"].string
+	infoAvaliabilityZone := p.info["availability_zone"]
+	return infoAvaliabilityZone.string()
 }
 
 func (p *pipe) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
@@ -1359,7 +1360,7 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 	commands := cmd.Commands()
 	keys := len(commands) - 1
 	builder := cmds.NewBuilder(cmds.InitSlot)
-	result := RedisResult{val: RedisMessage{typ: '*', values: nil}}
+	result := RedisResult{val: RedisMessage{typ: '*'}}
 	mgetcc := cmds.MGetCacheCmd(cmd)
 	if mgetcc[0] == 'J' {
 		keys-- // the last one of JSON.MGET is a path, not a key
@@ -1371,10 +1372,11 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 	for i, key := range commands[1 : keys+1] {
 		v, entry := p.cache.Flight(key, mgetcc, ttl, now)
 		if v.typ != 0 { // cache hit for one key
-			if len(result.val.values) == 0 {
-				result.val.values = make([]RedisMessage, keys)
+			if len(result.val.values()) == 0 {
+				result.val.setValues(make([]RedisMessage, keys))
+
 			}
-			result.val.values[i] = v
+			result.val.values()[i] = v
 			continue
 		}
 		if entry != nil {
@@ -1432,27 +1434,27 @@ func (p *pipe) doCacheMGet(ctx context.Context, cmd Cacheable, ttl time.Duration
 		if len(rewritten.Commands()) == len(commands) { // all cache miss
 			return newResult(exec[last], nil)
 		}
-		partial = exec[last].values
+		partial = exec[last].values()
 	} else { // all cache hit
 		result.val.attrs = cacheMark
 	}
 
-	if len(result.val.values) == 0 {
-		result.val.values = make([]RedisMessage, keys)
+	if len(result.val.values()) == 0 {
+		result.val.setValues(make([]RedisMessage, keys))
 	}
 	for i, entry := range entries.e {
 		v, err := entry.Wait(ctx)
 		if err != nil {
 			return newErrResult(err)
 		}
-		result.val.values[i] = v
+		result.val.values()[i] = v
 	}
 
 	j := 0
 	for _, ret := range partial {
-		for ; j < len(result.val.values); j++ {
-			if result.val.values[j].typ == 0 {
-				result.val.values[j] = ret
+		for ; j < len(result.val.values()); j++ {
+			if result.val.values()[j].typ == 0 {
+				result.val.values()[j] = ret
 				break
 			}
 		}

--- a/pipe.go
+++ b/pipe.go
@@ -244,7 +244,7 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 			}
 		}
 	}
-	if proto := p.info["proto"]; proto.integer < 3 {
+	if proto := p.info["proto"]; proto.intlen < 3 {
 		r2 = true
 	}
 	if !r2 && !r2ps {
@@ -575,7 +575,7 @@ func (p *pipe) _backgroundRead() (err error) {
 				for i, cp := range msgs {
 					ck := cmds.MGetCacheKey(cacheable, i)
 					cp.attrs = cacheMark
-					if pttl := msg.values()[i].integer; pttl >= 0 {
+					if pttl := msg.values()[i].intlen; pttl >= 0 {
 						cp.setExpireAt(now.Add(time.Duration(pttl) * time.Millisecond).UnixMilli())
 					}
 					msgs[i].setExpireAt(p.cache.Update(ck, cc, cp))
@@ -585,7 +585,7 @@ func (p *pipe) _backgroundRead() (err error) {
 				ci := len(msg.values()) - 1
 				cp := msg.values()[ci]
 				cp.attrs = cacheMark
-				if pttl := msg.values()[ci-1].integer; pttl >= 0 {
+				if pttl := msg.values()[ci-1].intlen; pttl >= 0 {
 					cp.setExpireAt(now.Add(time.Duration(pttl) * time.Millisecond).UnixMilli())
 				}
 				msg.values()[ci].setExpireAt(p.cache.Update(ck, cc, cp))
@@ -712,24 +712,24 @@ func (p *pipe) handlePush(values []RedisMessage) (reply bool, unsubscribe bool) 
 	case "unsubscribe":
 		p.nsubs.Unsubscribe(values[1].string())
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].intlen})
 		}
 		return true, true
 	case "punsubscribe":
 		p.psubs.Unsubscribe(values[1].string())
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].intlen})
 		}
 		return true, true
 	case "sunsubscribe":
 		p.ssubs.Unsubscribe(values[1].string())
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].intlen})
 		}
 		return true, true
 	case "subscribe", "psubscribe", "ssubscribe":
 		if len(values) >= 3 {
-			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].integer})
+			p.pshks.Load().(*pshks).hooks.OnSubscription(PubSubSubscription{Kind: values[0].string(), Channel: values[1].string(), Count: values[2].intlen})
 		}
 		return true, false
 	}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -61,7 +61,7 @@ func (r *redisMock) Expect(expected ...string) *redisExpect {
 func (r *redisExpect) ReplyString(replies ...string) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(redisMessageContainString('+', reply))
+			r.Reply(strmsg('+', reply))
 		}
 	}
 	return r
@@ -70,7 +70,7 @@ func (r *redisExpect) ReplyString(replies ...string) *redisExpect {
 func (r *redisExpect) ReplyBlobString(replies ...string) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(redisMessageContainString('$', reply))
+			r.Reply(strmsg('$', reply))
 		}
 	}
 	return r
@@ -79,7 +79,7 @@ func (r *redisExpect) ReplyBlobString(replies ...string) *redisExpect {
 func (r *redisExpect) ReplyError(replies ...string) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(redisMessageContainString('-', reply))
+			r.Reply(strmsg('-', reply))
 		}
 	}
 	return r
@@ -147,12 +147,12 @@ func setup(t *testing.T, option ClientOption) (*pipe, *redisMock, func(), func()
 	}
 	go func() {
 		mock.Expect("HELLO", "3").
-			Reply(redisMessageContainSlice(
+			Reply(slicemsg(
 				'%',
 				[]RedisMessage{
-					redisMessageContainString('+', "version"),
-					redisMessageContainString('+', "6.0.0"),
-					redisMessageContainString('+', "proto"),
+					strmsg('+', "version"),
+					strmsg('+', "6.0.0"),
+					strmsg('+', "proto"),
 					{typ: ':', integer: 3},
 				},
 			))
@@ -209,13 +209,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "default", "pa", "SETNAME", "cn").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						RedisMessage{typ: ':', integer: 3},
-						redisMessageContainString('+', "availability_zone"),
-						redisMessageContainString('+', "us-west-1a"),
+						strmsg('+', "availability_zone"),
+						strmsg('+', "us-west-1a"),
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
@@ -258,13 +258,13 @@ func TestNewPipe(t *testing.T) {
 			mock.Expect("AUTH", "pa").
 				ReplyString("OK")
 			mock.Expect("HELLO", "2").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'*',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 2},
-						redisMessageContainString('+', "availability_zone"),
-						redisMessageContainString('+', "us-west-1a"),
+						strmsg('+', "availability_zone"),
+						strmsg('+', "us-west-1a"),
 					},
 				))
 			mock.Expect("CLIENT", "SETNAME", "cn").
@@ -307,10 +307,10 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 3},
 					},
 				))
@@ -346,10 +346,10 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 3},
 					},
 				))
@@ -386,10 +386,10 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 3},
 					},
 				))
@@ -417,10 +417,10 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 3},
 					},
 				))
@@ -456,10 +456,10 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 3},
 					},
 				))
@@ -521,10 +521,10 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3").
-				Reply(redisMessageContainSlice(
+				Reply(slicemsg(
 					'%',
 					[]RedisMessage{
-						redisMessageContainString('+', "proto"),
+						strmsg('+', "proto"),
 						{typ: ':', integer: 3},
 					},
 				))
@@ -597,26 +597,26 @@ func TestNewRESP2Pipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "server"),
-					redisMessageContainString('+', "redis"),
-					redisMessageContainString('+', "proto"),
+				Reply(slicemsg('*', []RedisMessage{
+					strmsg('+', "server"),
+					strmsg('+', "redis"),
+					strmsg('+', "proto"),
 					{typ: ':', integer: 2},
-					redisMessageContainString('+', "availability_zone"),
-					redisMessageContainString('+', "us-west-1a"),
+					strmsg('+', "availability_zone"),
+					strmsg('+', "us-west-1a"),
 				}))
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("HELLO", "2").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', "server"),
-					redisMessageContainString('+', "redis"),
-					redisMessageContainString('+', "proto"),
+				Reply(slicemsg('*', []RedisMessage{
+					strmsg('+', "server"),
+					strmsg('+', "redis"),
+					strmsg('+', "proto"),
 					{typ: ':', integer: 2},
-					redisMessageContainString('+', "availability_zone"),
-					redisMessageContainString('+', "us-west-1a"),
+					strmsg('+', "availability_zone"),
+					strmsg('+', "us-west-1a"),
 				}))
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
 				ReplyError("UNKNOWN COMMAND")
@@ -890,7 +890,7 @@ func TestIgnoreOutOfBandDataDuringSyncMode(t *testing.T) {
 	p, mock, cancel, _ := setup(t, ClientOption{})
 	defer cancel()
 	go func() {
-		mock.Expect("PING").Reply(redisMessageContainString('>', "This should be ignore")).ReplyString("OK")
+		mock.Expect("PING").Reply(strmsg('>', "This should be ignore")).ReplyString("OK")
 	}()
 	ExpectOK(t, p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})))
 }
@@ -1219,11 +1219,11 @@ func TestNoReplyExceedRingSize(t *testing.T) {
 	}()
 
 	for i := 0; i < times; i++ {
-		mock.Expect("UNSUBSCRIBE").Reply(redisMessageContainSlice('>', []RedisMessage{
-			redisMessageContainString('+', "unsubscribe"),
-			redisMessageContainString('+', "1"),
+		mock.Expect("UNSUBSCRIBE").Reply(slicemsg('>', []RedisMessage{
+			strmsg('+', "unsubscribe"),
+			strmsg('+', "1"),
 			{typ: ':', integer: 0},
-		})).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainString('+', "PONG"))
+		})).Expect(cmds.PingCmd.Commands()...).Reply(strmsg('+', "PONG"))
 	}
 	<-wait
 }
@@ -1265,7 +1265,7 @@ func TestResponseSequenceWithPushMessageInjected(t *testing.T) {
 	for i := 0; i < times; i++ {
 		m, _ := mock.ReadMessage()
 		mock.Expect().ReplyString(m.values()[1].string()).
-			Reply(redisMessageContainSlice('>', []RedisMessage{redisMessageContainString('+', "should be ignore")}))
+			Reply(slicemsg('>', []RedisMessage{strmsg('+', "should be ignore")}))
 	}
 	wg.Wait()
 }
@@ -1285,16 +1285,16 @@ func TestClientSideCaching(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: ttl},
-				redisMessageContainString('+', resp),
+				strmsg('+', resp),
 			}))
 	}
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
+				strmsg('+', "invalidate"),
 				keys,
 			},
 		))
@@ -1334,7 +1334,7 @@ func TestClientSideCaching(t *testing.T) {
 	}
 
 	// cache invalidation
-	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}))
+	invalidateCSC(slicemsg('*', []RedisMessage{strmsg('+', "a")}))
 	go func() {
 		expectCSC(-1, "2")
 	}()
@@ -1377,16 +1377,16 @@ func TestClientSideCachingBCAST(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: ttl},
-				redisMessageContainString('+', resp),
+				strmsg('+', resp),
 			}))
 	}
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
+				strmsg('+', "invalidate"),
 				keys,
 			},
 		))
@@ -1426,7 +1426,7 @@ func TestClientSideCachingBCAST(t *testing.T) {
 	}
 
 	// cache invalidation
-	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}))
+	invalidateCSC(slicemsg('*', []RedisMessage{strmsg('+', "a")}))
 	go func() {
 		expectCSC(-1, "2")
 	}()
@@ -1469,16 +1469,16 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: ttl},
-				redisMessageContainString('+', resp),
+				strmsg('+', resp),
 			}))
 	}
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
+				strmsg('+', "invalidate"),
 				keys,
 			},
 		))
@@ -1518,7 +1518,7 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 	}
 
 	// cache invalidation
-	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}))
+	invalidateCSC(slicemsg('*', []RedisMessage{strmsg('+', "a")}))
 	go func() {
 		expectCSC(-1, "2")
 	}()
@@ -1617,10 +1617,10 @@ func TestClientSideCachingMGet(t *testing.T) {
 	defer cancel()
 
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
+				strmsg('+', "invalidate"),
 				keys,
 			},
 		))
@@ -1640,11 +1640,11 @@ func TestClientSideCachingMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 1000},
 				{typ: ':', integer: 2000},
 				{typ: ':', integer: 3000},
-				redisMessageContainSlice('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 1},
 					{typ: ':', integer: 2},
 					{typ: ':', integer: 3},
@@ -1690,7 +1690,7 @@ func TestClientSideCachingMGet(t *testing.T) {
 	}
 
 	// partial cache invalidation
-	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a1"), redisMessageContainString('+', "a3")}))
+	invalidateCSC(slicemsg('*', []RedisMessage{strmsg('+', "a1"), strmsg('+', "a3")}))
 	go func() {
 		mock.Expect("CLIENT", "CACHING", "YES").
 			Expect("MULTI").
@@ -1703,10 +1703,10 @@ func TestClientSideCachingMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 10000},
 				{typ: ':', integer: 30000},
-				redisMessageContainSlice('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 10},
 					{typ: ':', integer: 30},
 				}),
@@ -1751,10 +1751,10 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 	defer cancel()
 
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
+				strmsg('+', "invalidate"),
 				keys,
 			},
 		))
@@ -1774,11 +1774,11 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 1000},
 				{typ: ':', integer: 2000},
 				{typ: ':', integer: 3000},
-				redisMessageContainSlice('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 1},
 					{typ: ':', integer: 2},
 					{typ: ':', integer: 3},
@@ -1824,7 +1824,7 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 	}
 
 	// partial cache invalidation
-	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a1"), redisMessageContainString('+', "a3")}))
+	invalidateCSC(slicemsg('*', []RedisMessage{strmsg('+', "a1"), strmsg('+', "a3")}))
 	go func() {
 		mock.Expect("CLIENT", "CACHING", "YES").
 			Expect("MULTI").
@@ -1837,10 +1837,10 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: 10000},
 				{typ: ':', integer: 30000},
-				redisMessageContainSlice('*', []RedisMessage{
+				slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 10},
 					{typ: ':', integer: 30},
 				}),
@@ -1964,7 +1964,7 @@ func TestClientSideCachingWithSideChannelMGet(t *testing.T) {
 	p.cache.Flight("a1", "GET", 10*time.Second, time.Now())
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		m := redisMessageContainString('+', "OK")
+		m := strmsg('+', "OK")
 		m.setExpireAt(time.Now().Add(10 * time.Millisecond).UnixMilli())
 		p.cache.Update("a1", "GET", m)
 	}()
@@ -2014,10 +2014,10 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 		defer cancel()
 
 		invalidateCSC := func(keys RedisMessage) {
-			mock.Expect().Reply(redisMessageContainSlice(
+			mock.Expect().Reply(slicemsg(
 				'>',
 				[]RedisMessage{
-					redisMessageContainString('+', "invalidate"),
+					strmsg('+', "invalidate"),
 					keys,
 				},
 			))
@@ -2043,7 +2043,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
+				Reply(slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 1000},
 					{typ: ':', integer: 1},
 				})).
@@ -2051,7 +2051,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
+				Reply(slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 2000},
 					{typ: ':', integer: 2},
 				})).
@@ -2059,7 +2059,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
+				Reply(slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 3000},
 					{typ: ':', integer: 3},
 				}))
@@ -2106,7 +2106,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 		}
 
 		// partial cache invalidation
-		invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a1"), redisMessageContainString('+', "a3")}))
+		invalidateCSC(slicemsg('*', []RedisMessage{strmsg('+', "a1"), strmsg('+', "a3")}))
 		go func() {
 			mock.Expect("CLIENT", "CACHING", "YES").
 				Expect("MULTI").
@@ -2122,7 +2122,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
+				Reply(slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 10000},
 					{typ: ':', integer: 10},
 				})).
@@ -2130,7 +2130,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
+				Reply(slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 30000},
 					{typ: ':', integer: 30},
 				}))
@@ -2212,7 +2212,7 @@ func TestClientSideCachingExecAbortDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(redisMessageContainSlice('*', []RedisMessage{
+				Reply(slicemsg('*', []RedisMessage{
 					{typ: ':', integer: 1000},
 					{typ: ':', integer: 1},
 				})).
@@ -2326,7 +2326,7 @@ func TestClientSideCachingWithSideChannelDoMultiCache(t *testing.T) {
 		p.cache.Flight("a1", "GET", 10*time.Second, time.Now())
 		go func() {
 			time.Sleep(100 * time.Millisecond)
-			m := redisMessageContainString('+', "OK")
+			m := strmsg('+', "OK")
 			m.setExpireAt(time.Now().Add(10 * time.Millisecond).UnixMilli())
 			p.cache.Update("a1", "GET", m)
 		}()
@@ -2396,9 +2396,9 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(redisMessageContainSlice('*', []RedisMessage{
+					Reply(slicemsg('*', []RedisMessage{
 						{typ: ':', integer: pttl},
-						redisMessageContainString('+', key),
+						strmsg('+', key),
 					}))
 			}
 			go func() {
@@ -2436,14 +2436,14 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(redisMessageContainSlice('*', []RedisMessage{
+					Reply(slicemsg('*', []RedisMessage{
 						{typ: ':', integer: -1},
 						{typ: ':', integer: 1000},
 						{typ: ':', integer: 20000},
-						redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', "a"),
-							redisMessageContainString('+', "b"),
-							redisMessageContainString('+', "c"),
+						slicemsg('*', []RedisMessage{
+							strmsg('+', "a"),
+							strmsg('+', "b"),
+							strmsg('+', "c"),
 						}),
 					}))
 			}()
@@ -2481,7 +2481,7 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(redisMessageContainSlice('*', []RedisMessage{
+					Reply(slicemsg('*', []RedisMessage{
 						{typ: ':', integer: -1},
 						{typ: ':', integer: 1},
 					})).
@@ -2489,7 +2489,7 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(redisMessageContainSlice('*', []RedisMessage{
+					Reply(slicemsg('*', []RedisMessage{
 						{typ: ':', integer: 1000},
 						{typ: ':', integer: 2},
 					})).
@@ -2497,7 +2497,7 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(redisMessageContainSlice('*', []RedisMessage{
+					Reply(slicemsg('*', []RedisMessage{
 						{typ: ':', integer: 20000},
 						{typ: ':', integer: 3},
 					}))
@@ -2546,12 +2546,12 @@ func TestClientSideCachingRedis6InvalidationBug1(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
-				redisMessageContainSlice(
+			Reply(slicemsg('*', []RedisMessage{
+				slicemsg(
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "invalidate"),
-						redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
+						strmsg('+', "invalidate"),
+						slicemsg('*', []RedisMessage{strmsg('+', "a")}),
 					},
 				),
 				{typ: ':', integer: -2},
@@ -2608,13 +2608,13 @@ func TestClientSideCachingRedis6InvalidationBug2(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: -2},
-				redisMessageContainSlice(
+				slicemsg(
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "invalidate"),
-						redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
+						strmsg('+', "invalidate"),
+						slicemsg('*', []RedisMessage{strmsg('+', "a")}),
 					},
 				),
 			})).Reply(RedisMessage{typ: '_'})
@@ -2669,13 +2669,13 @@ func TestClientSideCachingRedis6InvalidationBugErr(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(redisMessageContainSlice('*', []RedisMessage{
+			Reply(slicemsg('*', []RedisMessage{
 				{typ: ':', integer: -2},
-				redisMessageContainSlice(
+				slicemsg(
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "invalidate"),
-						redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
+						strmsg('+', "invalidate"),
+						slicemsg('*', []RedisMessage{strmsg('+', "a")}),
 					},
 				),
 			}))
@@ -2699,11 +2699,11 @@ func TestDisableClientSideCaching(t *testing.T) {
 	p.background()
 
 	go func() {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
-				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
+				strmsg('+', "invalidate"),
+				slicemsg('*', []RedisMessage{strmsg('+', "a")}),
 			},
 		))
 		mock.Expect("GET", "a").ReplyString("1").
@@ -2739,11 +2739,11 @@ func TestOnInvalidations(t *testing.T) {
 	})
 
 	go func() {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
-				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
+				strmsg('+', "invalidate"),
+				slicemsg('*', []RedisMessage{strmsg('+', "a")}),
 			},
 		))
 	}()
@@ -2753,10 +2753,10 @@ func TestOnInvalidations(t *testing.T) {
 	}
 
 	go func() {
-		mock.Expect().Reply(redisMessageContainSlice(
+		mock.Expect().Reply(slicemsg(
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "invalidate"),
+				strmsg('+', "invalidate"),
 				{typ: '_'},
 			},
 		))
@@ -2818,14 +2818,14 @@ func TestPubSub(t *testing.T) {
 		go func() {
 			for _, c := range commands {
 				if c.IsUnsub() {
-					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
-						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
-						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
-					})).Reply(redisMessageContainString('+', "PONG"))
+					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(slicemsg('>', []RedisMessage{
+						strmsg('+', strings.ToLower(c.Commands()[0])),
+						strmsg('+', strings.ToLower(c.Commands()[1])),
+					})).Reply(strmsg('+', "PONG"))
 				} else {
-					mock.Expect(c.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
-						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
-						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
+					mock.Expect(c.Commands()...).Reply(slicemsg('>', []RedisMessage{
+						strmsg('+', strings.ToLower(c.Commands()[0])),
+						strmsg('+', strings.ToLower(c.Commands()[1])),
 					}))
 				}
 				mock.Expect("GET", "k").ReplyString("v")
@@ -2854,14 +2854,14 @@ func TestPubSub(t *testing.T) {
 		go func() {
 			for _, c := range commands {
 				if c.IsUnsub() {
-					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
-						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
-						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
-					})).Reply(redisMessageContainString('+', "PONG"))
+					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(slicemsg('>', []RedisMessage{
+						strmsg('+', strings.ToLower(c.Commands()[0])),
+						strmsg('+', strings.ToLower(c.Commands()[1])),
+					})).Reply(strmsg('+', "PONG"))
 				} else {
-					mock.Expect(c.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
-						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
-						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
+					mock.Expect(c.Commands()...).Reply(slicemsg('>', []RedisMessage{
+						strmsg('+', strings.ToLower(c.Commands()[0])),
+						strmsg('+', strings.ToLower(c.Commands()[1])),
 					}))
 				}
 			}
@@ -2882,24 +2882,24 @@ func TestPubSub(t *testing.T) {
 		deactivate := builder.Unsubscribe().Channel("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "subscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "subscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "message"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "2"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "message"),
+					strmsg('+', "1"),
+					strmsg('+', "2"),
 				}),
 			)
 			mock.Expect(deactivate.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "unsubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "unsubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 0},
 				}),
-			).Reply(redisMessageContainString('+', "PONG"))
+			).Reply(strmsg('+', "PONG"))
 		}()
 
 		if err := p.Receive(ctx, activate, func(msg PubSubMessage) {
@@ -2923,24 +2923,24 @@ func TestPubSub(t *testing.T) {
 		deactivate := builder.Sunsubscribe().Channel("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "ssubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "ssubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "smessage"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "2"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "smessage"),
+					strmsg('+', "1"),
+					strmsg('+', "2"),
 				}),
 			)
 			mock.Expect(deactivate.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "sunsubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "sunsubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 0},
 				}),
-			).Reply(redisMessageContainString('+', "PONG"))
+			).Reply(strmsg('+', "PONG"))
 		}()
 
 		if err := p.Receive(ctx, activate, func(msg PubSubMessage) {
@@ -2964,25 +2964,25 @@ func TestPubSub(t *testing.T) {
 		deactivate := builder.Punsubscribe().Pattern("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "psubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "psubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "pmessage"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "2"),
-					redisMessageContainString('+', "3"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "pmessage"),
+					strmsg('+', "1"),
+					strmsg('+', "2"),
+					strmsg('+', "3"),
 				}),
 			)
 			mock.Expect(deactivate.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "punsubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "punsubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 0},
 				}),
-			).Reply(redisMessageContainString('+', "PONG"))
+			).Reply(strmsg('+', "PONG"))
 		}()
 
 		if err := p.Receive(ctx, activate, func(msg PubSubMessage) {
@@ -3028,15 +3028,15 @@ func TestPubSub(t *testing.T) {
 		activate := builder.Subscribe().Channel("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "subscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "subscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "message"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "2"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "message"),
+					strmsg('+', "1"),
+					strmsg('+', "2"),
 				}),
 			)
 		}()
@@ -3067,9 +3067,9 @@ func TestPubSub(t *testing.T) {
 		go func() {
 			for _, cmd := range commands {
 				if cmd.IsUnsub() {
-					mock.Expect(cmd.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainString('-', cmd.Commands()[0])).Reply(redisMessageContainString('+', "PONG"))
+					mock.Expect(cmd.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(strmsg('-', cmd.Commands()[0])).Reply(strmsg('+', "PONG"))
 				} else {
-					mock.Expect(cmd.Commands()...).Reply(redisMessageContainString('-', cmd.Commands()[0]))
+					mock.Expect(cmd.Commands()...).Reply(strmsg('-', cmd.Commands()[0]))
 				}
 			}
 		}()
@@ -3100,37 +3100,37 @@ func TestPubSub(t *testing.T) {
 			go func() {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-						redisMessageContainSlice('>', []RedisMessage{
-							redisMessageContainString('+', "unsubscribe"),
-							redisMessageContainString('+', "a"),
+						slicemsg('>', []RedisMessage{
+							strmsg('+', "unsubscribe"),
+							strmsg('+', "a"),
 							{typ: ':', integer: 1},
 						}),
-						redisMessageContainSlice('>', []RedisMessage{ // skip
-							redisMessageContainString('+', "unsubscribe"),
-							redisMessageContainString('+', "b"),
+						slicemsg('>', []RedisMessage{ // skip
+							strmsg('+', "unsubscribe"),
+							strmsg('+', "b"),
 							{typ: ':', integer: 1},
 						}),
-						redisMessageContainSlice('>', []RedisMessage{ // skip
-							redisMessageContainString('+', "unsubscribe"),
-							redisMessageContainString('+', "c"),
+						slicemsg('>', []RedisMessage{ // skip
+							strmsg('+', "unsubscribe"),
+							strmsg('+', "c"),
 							{typ: ':', integer: 1},
 						}),
-					).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+					).Reply(strmsg('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(
-						redisMessageContainSlice('>', []RedisMessage{
-							redisMessageContainString('+', "subscribe"),
-							redisMessageContainString('+', "a"),
+						slicemsg('>', []RedisMessage{
+							strmsg('+', "subscribe"),
+							strmsg('+', "a"),
 							{typ: ':', integer: 1},
 						}),
-						redisMessageContainSlice('>', []RedisMessage{ // skip
-							redisMessageContainString('+', "subscribe"),
-							redisMessageContainString('+', "b"),
+						slicemsg('>', []RedisMessage{ // skip
+							strmsg('+', "subscribe"),
+							strmsg('+', "b"),
 							{typ: ':', integer: 1},
 						}),
-						redisMessageContainSlice('>', []RedisMessage{ // skip
-							redisMessageContainString('+', "subscribe"),
-							redisMessageContainString('+', "c"),
+						slicemsg('>', []RedisMessage{ // skip
+							strmsg('+', "subscribe"),
+							strmsg('+', "c"),
 							{typ: ':', integer: 1},
 						}),
 					).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
@@ -3159,37 +3159,37 @@ func TestPubSub(t *testing.T) {
 		}
 
 		replies := [][]RedisMessage{{
-			redisMessageContainSlice(
+			slicemsg(
 				'>',
 				[]RedisMessage{
-					redisMessageContainString('+', "unsubscribe"),
+					strmsg('+', "unsubscribe"),
 					{typ: '_'},
 					{typ: ':', integer: 0},
 				},
 			),
 		}, {
-			redisMessageContainSlice(
+			slicemsg(
 				'>',
 				[]RedisMessage{
-					redisMessageContainString('+', "punsubscribe"),
-					redisMessageContainString('+', "1"),
+					strmsg('+', "punsubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 0},
 				},
 			),
 		}, {
-			redisMessageContainSlice(
+			slicemsg(
 				'>',
 				[]RedisMessage{
-					redisMessageContainString('+', "sunsubscribe"),
-					redisMessageContainString('+', "2"),
+					strmsg('+', "sunsubscribe"),
+					strmsg('+', "2"),
 					{typ: ':', integer: 0},
 				},
 			),
-			redisMessageContainSlice(
+			slicemsg(
 				'>',
 				[]RedisMessage{
-					redisMessageContainString('+', "sunsubscribe"),
-					redisMessageContainString('+', "3"),
+					strmsg('+', "sunsubscribe"),
+					strmsg('+', "3"),
 					{typ: ':', integer: 0},
 				},
 			),
@@ -3198,7 +3198,7 @@ func TestPubSub(t *testing.T) {
 		for i, cmd1 := range commands {
 			cmd2 := builder.Get().Key(strconv.Itoa(i)).Build()
 			go func() {
-				mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+				mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(strmsg('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 			}()
 
 			if err := p.Do(ctx, cmd1).Error(); err != nil {
@@ -3229,53 +3229,53 @@ func TestPubSub(t *testing.T) {
 
 				replies := [][]RedisMessage{
 					{
-						redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+						slicemsg( // proactive unsubscribe before user unsubscribe
 							'>',
 							[]RedisMessage{
-								redisMessageContainString('+', command),
-								redisMessageContainString('+', "1"),
+								strmsg('+', command),
+								strmsg('+', "1"),
 								{typ: ':', integer: 0},
 							},
 						),
-						redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+						slicemsg( // proactive unsubscribe before user unsubscribe
 							'>',
 							[]RedisMessage{
-								redisMessageContainString('+', command),
-								redisMessageContainString('+', "2"),
+								strmsg('+', command),
+								strmsg('+', "2"),
 								{typ: ':', integer: 0},
 							},
 						),
-						redisMessageContainSlice( // user unsubscribe
+						slicemsg( // user unsubscribe
 							'>',
 							[]RedisMessage{
-								redisMessageContainString('+', command),
+								strmsg('+', command),
 								{typ: '_'},
 								{typ: ':', integer: 0},
 							},
 						),
-						redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+						slicemsg( // proactive unsubscribe after user unsubscribe
 							'>',
 							[]RedisMessage{
-								redisMessageContainString('+', command),
+								strmsg('+', command),
 								{typ: '_'},
 								{typ: ':', integer: 0},
 							},
 						),
 					},
 					{
-						redisMessageContainSlice( // user ssubscribe
+						slicemsg( // user ssubscribe
 							'>',
 							[]RedisMessage{
-								redisMessageContainString('+', "ssubscribe"),
-								redisMessageContainString('+', "3"),
+								strmsg('+', "ssubscribe"),
+								strmsg('+', "3"),
 								{typ: ':', integer: 0},
 							},
 						),
-						redisMessageContainSlice( // proactive unsubscribe after user ssubscribe
+						slicemsg( // proactive unsubscribe after user ssubscribe
 							'>',
 							[]RedisMessage{
-								redisMessageContainString('+', command),
-								redisMessageContainString('+', "3"),
+								strmsg('+', command),
+								strmsg('+', "3"),
 								{typ: ':', integer: 0},
 							},
 						),
@@ -3285,11 +3285,11 @@ func TestPubSub(t *testing.T) {
 				p.background()
 
 				// proactive unsubscribe before other commands
-				mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				mock.Expect().Reply(slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', command),
-						redisMessageContainString('+', "0"),
+						strmsg('+', command),
+						strmsg('+', "0"),
 						{typ: ':', integer: 0},
 					},
 				))
@@ -3300,7 +3300,7 @@ func TestPubSub(t *testing.T) {
 					cmd2 := builder.Get().Key(strconv.Itoa(i)).Build()
 					go func() {
 						if cmd1.IsUnsub() {
-							mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+							mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(strmsg('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 						} else {
 							mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 						}
@@ -3330,61 +3330,61 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "a"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "a"),
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "b"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "b"),
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainString( // user unsubscribe, but error
+				strmsg( // user unsubscribe, but error
 					'-',
 					"MOVED 1111",
 				),
 			}, {
-				redisMessageContainString( // user unsubscribe, but error
+				strmsg( // user unsubscribe, but error
 					'-',
 					"MOVED 222",
 				),
 			}, {
-				redisMessageContainSlice( // user unsubscribe success
+				slicemsg( // user unsubscribe success
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "c"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "c"),
 						{typ: ':', integer: 0},
 					},
 				),
 			}, {
-				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+				slicemsg( // proactive unsubscribe after user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
+						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainString('+', "mk"),
+				strmsg('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+		mock.Expect().Reply(slicemsg( // proactive unsubscribe before user unsubscribe
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "sunsubscribe"),
-				redisMessageContainString('+', "0"),
+				strmsg('+', "sunsubscribe"),
+				strmsg('+', "0"),
 				{typ: ':', integer: 0},
 			},
 		))
@@ -3395,7 +3395,7 @@ func TestPubSub(t *testing.T) {
 			cmd2 := builder.Get().Key(strconv.Itoa(i)).Build()
 			go func() {
 				if cmd1.IsUnsub() {
-					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(strmsg('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
@@ -3423,9 +3423,9 @@ func TestPubSub(t *testing.T) {
 			p.queue.PutOne(push)
 			_, _, ch := p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(redisMessageContainString(
+				mock.Expect().Reply(strmsg(
 					'-', "MOVED",
-				)).Reply(redisMessageContainString(
+				)).Reply(strmsg(
 					'-', "MOVED",
 				))
 			}()
@@ -3455,9 +3455,9 @@ func TestPubSub(t *testing.T) {
 			_, _, ch := p.queue.NextWriteCmd()
 			_, _, _ = p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(redisMessageContainString(
+				mock.Expect().Reply(strmsg(
 					'-', "MOVED",
-				)).Reply(redisMessageContainString(
+				)).Reply(strmsg(
 					'-', "MOVED",
 				))
 			}()
@@ -3488,45 +3488,45 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "a"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "a"),
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "b"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "b"),
 						{typ: ':', integer: 0},
 					},
 				),
 			}, {
 				// empty
 			}, {
-				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+				slicemsg( // proactive unsubscribe after user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
+						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainString('+', "mk"),
+				strmsg('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+		mock.Expect().Reply(slicemsg( // proactive unsubscribe before user unsubscribe
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "sunsubscribe"),
-				redisMessageContainString('+', "0"),
+				strmsg('+', "sunsubscribe"),
+				strmsg('+', "0"),
 				{typ: ':', integer: 0},
 			},
 		))
@@ -3539,7 +3539,7 @@ func TestPubSub(t *testing.T) {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).
 						Reply(replies[i]...).
-						Reply(redisMessageContainString( // failed unsubReply
+						Reply(strmsg( // failed unsubReply
 							'-',
 							"NOPERM User u has no permissions to run the 'ping' command",
 						)).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
@@ -3575,45 +3575,45 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "a"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "a"),
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "b"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "b"),
 						{typ: ':', integer: 0},
 					},
 				),
 			}, {
 				// empty
 			}, {
-				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+				slicemsg( // proactive unsubscribe after user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
+						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainString('+', "mk"),
+				strmsg('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+		mock.Expect().Reply(slicemsg( // proactive unsubscribe before user unsubscribe
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "sunsubscribe"),
-				redisMessageContainString('+', "0"),
+				strmsg('+', "sunsubscribe"),
+				strmsg('+', "0"),
 				{typ: ':', integer: 0},
 			},
 		))
@@ -3626,7 +3626,7 @@ func TestPubSub(t *testing.T) {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).
 						Reply(replies[i]...).
-						Reply(redisMessageContainString( // failed unsubReply
+						Reply(strmsg( // failed unsubReply
 							'-',
 							"LOADING server is loading the dataset in memory",
 						)).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
@@ -3662,45 +3662,45 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "a"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "a"),
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+				slicemsg( // proactive unsubscribe before user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
-						redisMessageContainString('+', "b"),
+						strmsg('+', "sunsubscribe"),
+						strmsg('+', "b"),
 						{typ: ':', integer: 0},
 					},
 				),
 			}, {
 				// empty
 			}, {
-				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+				slicemsg( // proactive unsubscribe after user unsubscribe
 					'>',
 					[]RedisMessage{
-						redisMessageContainString('+', "sunsubscribe"),
+						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
 				),
-				redisMessageContainString('+', "mk"),
+				strmsg('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+		mock.Expect().Reply(slicemsg( // proactive unsubscribe before user unsubscribe
 			'>',
 			[]RedisMessage{
-				redisMessageContainString('+', "sunsubscribe"),
-				redisMessageContainString('+', "0"),
+				strmsg('+', "sunsubscribe"),
+				strmsg('+', "0"),
 				{typ: ':', integer: 0},
 			},
 		))
@@ -3713,7 +3713,7 @@ func TestPubSub(t *testing.T) {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).
 						Reply(replies[i]...).
-						Reply(redisMessageContainString( // failed unsubReply
+						Reply(strmsg( // failed unsubReply
 							'-',
 							"BUSY",
 						)).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
@@ -3746,10 +3746,10 @@ func TestPubSub(t *testing.T) {
 			p.queue.PutOne(builder.Get().Key("a").Build())
 			p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(redisMessageContainSlice(
+				mock.Expect().Reply(slicemsg(
 					'>', []RedisMessage{
-						redisMessageContainString('+', push),
-						redisMessageContainString('+', ""),
+						strmsg('+', push),
+						strmsg('+', ""),
 					},
 				))
 			}()
@@ -3776,7 +3776,7 @@ func TestPubSub(t *testing.T) {
 			p.queue.PutOne(cmd)
 			p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(redisMessageContainString('+', "QUEUED"))
+				mock.Expect().Reply(strmsg('+', "QUEUED"))
 			}()
 			p._backgroundRead()
 			return
@@ -3926,41 +3926,41 @@ func TestPubSubHooks(t *testing.T) {
 		deactivate2 := builder.Punsubscribe().Pattern("2").Build()
 		go func() {
 			mock.Expect(activate1.Commands()...).Expect(activate2.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "subscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "subscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "psubscribe"),
-					redisMessageContainString('+', "2"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "psubscribe"),
+					strmsg('+', "2"),
 					{typ: ':', integer: 2},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "message"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "11"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "message"),
+					strmsg('+', "1"),
+					strmsg('+', "11"),
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "pmessage"),
-					redisMessageContainString('+', "2"),
-					redisMessageContainString('+', "22"),
-					redisMessageContainString('+', "222"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "pmessage"),
+					strmsg('+', "2"),
+					strmsg('+', "22"),
+					strmsg('+', "222"),
 				}),
 			)
 			mock.Expect(deactivate1.Commands()...).Expect(cmds.PingCmd.Commands()...).Expect(deactivate2.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "unsubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "unsubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainString('+', "PONG"),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "punsubscribe"),
-					redisMessageContainString('+', "2"),
+				strmsg('+', "PONG"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "punsubscribe"),
+					strmsg('+', "2"),
 					{typ: ':', integer: 2},
 				}),
-				redisMessageContainString('+', "PONG"),
+				strmsg('+', "PONG"),
 			)
 			cancel()
 		}()
@@ -4015,41 +4015,41 @@ func TestPubSubHooks(t *testing.T) {
 		deactivate2 := builder.Punsubscribe().Pattern("2").Build()
 		go func() {
 			mock.Expect(activate1.Commands()...).Expect(activate2.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "subscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "subscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "psubscribe"),
-					redisMessageContainString('+', "2"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "psubscribe"),
+					strmsg('+', "2"),
 					{typ: ':', integer: 2},
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "message"),
-					redisMessageContainString('+', "1"),
-					redisMessageContainString('+', "11"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "message"),
+					strmsg('+', "1"),
+					strmsg('+', "11"),
 				}),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "pmessage"),
-					redisMessageContainString('+', "2"),
-					redisMessageContainString('+', "22"),
-					redisMessageContainString('+', "222"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "pmessage"),
+					strmsg('+', "2"),
+					strmsg('+', "22"),
+					strmsg('+', "222"),
 				}),
 			)
 			mock.Expect(deactivate1.Commands()...).Expect(cmds.PingCmd.Commands()...).Expect(deactivate2.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "unsubscribe"),
-					redisMessageContainString('+', "1"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "unsubscribe"),
+					strmsg('+', "1"),
 					{typ: ':', integer: 1},
 				}),
-				redisMessageContainString('+', "PONG"),
-				redisMessageContainSlice('>', []RedisMessage{
-					redisMessageContainString('+', "punsubscribe"),
-					redisMessageContainString('+', "2"),
+				strmsg('+', "PONG"),
+				slicemsg('>', []RedisMessage{
+					strmsg('+', "punsubscribe"),
+					strmsg('+', "2"),
 					{typ: ':', integer: 2},
 				}),
-				redisMessageContainString('+', "PONG"),
+				strmsg('+', "PONG"),
 			)
 			cancel()
 		}()
@@ -5085,19 +5085,19 @@ func TestPipe_CleanSubscriptions_6(t *testing.T) {
 		p.CleanSubscriptions()
 	}()
 	mock.Expect("UNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("PUNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("DISCARD").Reply(
-		redisMessageContainSlice('>', []RedisMessage{
-			redisMessageContainString('+', "unsubscribe"),
+		slicemsg('>', []RedisMessage{
+			strmsg('+', "unsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 1},
 		}),
-		redisMessageContainString('+', "PONG"),
-		redisMessageContainSlice('>', []RedisMessage{
-			redisMessageContainString('+', "punsubscribe"),
+		strmsg('+', "PONG"),
+		slicemsg('>', []RedisMessage{
+			strmsg('+', "punsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 2},
 		}),
-		redisMessageContainString('+', "PONG"),
-		redisMessageContainString('+', "OK"),
+		strmsg('+', "PONG"),
+		strmsg('+', "OK"),
 	)
 }
 
@@ -5128,25 +5128,25 @@ func TestPipe_CleanSubscriptions_7(t *testing.T) {
 		p.CleanSubscriptions()
 	}()
 	mock.Expect("UNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("PUNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("SUNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("DISCARD").Reply(
-		redisMessageContainSlice('>', []RedisMessage{
-			redisMessageContainString('+', "unsubscribe"),
+		slicemsg('>', []RedisMessage{
+			strmsg('+', "unsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 1},
 		}),
-		redisMessageContainString('+', "PONG"),
-		redisMessageContainSlice('>', []RedisMessage{
-			redisMessageContainString('+', "punsubscribe"),
+		strmsg('+', "PONG"),
+		slicemsg('>', []RedisMessage{
+			strmsg('+', "punsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 2},
 		}),
-		redisMessageContainString('+', "PONG"),
-		redisMessageContainSlice('>', []RedisMessage{
-			redisMessageContainString('+', "sunsubscribe"),
+		strmsg('+', "PONG"),
+		slicemsg('>', []RedisMessage{
+			strmsg('+', "sunsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 3},
 		}),
-		redisMessageContainString('+', "PONG"),
-		redisMessageContainString('+', "OK"),
+		strmsg('+', "PONG"),
+		strmsg('+', "OK"),
 	)
 }
 
@@ -5317,16 +5317,16 @@ func TestErrorPipe(t *testing.T) {
 
 func TestBackgroundPing(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
-	timeout := 100*time.Millisecond
+	timeout := 100 * time.Millisecond
 	t.Run("background ping", func(t *testing.T) {
-		opt := ClientOption{ConnWriteTimeout: timeout, 
-							Dialer: net.Dialer{KeepAlive: timeout}, 
-							DisableAutoPipelining: true}
+		opt := ClientOption{ConnWriteTimeout: timeout,
+			Dialer:                net.Dialer{KeepAlive: timeout},
+			DisableAutoPipelining: true}
 		p, mock, cancel, _ := setup(t, opt)
 		defer cancel()
-		time.Sleep(50*time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		prev := atomic.LoadInt32(&p.recvs)
-		
+
 		for i := range 10 {
 			atomic.AddInt32(&p.blcksig, 1) // block
 			time.Sleep(timeout)
@@ -5344,7 +5344,7 @@ func TestBackgroundPing(t *testing.T) {
 		}()
 		for i := range 10 {
 			time.Sleep(timeout)
-			recv := atomic.LoadInt32(&p.recvs)		
+			recv := atomic.LoadInt32(&p.recvs)
 			if prev == recv {
 				t.Fatalf("round %d unexpect recv %v, need be different from prev %v", i, recv, prev)
 			}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -213,7 +213,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						RedisMessage{typ: ':', intlen: 3},
+						{typ: ':', intlen: 3},
 						strmsg('+', "availability_zone"),
 						strmsg('+', "us-west-1a"),
 					},

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -47,12 +47,12 @@ func (r *redisMock) Expect(expected ...string) *redisExpect {
 	if err != nil {
 		return &redisExpect{redisMock: r, err: err}
 	}
-	if len(expected) != len(m.values) {
-		r.t.Fatalf("redismock receive unexpected command length: expected %v, got : %v", len(expected), m.values)
+	if len(expected) != len(m.values()) {
+		r.t.Fatalf("redismock receive unexpected command length: expected %v, got : %v", len(expected), m.values())
 	}
 	for i, expected := range expected {
-		if m.values[i].string != expected {
-			r.t.Fatalf("redismock receive unexpected command: expected %v, got : %v", expected, m.values[i])
+		if m.values()[i].string() != expected {
+			r.t.Fatalf("redismock receive unexpected command: expected %v, got : %v", expected, m.values()[i])
 		}
 	}
 	return &redisExpect{redisMock: r}
@@ -61,7 +61,7 @@ func (r *redisMock) Expect(expected ...string) *redisExpect {
 func (r *redisExpect) ReplyString(replies ...string) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(RedisMessage{typ: '+', string: reply})
+			r.Reply(redisMessageContainString('+', reply))
 		}
 	}
 	return r
@@ -70,7 +70,7 @@ func (r *redisExpect) ReplyString(replies ...string) *redisExpect {
 func (r *redisExpect) ReplyBlobString(replies ...string) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(RedisMessage{typ: '$', string: reply})
+			r.Reply(redisMessageContainString('$', reply))
 		}
 	}
 	return r
@@ -79,7 +79,7 @@ func (r *redisExpect) ReplyBlobString(replies ...string) *redisExpect {
 func (r *redisExpect) ReplyError(replies ...string) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(RedisMessage{typ: '-', string: reply})
+			r.Reply(redisMessageContainString('-', reply))
 		}
 	}
 	return r
@@ -111,14 +111,14 @@ func write(o io.Writer, m RedisMessage) (err error) {
 	_, err = o.Write([]byte{m.typ})
 	switch m.typ {
 	case '$':
-		_, _ = o.Write(append([]byte(strconv.Itoa(len(m.string))), '\r', '\n'))
-		_, err = o.Write(append([]byte(m.string), '\r', '\n'))
+		_, _ = o.Write(append([]byte(strconv.Itoa(len(m.string()))), '\r', '\n'))
+		_, err = o.Write(append([]byte(m.string()), '\r', '\n'))
 	case '+', '-', '_':
-		_, err = o.Write(append([]byte(m.string), '\r', '\n'))
+		_, err = o.Write(append([]byte(m.string()), '\r', '\n'))
 	case ':':
 		_, err = o.Write(append([]byte(strconv.FormatInt(m.integer, 10)), '\r', '\n'))
 	case '%', '>', '*':
-		size := int64(len(m.values))
+		size := int64(len(m.values()))
 		if m.typ == '%' {
 			if size%2 != 0 {
 				panic("map message with wrong value length")
@@ -126,7 +126,7 @@ func write(o io.Writer, m RedisMessage) (err error) {
 			size /= 2
 		}
 		_, err = o.Write(append([]byte(strconv.FormatInt(size, 10)), '\r', '\n'))
-		for _, v := range m.values {
+		for _, v := range m.values() {
 			err = write(o, v)
 		}
 	default:
@@ -147,15 +147,15 @@ func setup(t *testing.T, option ClientOption) (*pipe, *redisMock, func(), func()
 	}
 	go func() {
 		mock.Expect("HELLO", "3").
-			Reply(RedisMessage{
-				typ: '%',
-				values: []RedisMessage{
-					{typ: '+', string: "version"},
-					{typ: '+', string: "6.0.0"},
-					{typ: '+', string: "proto"},
+			Reply(redisMessageContainSlice(
+				'%',
+				[]RedisMessage{
+					redisMessageContainString('+', "version"),
+					redisMessageContainString('+', "6.0.0"),
+					redisMessageContainString('+', "proto"),
 					{typ: ':', integer: 3},
 				},
-			})
+			))
 		if option.ClientTrackingOptions != nil {
 			mock.Expect(append([]string{"CLIENT", "TRACKING", "ON"}, option.ClientTrackingOptions...)...).
 				ReplyString("OK")
@@ -172,7 +172,7 @@ func setup(t *testing.T, option ClientOption) (*pipe, *redisMock, func(), func()
 	if err != nil {
 		t.Fatalf("pipe setup failed: %v", err)
 	}
-	if info := p.Info(); info["version"].string != "6.0.0" {
+	if infoVersion := p.Info()["version"]; infoVersion.string() != "6.0.0" {
 		t.Fatalf("pipe setup failed, unexpected hello response: %v", p.Info())
 	}
 	if version := p.Version(); version != 6 {
@@ -209,15 +209,15 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "default", "pa", "SETNAME", "cn").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
-						{typ: ':', integer: 3},
-						{typ: '+', string: "availability_zone"},
-						{typ: '+', string: "us-west-1a"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
+						RedisMessage{typ: ':', integer: 3},
+						redisMessageContainString('+', "availability_zone"),
+						redisMessageContainString('+', "us-west-1a"),
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
@@ -258,15 +258,15 @@ func TestNewPipe(t *testing.T) {
 			mock.Expect("AUTH", "pa").
 				ReplyString("OK")
 			mock.Expect("HELLO", "2").
-				Reply(RedisMessage{
-					typ: '*',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'*',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 2},
-						{typ: '+', string: "availability_zone"},
-						{typ: '+', string: "us-west-1a"},
+						redisMessageContainString('+', "availability_zone"),
+						redisMessageContainString('+', "us-west-1a"),
 					},
-				})
+				))
 			mock.Expect("CLIENT", "SETNAME", "cn").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
@@ -307,13 +307,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 3},
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
@@ -346,13 +346,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 3},
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
@@ -386,13 +386,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 3},
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN", "NOLOOP").
 				ReplyString("OK")
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
@@ -417,13 +417,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 3},
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
@@ -456,13 +456,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3", "AUTH", "ua", "pa", "SETNAME", "cn").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 3},
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 			mock.Expect("SELECT", "1").
@@ -521,13 +521,13 @@ func TestNewPipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3").
-				Reply(RedisMessage{
-					typ: '%',
-					values: []RedisMessage{
-						{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice(
+					'%',
+					[]RedisMessage{
+						redisMessageContainString('+', "proto"),
 						{typ: ':', integer: 3},
 					},
-				})
+				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 				ReplyString("OK")
 		}()
@@ -597,27 +597,27 @@ func TestNewRESP2Pipe(t *testing.T) {
 		mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
 		go func() {
 			mock.Expect("HELLO", "3").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "server"},
-					{typ: '+', string: "redis"},
-					{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "server"),
+					redisMessageContainString('+', "redis"),
+					redisMessageContainString('+', "proto"),
 					{typ: ':', integer: 2},
-					{typ: '+', string: "availability_zone"},
-					{typ: '+', string: "us-west-1a"},
-				}})
+					redisMessageContainString('+', "availability_zone"),
+					redisMessageContainString('+', "us-west-1a"),
+				}))
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("HELLO", "2").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '+', string: "server"},
-					{typ: '+', string: "redis"},
-					{typ: '+', string: "proto"},
+				Reply(redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', "server"),
+					redisMessageContainString('+', "redis"),
+					redisMessageContainString('+', "proto"),
 					{typ: ':', integer: 2},
-					{typ: '+', string: "availability_zone"},
-					{typ: '+', string: "us-west-1a"},
-				}})
+					redisMessageContainString('+', "availability_zone"),
+					redisMessageContainString('+', "us-west-1a"),
+				}))
 			mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
@@ -890,7 +890,7 @@ func TestIgnoreOutOfBandDataDuringSyncMode(t *testing.T) {
 	p, mock, cancel, _ := setup(t, ClientOption{})
 	defer cancel()
 	go func() {
-		mock.Expect("PING").Reply(RedisMessage{typ: '>', string: "This should be ignore"}).ReplyString("OK")
+		mock.Expect("PING").Reply(redisMessageContainString('>', "This should be ignore")).ReplyString("OK")
 	}()
 	ExpectOK(t, p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})))
 }
@@ -1219,11 +1219,11 @@ func TestNoReplyExceedRingSize(t *testing.T) {
 	}()
 
 	for i := 0; i < times; i++ {
-		mock.Expect("UNSUBSCRIBE").Reply(RedisMessage{typ: '>', values: []RedisMessage{
-			{typ: '+', string: "unsubscribe"},
-			{typ: '+', string: "1"},
+		mock.Expect("UNSUBSCRIBE").Reply(redisMessageContainSlice('>', []RedisMessage{
+			redisMessageContainString('+', "unsubscribe"),
+			redisMessageContainString('+', "1"),
 			{typ: ':', integer: 0},
-		}}).Expect(cmds.PingCmd.Commands()...).Reply(RedisMessage{typ: '+', string: "PONG"})
+		})).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainString('+', "PONG"))
 	}
 	<-wait
 }
@@ -1257,15 +1257,15 @@ func TestResponseSequenceWithPushMessageInjected(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			v := strconv.Itoa(i)
-			if val, _ := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", v})).ToMessage(); val.string != v {
-				t.Errorf("out of order response, expected %v, got %v", v, val.string)
+			if val, _ := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", v})).ToMessage(); val.string() != v {
+				t.Errorf("out of order response, expected %v, got %v", v, val.string())
 			}
 		}(i)
 	}
 	for i := 0; i < times; i++ {
 		m, _ := mock.ReadMessage()
-		mock.Expect().ReplyString(m.values[1].string).
-			Reply(RedisMessage{typ: '>', values: []RedisMessage{{typ: '+', string: "should be ignore"}}})
+		mock.Expect().ReplyString(m.values()[1].string()).
+			Reply(redisMessageContainSlice('>', []RedisMessage{redisMessageContainString('+', "should be ignore")}))
 	}
 	wg.Wait()
 }
@@ -1285,19 +1285,19 @@ func TestClientSideCaching(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: ttl},
-				{typ: '+', string: resp},
-			}})
+				redisMessageContainString('+', resp),
+			}))
 	}
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
 				keys,
 			},
-		})
+		))
 	}
 
 	go func() {
@@ -1313,8 +1313,8 @@ func TestClientSideCaching(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
-			if v.string != "1" {
-				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
+			if v.string() != "1" {
+				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string())
 			}
 			if v.IsCacheHit() {
 				atomic.AddUint64(&hits, 1)
@@ -1334,13 +1334,13 @@ func TestClientSideCaching(t *testing.T) {
 	}
 
 	// cache invalidation
-	invalidateCSC(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}})
+	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}))
 	go func() {
 		expectCSC(-1, "2")
 	}()
 
 	for {
-		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "2" {
+		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string() == "2" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -1353,7 +1353,7 @@ func TestClientSideCaching(t *testing.T) {
 	}()
 
 	for {
-		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "3" {
+		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string() == "3" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -1377,19 +1377,19 @@ func TestClientSideCachingBCAST(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: ttl},
-				{typ: '+', string: resp},
-			}})
+				redisMessageContainString('+', resp),
+			}))
 	}
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
 				keys,
 			},
-		})
+		))
 	}
 
 	go func() {
@@ -1405,8 +1405,8 @@ func TestClientSideCachingBCAST(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
-			if v.string != "1" {
-				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
+			if v.string() != "1" {
+				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string())
 			}
 			if v.IsCacheHit() {
 				atomic.AddUint64(&hits, 1)
@@ -1426,13 +1426,13 @@ func TestClientSideCachingBCAST(t *testing.T) {
 	}
 
 	// cache invalidation
-	invalidateCSC(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}})
+	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}))
 	go func() {
 		expectCSC(-1, "2")
 	}()
 
 	for {
-		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "2" {
+		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string() == "2" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -1445,7 +1445,7 @@ func TestClientSideCachingBCAST(t *testing.T) {
 	}()
 
 	for {
-		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "3" {
+		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string() == "3" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -1469,19 +1469,19 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: ttl},
-				{typ: '+', string: resp},
-			}})
+				redisMessageContainString('+', resp),
+			}))
 	}
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
 				keys,
 			},
-		})
+		))
 	}
 
 	go func() {
@@ -1497,8 +1497,8 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
-			if v.string != "1" {
-				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
+			if v.string() != "1" {
+				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string())
 			}
 			if v.IsCacheHit() {
 				atomic.AddUint64(&hits, 1)
@@ -1518,13 +1518,13 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 	}
 
 	// cache invalidation
-	invalidateCSC(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}})
+	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}))
 	go func() {
 		expectCSC(-1, "2")
 	}()
 
 	for {
-		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "2" {
+		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string() == "2" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -1537,7 +1537,7 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 	}()
 
 	for {
-		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "3" {
+		if v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string() == "3" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -1617,13 +1617,13 @@ func TestClientSideCachingMGet(t *testing.T) {
 	defer cancel()
 
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
 				keys,
 			},
-		})
+		))
 	}
 
 	go func() {
@@ -1640,16 +1640,16 @@ func TestClientSideCachingMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 1000},
 				{typ: ':', integer: 2000},
 				{typ: ':', integer: 3000},
-				{typ: '*', values: []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 1},
 					{typ: ':', integer: 2},
 					{typ: ':', integer: 3},
-				}},
-			}})
+				}),
+			}))
 	}()
 	// single flight
 	miss := uint64(0)
@@ -1690,7 +1690,7 @@ func TestClientSideCachingMGet(t *testing.T) {
 	}
 
 	// partial cache invalidation
-	invalidateCSC(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a1"}, {typ: '+', string: "a3"}}})
+	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a1"), redisMessageContainString('+', "a3")}))
 	go func() {
 		mock.Expect("CLIENT", "CACHING", "YES").
 			Expect("MULTI").
@@ -1703,14 +1703,14 @@ func TestClientSideCachingMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 10000},
 				{typ: ':', integer: 30000},
-				{typ: '*', values: []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 10},
 					{typ: ':', integer: 30},
-				}},
-			}})
+				}),
+			}))
 	}()
 
 	for {
@@ -1751,13 +1751,13 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 	defer cancel()
 
 	invalidateCSC := func(keys RedisMessage) {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
 				keys,
 			},
-		})
+		))
 	}
 
 	go func() {
@@ -1774,16 +1774,16 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 1000},
 				{typ: ':', integer: 2000},
 				{typ: ':', integer: 3000},
-				{typ: '*', values: []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 1},
 					{typ: ':', integer: 2},
 					{typ: ':', integer: 3},
-				}},
-			}})
+				}),
+			}))
 	}()
 	// single flight
 	miss := uint64(0)
@@ -1824,7 +1824,7 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 	}
 
 	// partial cache invalidation
-	invalidateCSC(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a1"}, {typ: '+', string: "a3"}}})
+	invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a1"), redisMessageContainString('+', "a3")}))
 	go func() {
 		mock.Expect("CLIENT", "CACHING", "YES").
 			Expect("MULTI").
@@ -1837,14 +1837,14 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: 10000},
 				{typ: ':', integer: 30000},
-				{typ: '*', values: []RedisMessage{
+				redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 10},
 					{typ: ':', integer: 30},
-				}},
-			}})
+				}),
+			}))
 	}()
 
 	for {
@@ -1964,7 +1964,7 @@ func TestClientSideCachingWithSideChannelMGet(t *testing.T) {
 	p.cache.Flight("a1", "GET", 10*time.Second, time.Now())
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		m := RedisMessage{typ: '+', string: "OK"}
+		m := redisMessageContainString('+', "OK")
 		m.setExpireAt(time.Now().Add(10 * time.Millisecond).UnixMilli())
 		p.cache.Update("a1", "GET", m)
 	}()
@@ -2014,13 +2014,13 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 		defer cancel()
 
 		invalidateCSC := func(keys RedisMessage) {
-			mock.Expect().Reply(RedisMessage{
-				typ: '>',
-				values: []RedisMessage{
-					{typ: '+', string: "invalidate"},
+			mock.Expect().Reply(redisMessageContainSlice(
+				'>',
+				[]RedisMessage{
+					redisMessageContainString('+', "invalidate"),
 					keys,
 				},
-			})
+			))
 		}
 
 		go func() {
@@ -2043,26 +2043,26 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
+				Reply(redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 1000},
 					{typ: ':', integer: 1},
-				}}).
+				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
+				Reply(redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 2000},
 					{typ: ':', integer: 2},
-				}}).
+				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
+				Reply(redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 3000},
 					{typ: ':', integer: 3},
-				}})
+				}))
 		}()
 		// single flight
 		miss := uint64(0)
@@ -2106,7 +2106,7 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 		}
 
 		// partial cache invalidation
-		invalidateCSC(RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "a1"}, {typ: '+', string: "a3"}}})
+		invalidateCSC(redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a1"), redisMessageContainString('+', "a3")}))
 		go func() {
 			mock.Expect("CLIENT", "CACHING", "YES").
 				Expect("MULTI").
@@ -2122,18 +2122,18 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
+				Reply(redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 10000},
 					{typ: ':', integer: 10},
-				}}).
+				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
+				Reply(redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 30000},
 					{typ: ':', integer: 30},
-				}})
+				}))
 		}()
 
 		if cache, ok := p.cache.(*lru); ok {
@@ -2212,10 +2212,10 @@ func TestClientSideCachingExecAbortDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
-				Reply(RedisMessage{typ: '*', values: []RedisMessage{
+				Reply(redisMessageContainSlice('*', []RedisMessage{
 					{typ: ':', integer: 1000},
 					{typ: ':', integer: 1},
-				}}).
+				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
@@ -2326,7 +2326,7 @@ func TestClientSideCachingWithSideChannelDoMultiCache(t *testing.T) {
 		p.cache.Flight("a1", "GET", 10*time.Second, time.Now())
 		go func() {
 			time.Sleep(100 * time.Millisecond)
-			m := RedisMessage{typ: '+', string: "OK"}
+			m := redisMessageContainString('+', "OK")
 			m.setExpireAt(time.Now().Add(10 * time.Millisecond).UnixMilli())
 			p.cache.Update("a1", "GET", m)
 		}()
@@ -2334,8 +2334,8 @@ func TestClientSideCachingWithSideChannelDoMultiCache(t *testing.T) {
 		arr := p.DoMultiCache(context.Background(), []CacheableTTL{
 			CT(Cacheable(cmds.NewCompleted([]string{"GET", "a1"})), time.Second*10),
 		}...).s
-		if arr[0].val.string != "OK" {
-			t.Errorf("unexpected value, got %v", arr[0].val.string)
+		if arr[0].val.string() != "OK" {
+			t.Errorf("unexpected value, got %v", arr[0].val.string())
 		}
 	}
 	t.Run("LRU", func(t *testing.T) {
@@ -2396,10 +2396,10 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(RedisMessage{typ: '*', values: []RedisMessage{
+					Reply(redisMessageContainSlice('*', []RedisMessage{
 						{typ: ':', integer: pttl},
-						{typ: '+', string: key},
-					}})
+						redisMessageContainString('+', key),
+					}))
 			}
 			go func() {
 				expectCSC(-1, "a")
@@ -2436,16 +2436,16 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(RedisMessage{typ: '*', values: []RedisMessage{
+					Reply(redisMessageContainSlice('*', []RedisMessage{
 						{typ: ':', integer: -1},
 						{typ: ':', integer: 1000},
 						{typ: ':', integer: 20000},
-						{typ: '*', values: []RedisMessage{
-							{typ: '+', string: "a"},
-							{typ: '+', string: "b"},
-							{typ: '+', string: "c"},
-						}},
-					}})
+						redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', "a"),
+							redisMessageContainString('+', "b"),
+							redisMessageContainString('+', "c"),
+						}),
+					}))
 			}()
 			v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewMGetCompleted([]string{"MGET", "a", "b", "c"})), 10*time.Second).ToArray()
 			if ttl := v[0].CacheTTL(); ttl != 10 {
@@ -2481,26 +2481,26 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(RedisMessage{typ: '*', values: []RedisMessage{
+					Reply(redisMessageContainSlice('*', []RedisMessage{
 						{typ: ':', integer: -1},
 						{typ: ':', integer: 1},
-					}}).
+					})).
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(RedisMessage{typ: '*', values: []RedisMessage{
+					Reply(redisMessageContainSlice('*', []RedisMessage{
 						{typ: ':', integer: 1000},
 						{typ: ':', integer: 2},
-					}}).
+					})).
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
-					Reply(RedisMessage{typ: '*', values: []RedisMessage{
+					Reply(redisMessageContainSlice('*', []RedisMessage{
 						{typ: ':', integer: 20000},
 						{typ: ':', integer: 3},
-					}})
+					}))
 			}()
 			arr := p.DoMultiCache(context.Background(), []CacheableTTL{
 				CT(Cacheable(cmds.NewCompleted([]string{"GET", "a1"})), time.Second*10),
@@ -2546,16 +2546,16 @@ func TestClientSideCachingRedis6InvalidationBug1(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
-				{
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "invalidate"},
-						{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}},
+			Reply(redisMessageContainSlice('*', []RedisMessage{
+				redisMessageContainSlice(
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "invalidate"),
+						redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
 					},
-				},
+				),
 				{typ: ':', integer: -2},
-			}}).Reply(RedisMessage{typ: '_'})
+			})).Reply(RedisMessage{typ: '_'})
 	}
 
 	go func() {
@@ -2572,7 +2572,7 @@ func TestClientSideCachingRedis6InvalidationBug1(t *testing.T) {
 			defer wg.Done()
 			v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
 			if v.typ != '_' {
-				t.Errorf("unexpected cached result, expected null, got %v", v.string)
+				t.Errorf("unexpected cached result, expected null, got %v", v.string())
 			}
 			if v.IsCacheHit() {
 				atomic.AddUint64(&hits, 1)
@@ -2608,16 +2608,16 @@ func TestClientSideCachingRedis6InvalidationBug2(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: -2},
-				{
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "invalidate"},
-						{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}},
+				redisMessageContainSlice(
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "invalidate"),
+						redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
 					},
-				},
-			}}).Reply(RedisMessage{typ: '_'})
+				),
+			})).Reply(RedisMessage{typ: '_'})
 	}
 
 	go func() {
@@ -2634,7 +2634,7 @@ func TestClientSideCachingRedis6InvalidationBug2(t *testing.T) {
 			defer wg.Done()
 			v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
 			if v.typ != '_' {
-				t.Errorf("unexpected cached result, expected null, got %v", v.string)
+				t.Errorf("unexpected cached result, expected null, got %v", v.string())
 			}
 			if v.IsCacheHit() {
 				atomic.AddUint64(&hits, 1)
@@ -2669,16 +2669,16 @@ func TestClientSideCachingRedis6InvalidationBugErr(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			ReplyString("OK").
-			Reply(RedisMessage{typ: '*', values: []RedisMessage{
+			Reply(redisMessageContainSlice('*', []RedisMessage{
 				{typ: ':', integer: -2},
-				{
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "invalidate"},
-						{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}},
+				redisMessageContainSlice(
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "invalidate"),
+						redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
 					},
-				},
-			}})
+				),
+			}))
 	}
 
 	go func() {
@@ -2699,13 +2699,13 @@ func TestDisableClientSideCaching(t *testing.T) {
 	p.background()
 
 	go func() {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
-				{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
+				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
 			},
-		})
+		))
 		mock.Expect("GET", "a").ReplyString("1").
 			Expect("GET", "b").
 			Expect("GET", "c").
@@ -2714,18 +2714,18 @@ func TestDisableClientSideCaching(t *testing.T) {
 	}()
 
 	v, _ := p.DoCache(context.Background(), Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
-	if v.string != "1" {
-		t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
+	if v.string() != "1" {
+		t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string())
 	}
 
 	vs := p.DoMultiCache(context.Background(),
 		CT(Cacheable(cmds.NewCompleted([]string{"GET", "b"})), 10*time.Second),
 		CT(Cacheable(cmds.NewCompleted([]string{"GET", "c"})), 10*time.Second)).s
-	if vs[0].val.string != "2" {
-		t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
+	if vs[0].val.string() != "2" {
+		t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string())
 	}
-	if vs[1].val.string != "3" {
-		t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
+	if vs[1].val.string() != "3" {
+		t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string())
 	}
 }
 
@@ -2739,27 +2739,27 @@ func TestOnInvalidations(t *testing.T) {
 	})
 
 	go func() {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
-				{typ: '*', values: []RedisMessage{{typ: '+', string: "a"}}},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
+				redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "a")}),
 			},
-		})
+		))
 	}()
 
-	if messages := <-ch; messages[0].string != "a" {
+	if messages := <-ch; messages[0].string() != "a" {
 		t.Fatalf("unexpected invlidation %v", messages)
 	}
 
 	go func() {
-		mock.Expect().Reply(RedisMessage{
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "invalidate"},
+		mock.Expect().Reply(redisMessageContainSlice(
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "invalidate"),
 				{typ: '_'},
 			},
-		})
+		))
 	}()
 
 	if messages := <-ch; messages != nil {
@@ -2818,15 +2818,15 @@ func TestPubSub(t *testing.T) {
 		go func() {
 			for _, c := range commands {
 				if c.IsUnsub() {
-					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(RedisMessage{typ: '>', values: []RedisMessage{
-						{typ: '+', string: strings.ToLower(c.Commands()[0])},
-						{typ: '+', string: strings.ToLower(c.Commands()[1])},
-					}}).Reply(RedisMessage{typ: '+', string: "PONG"})
+					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
+						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
+						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
+					})).Reply(redisMessageContainString('+', "PONG"))
 				} else {
-					mock.Expect(c.Commands()...).Reply(RedisMessage{typ: '>', values: []RedisMessage{
-						{typ: '+', string: strings.ToLower(c.Commands()[0])},
-						{typ: '+', string: strings.ToLower(c.Commands()[1])},
-					}})
+					mock.Expect(c.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
+						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
+						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
+					}))
 				}
 				mock.Expect("GET", "k").ReplyString("v")
 			}
@@ -2834,7 +2834,7 @@ func TestPubSub(t *testing.T) {
 
 		for _, c := range commands {
 			p.Do(context.Background(), c)
-			if v, _ := p.Do(context.Background(), builder.Get().Key("k").Build()).ToMessage(); v.string != "v" {
+			if v, _ := p.Do(context.Background(), builder.Get().Key("k").Build()).ToMessage(); v.string() != "v" {
 				t.Fatalf("no-reply commands should not affect nornal commands")
 			}
 		}
@@ -2854,22 +2854,22 @@ func TestPubSub(t *testing.T) {
 		go func() {
 			for _, c := range commands {
 				if c.IsUnsub() {
-					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(RedisMessage{typ: '>', values: []RedisMessage{
-						{typ: '+', string: strings.ToLower(c.Commands()[0])},
-						{typ: '+', string: strings.ToLower(c.Commands()[1])},
-					}}).Reply(RedisMessage{typ: '+', string: "PONG"})
+					mock.Expect(c.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
+						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
+						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
+					})).Reply(redisMessageContainString('+', "PONG"))
 				} else {
-					mock.Expect(c.Commands()...).Reply(RedisMessage{typ: '>', values: []RedisMessage{
-						{typ: '+', string: strings.ToLower(c.Commands()[0])},
-						{typ: '+', string: strings.ToLower(c.Commands()[1])},
-					}})
+					mock.Expect(c.Commands()...).Reply(redisMessageContainSlice('>', []RedisMessage{
+						redisMessageContainString('+', strings.ToLower(c.Commands()[0])),
+						redisMessageContainString('+', strings.ToLower(c.Commands()[1])),
+					}))
 				}
 			}
 			mock.Expect("GET", "k").ReplyString("v")
 		}()
 
 		p.DoMulti(context.Background(), commands...)
-		if v, _ := p.Do(context.Background(), builder.Get().Key("k").Build()).ToMessage(); v.string != "v" {
+		if v, _ := p.Do(context.Background(), builder.Get().Key("k").Build()).ToMessage(); v.string() != "v" {
 			t.Fatalf("no-reply commands should not affect nornal commands")
 		}
 	})
@@ -2882,24 +2882,24 @@ func TestPubSub(t *testing.T) {
 		deactivate := builder.Unsubscribe().Channel("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "subscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "subscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "message"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "2"},
-				}},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "message"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "2"),
+				}),
 			)
 			mock.Expect(deactivate.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "unsubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "unsubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 0},
-				}},
-			).Reply(RedisMessage{typ: '+', string: "PONG"})
+				}),
+			).Reply(redisMessageContainString('+', "PONG"))
 		}()
 
 		if err := p.Receive(ctx, activate, func(msg PubSubMessage) {
@@ -2923,24 +2923,24 @@ func TestPubSub(t *testing.T) {
 		deactivate := builder.Sunsubscribe().Channel("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "ssubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "ssubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "smessage"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "2"},
-				}},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "smessage"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "2"),
+				}),
 			)
 			mock.Expect(deactivate.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "sunsubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "sunsubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 0},
-				}},
-			).Reply(RedisMessage{typ: '+', string: "PONG"})
+				}),
+			).Reply(redisMessageContainString('+', "PONG"))
 		}()
 
 		if err := p.Receive(ctx, activate, func(msg PubSubMessage) {
@@ -2964,25 +2964,25 @@ func TestPubSub(t *testing.T) {
 		deactivate := builder.Punsubscribe().Pattern("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "psubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "psubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "pmessage"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "2"},
-					{typ: '+', string: "3"},
-				}},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "pmessage"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "2"),
+					redisMessageContainString('+', "3"),
+				}),
 			)
 			mock.Expect(deactivate.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "punsubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "punsubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 0},
-				}},
-			).Reply(RedisMessage{typ: '+', string: "PONG"})
+				}),
+			).Reply(redisMessageContainString('+', "PONG"))
 		}()
 
 		if err := p.Receive(ctx, activate, func(msg PubSubMessage) {
@@ -3028,16 +3028,16 @@ func TestPubSub(t *testing.T) {
 		activate := builder.Subscribe().Channel("1").Build()
 		go func() {
 			mock.Expect(activate.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "subscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "subscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "message"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "2"},
-				}},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "message"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "2"),
+				}),
 			)
 		}()
 
@@ -3067,9 +3067,9 @@ func TestPubSub(t *testing.T) {
 		go func() {
 			for _, cmd := range commands {
 				if cmd.IsUnsub() {
-					mock.Expect(cmd.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(RedisMessage{typ: '-', string: cmd.Commands()[0]}).Reply(RedisMessage{typ: '+', string: "PONG"})
+					mock.Expect(cmd.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(redisMessageContainString('-', cmd.Commands()[0])).Reply(redisMessageContainString('+', "PONG"))
 				} else {
-					mock.Expect(cmd.Commands()...).Reply(RedisMessage{typ: '-', string: cmd.Commands()[0]})
+					mock.Expect(cmd.Commands()...).Reply(redisMessageContainString('-', cmd.Commands()[0]))
 				}
 			}
 		}()
@@ -3100,39 +3100,39 @@ func TestPubSub(t *testing.T) {
 			go func() {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-						RedisMessage{typ: '>', values: []RedisMessage{
-							{typ: '+', string: "unsubscribe"},
-							{typ: '+', string: "a"},
+						redisMessageContainSlice('>', []RedisMessage{
+							redisMessageContainString('+', "unsubscribe"),
+							redisMessageContainString('+', "a"),
 							{typ: ':', integer: 1},
-						}},
-						RedisMessage{typ: '>', values: []RedisMessage{ // skip
-							{typ: '+', string: "unsubscribe"},
-							{typ: '+', string: "b"},
+						}),
+						redisMessageContainSlice('>', []RedisMessage{ // skip
+							redisMessageContainString('+', "unsubscribe"),
+							redisMessageContainString('+', "b"),
 							{typ: ':', integer: 1},
-						}},
-						RedisMessage{typ: '>', values: []RedisMessage{ // skip
-							{typ: '+', string: "unsubscribe"},
-							{typ: '+', string: "c"},
+						}),
+						redisMessageContainSlice('>', []RedisMessage{ // skip
+							redisMessageContainString('+', "unsubscribe"),
+							redisMessageContainString('+', "c"),
 							{typ: ':', integer: 1},
-						}},
-					).Reply(RedisMessage{typ: '+', string: "PONG"}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+						}),
+					).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(
-						RedisMessage{typ: '>', values: []RedisMessage{
-							{typ: '+', string: "subscribe"},
-							{typ: '+', string: "a"},
+						redisMessageContainSlice('>', []RedisMessage{
+							redisMessageContainString('+', "subscribe"),
+							redisMessageContainString('+', "a"),
 							{typ: ':', integer: 1},
-						}},
-						RedisMessage{typ: '>', values: []RedisMessage{ // skip
-							{typ: '+', string: "subscribe"},
-							{typ: '+', string: "b"},
+						}),
+						redisMessageContainSlice('>', []RedisMessage{ // skip
+							redisMessageContainString('+', "subscribe"),
+							redisMessageContainString('+', "b"),
 							{typ: ':', integer: 1},
-						}},
-						RedisMessage{typ: '>', values: []RedisMessage{ // skip
-							{typ: '+', string: "subscribe"},
-							{typ: '+', string: "c"},
+						}),
+						redisMessageContainSlice('>', []RedisMessage{ // skip
+							redisMessageContainString('+', "subscribe"),
+							redisMessageContainString('+', "c"),
 							{typ: ':', integer: 1},
-						}},
+						}),
 					).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
 
@@ -3159,46 +3159,46 @@ func TestPubSub(t *testing.T) {
 		}
 
 		replies := [][]RedisMessage{{
-			{
-				typ: '>',
-				values: []RedisMessage{
-					{typ: '+', string: "unsubscribe"},
+			redisMessageContainSlice(
+				'>',
+				[]RedisMessage{
+					redisMessageContainString('+', "unsubscribe"),
 					{typ: '_'},
 					{typ: ':', integer: 0},
 				},
-			},
+			),
 		}, {
-			{
-				typ: '>',
-				values: []RedisMessage{
-					{typ: '+', string: "punsubscribe"},
-					{typ: '+', string: "1"},
+			redisMessageContainSlice(
+				'>',
+				[]RedisMessage{
+					redisMessageContainString('+', "punsubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 0},
 				},
-			},
+			),
 		}, {
-			{
-				typ: '>',
-				values: []RedisMessage{
-					{typ: '+', string: "sunsubscribe"},
-					{typ: '+', string: "2"},
+			redisMessageContainSlice(
+				'>',
+				[]RedisMessage{
+					redisMessageContainString('+', "sunsubscribe"),
+					redisMessageContainString('+', "2"),
 					{typ: ':', integer: 0},
 				},
-			},
-			{
-				typ: '>',
-				values: []RedisMessage{
-					{typ: '+', string: "sunsubscribe"},
-					{typ: '+', string: "3"},
+			),
+			redisMessageContainSlice(
+				'>',
+				[]RedisMessage{
+					redisMessageContainString('+', "sunsubscribe"),
+					redisMessageContainString('+', "3"),
 					{typ: ':', integer: 0},
 				},
-			},
+			),
 		}}
 
 		for i, cmd1 := range commands {
 			cmd2 := builder.Get().Key(strconv.Itoa(i)).Build()
 			go func() {
-				mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(RedisMessage{typ: '+', string: "PONG"}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+				mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 			}()
 
 			if err := p.Do(ctx, cmd1).Error(); err != nil {
@@ -3229,70 +3229,70 @@ func TestPubSub(t *testing.T) {
 
 				replies := [][]RedisMessage{
 					{
-						{ // proactive unsubscribe before user unsubscribe
-							typ: '>',
-							values: []RedisMessage{
-								{typ: '+', string: command},
-								{typ: '+', string: "1"},
+						redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+							'>',
+							[]RedisMessage{
+								redisMessageContainString('+', command),
+								redisMessageContainString('+', "1"),
 								{typ: ':', integer: 0},
 							},
-						},
-						{ // proactive unsubscribe before user unsubscribe
-							typ: '>',
-							values: []RedisMessage{
-								{typ: '+', string: command},
-								{typ: '+', string: "2"},
+						),
+						redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+							'>',
+							[]RedisMessage{
+								redisMessageContainString('+', command),
+								redisMessageContainString('+', "2"),
 								{typ: ':', integer: 0},
 							},
-						},
-						{ // user unsubscribe
-							typ: '>',
-							values: []RedisMessage{
-								{typ: '+', string: command},
+						),
+						redisMessageContainSlice( // user unsubscribe
+							'>',
+							[]RedisMessage{
+								redisMessageContainString('+', command),
 								{typ: '_'},
 								{typ: ':', integer: 0},
 							},
-						},
-						{ // proactive unsubscribe after user unsubscribe
-							typ: '>',
-							values: []RedisMessage{
-								{typ: '+', string: command},
+						),
+						redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+							'>',
+							[]RedisMessage{
+								redisMessageContainString('+', command),
 								{typ: '_'},
 								{typ: ':', integer: 0},
 							},
-						},
+						),
 					},
 					{
-						{ // user ssubscribe
-							typ: '>',
-							values: []RedisMessage{
-								{typ: '+', string: "ssubscribe"},
-								{typ: '+', string: "3"},
+						redisMessageContainSlice( // user ssubscribe
+							'>',
+							[]RedisMessage{
+								redisMessageContainString('+', "ssubscribe"),
+								redisMessageContainString('+', "3"),
 								{typ: ':', integer: 0},
 							},
-						},
-						{ // proactive unsubscribe after user ssubscribe
-							typ: '>',
-							values: []RedisMessage{
-								{typ: '+', string: command},
-								{typ: '+', string: "3"},
+						),
+						redisMessageContainSlice( // proactive unsubscribe after user ssubscribe
+							'>',
+							[]RedisMessage{
+								redisMessageContainString('+', command),
+								redisMessageContainString('+', "3"),
 								{typ: ':', integer: 0},
 							},
-						},
+						),
 					},
 				}
 
 				p.background()
 
 				// proactive unsubscribe before other commands
-				mock.Expect().Reply(RedisMessage{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: command},
-						{typ: '+', string: "0"},
+				mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', command),
+						redisMessageContainString('+', "0"),
 						{typ: ':', integer: 0},
 					},
-				})
+				))
 
 				time.Sleep(time.Millisecond * 100)
 
@@ -3300,7 +3300,7 @@ func TestPubSub(t *testing.T) {
 					cmd2 := builder.Get().Key(strconv.Itoa(i)).Build()
 					go func() {
 						if cmd1.IsUnsub() {
-							mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(RedisMessage{typ: '+', string: "PONG"}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+							mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 						} else {
 							mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 						}
@@ -3330,64 +3330,64 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "a"},
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "a"),
 						{typ: ':', integer: 0},
 					},
-				},
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "b"},
+				),
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "b"),
 						{typ: ':', integer: 0},
 					},
-				},
-				{ // user unsubscribe, but error
-					typ:    '-',
-					string: "MOVED 1111",
-				},
+				),
+				redisMessageContainString( // user unsubscribe, but error
+					'-',
+					"MOVED 1111",
+				),
 			}, {
-				{ // user unsubscribe, but error
-					typ:    '-',
-					string: "MOVED 222",
-				},
+				redisMessageContainString( // user unsubscribe, but error
+					'-',
+					"MOVED 222",
+				),
 			}, {
-				{ // user unsubscribe success
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "c"},
+				redisMessageContainSlice( // user unsubscribe success
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "c"),
 						{typ: ':', integer: 0},
 					},
-				},
+				),
 			}, {
-				{ // proactive unsubscribe after user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
+				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
-				},
-				{typ: '+', string: "mk"},
+				),
+				redisMessageContainString('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(RedisMessage{ // proactive unsubscribe before user unsubscribe
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "sunsubscribe"},
-				{typ: '+', string: "0"},
+		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "sunsubscribe"),
+				redisMessageContainString('+', "0"),
 				{typ: ':', integer: 0},
 			},
-		})
+		))
 
 		time.Sleep(time.Millisecond * 100)
 
@@ -3395,7 +3395,7 @@ func TestPubSub(t *testing.T) {
 			cmd2 := builder.Get().Key(strconv.Itoa(i)).Build()
 			go func() {
 				if cmd1.IsUnsub() {
-					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(RedisMessage{typ: '+', string: "PONG"}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(replies[i]...).Reply(redisMessageContainString('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
@@ -3423,11 +3423,11 @@ func TestPubSub(t *testing.T) {
 			p.queue.PutOne(push)
 			_, _, ch := p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(RedisMessage{
-					typ: '-', string: "MOVED",
-				}).Reply(RedisMessage{
-					typ: '-', string: "MOVED",
-				})
+				mock.Expect().Reply(redisMessageContainString(
+					'-', "MOVED",
+				)).Reply(redisMessageContainString(
+					'-', "MOVED",
+				))
 			}()
 			go func() {
 				<-ch
@@ -3455,11 +3455,11 @@ func TestPubSub(t *testing.T) {
 			_, _, ch := p.queue.NextWriteCmd()
 			_, _, _ = p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(RedisMessage{
-					typ: '-', string: "MOVED",
-				}).Reply(RedisMessage{
-					typ: '-', string: "MOVED",
-				})
+				mock.Expect().Reply(redisMessageContainString(
+					'-', "MOVED",
+				)).Reply(redisMessageContainString(
+					'-', "MOVED",
+				))
 			}()
 			go func() {
 				<-ch
@@ -3488,48 +3488,48 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "a"},
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "a"),
 						{typ: ':', integer: 0},
 					},
-				},
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "b"},
+				),
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "b"),
 						{typ: ':', integer: 0},
 					},
-				},
+				),
 			}, {
 				// empty
 			}, {
-				{ // proactive unsubscribe after user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
+				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
-				},
-				{typ: '+', string: "mk"},
+				),
+				redisMessageContainString('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(RedisMessage{ // proactive unsubscribe before user unsubscribe
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "sunsubscribe"},
-				{typ: '+', string: "0"},
+		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "sunsubscribe"),
+				redisMessageContainString('+', "0"),
 				{typ: ':', integer: 0},
 			},
-		})
+		))
 
 		time.Sleep(time.Millisecond * 100)
 
@@ -3539,10 +3539,10 @@ func TestPubSub(t *testing.T) {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).
 						Reply(replies[i]...).
-						Reply(RedisMessage{ // failed unsubReply
-							typ:    '-',
-							string: "NOPERM User u has no permissions to run the 'ping' command",
-						}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+						Reply(redisMessageContainString( // failed unsubReply
+							'-',
+							"NOPERM User u has no permissions to run the 'ping' command",
+						)).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
@@ -3575,48 +3575,48 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "a"},
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "a"),
 						{typ: ':', integer: 0},
 					},
-				},
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "b"},
+				),
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "b"),
 						{typ: ':', integer: 0},
 					},
-				},
+				),
 			}, {
 				// empty
 			}, {
-				{ // proactive unsubscribe after user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
+				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
-				},
-				{typ: '+', string: "mk"},
+				),
+				redisMessageContainString('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(RedisMessage{ // proactive unsubscribe before user unsubscribe
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "sunsubscribe"},
-				{typ: '+', string: "0"},
+		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "sunsubscribe"),
+				redisMessageContainString('+', "0"),
 				{typ: ':', integer: 0},
 			},
-		})
+		))
 
 		time.Sleep(time.Millisecond * 100)
 
@@ -3626,10 +3626,10 @@ func TestPubSub(t *testing.T) {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).
 						Reply(replies[i]...).
-						Reply(RedisMessage{ // failed unsubReply
-							typ:    '-',
-							string: "LOADING server is loading the dataset in memory",
-						}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+						Reply(redisMessageContainString( // failed unsubReply
+							'-',
+							"LOADING server is loading the dataset in memory",
+						)).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
@@ -3662,48 +3662,48 @@ func TestPubSub(t *testing.T) {
 
 		replies := [][]RedisMessage{
 			{
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "a"},
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "a"),
 						{typ: ':', integer: 0},
 					},
-				},
-				{ // proactive unsubscribe before user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
-						{typ: '+', string: "b"},
+				),
+				redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
+						redisMessageContainString('+', "b"),
 						{typ: ':', integer: 0},
 					},
-				},
+				),
 			}, {
 				// empty
 			}, {
-				{ // proactive unsubscribe after user unsubscribe
-					typ: '>',
-					values: []RedisMessage{
-						{typ: '+', string: "sunsubscribe"},
+				redisMessageContainSlice( // proactive unsubscribe after user unsubscribe
+					'>',
+					[]RedisMessage{
+						redisMessageContainString('+', "sunsubscribe"),
 						{typ: '_'},
 						{typ: ':', integer: 0},
 					},
-				},
-				{typ: '+', string: "mk"},
+				),
+				redisMessageContainString('+', "mk"),
 			},
 		}
 
 		p.background()
 
 		// proactive unsubscribe before other commands
-		mock.Expect().Reply(RedisMessage{ // proactive unsubscribe before user unsubscribe
-			typ: '>',
-			values: []RedisMessage{
-				{typ: '+', string: "sunsubscribe"},
-				{typ: '+', string: "0"},
+		mock.Expect().Reply(redisMessageContainSlice( // proactive unsubscribe before user unsubscribe
+			'>',
+			[]RedisMessage{
+				redisMessageContainString('+', "sunsubscribe"),
+				redisMessageContainString('+', "0"),
 				{typ: ':', integer: 0},
 			},
-		})
+		))
 
 		time.Sleep(time.Millisecond * 100)
 
@@ -3713,10 +3713,10 @@ func TestPubSub(t *testing.T) {
 				if cmd1.IsUnsub() {
 					mock.Expect(cmd1.Commands()...).Expect(cmds.PingCmd.Commands()...).
 						Reply(replies[i]...).
-						Reply(RedisMessage{ // failed unsubReply
-							typ:    '-',
-							string: "BUSY",
-						}).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
+						Reply(redisMessageContainString( // failed unsubReply
+							'-',
+							"BUSY",
+						)).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
 					mock.Expect(cmd1.Commands()...).Reply(replies[i]...).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
@@ -3746,12 +3746,12 @@ func TestPubSub(t *testing.T) {
 			p.queue.PutOne(builder.Get().Key("a").Build())
 			p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(RedisMessage{
-					typ: '>', values: []RedisMessage{
-						{typ: '+', string: push},
-						{typ: '+', string: ""},
+				mock.Expect().Reply(redisMessageContainSlice(
+					'>', []RedisMessage{
+						redisMessageContainString('+', push),
+						redisMessageContainString('+', ""),
 					},
-				})
+				))
 			}()
 			p._backgroundRead()
 			return
@@ -3776,7 +3776,7 @@ func TestPubSub(t *testing.T) {
 			p.queue.PutOne(cmd)
 			p.queue.NextWriteCmd()
 			go func() {
-				mock.Expect().Reply(RedisMessage{typ: '+', string: "QUEUED"})
+				mock.Expect().Reply(redisMessageContainString('+', "QUEUED"))
 			}()
 			p._backgroundRead()
 			return
@@ -3926,41 +3926,41 @@ func TestPubSubHooks(t *testing.T) {
 		deactivate2 := builder.Punsubscribe().Pattern("2").Build()
 		go func() {
 			mock.Expect(activate1.Commands()...).Expect(activate2.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "subscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "subscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "psubscribe"},
-					{typ: '+', string: "2"},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "psubscribe"),
+					redisMessageContainString('+', "2"),
 					{typ: ':', integer: 2},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "message"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "11"},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "pmessage"},
-					{typ: '+', string: "2"},
-					{typ: '+', string: "22"},
-					{typ: '+', string: "222"},
-				}},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "message"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "11"),
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "pmessage"),
+					redisMessageContainString('+', "2"),
+					redisMessageContainString('+', "22"),
+					redisMessageContainString('+', "222"),
+				}),
 			)
 			mock.Expect(deactivate1.Commands()...).Expect(cmds.PingCmd.Commands()...).Expect(deactivate2.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "unsubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "unsubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '+', string: "PONG"},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "punsubscribe"},
-					{typ: '+', string: "2"},
+				}),
+				redisMessageContainString('+', "PONG"),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "punsubscribe"),
+					redisMessageContainString('+', "2"),
 					{typ: ':', integer: 2},
-				}},
-				RedisMessage{typ: '+', string: "PONG"},
+				}),
+				redisMessageContainString('+', "PONG"),
 			)
 			cancel()
 		}()
@@ -4015,41 +4015,41 @@ func TestPubSubHooks(t *testing.T) {
 		deactivate2 := builder.Punsubscribe().Pattern("2").Build()
 		go func() {
 			mock.Expect(activate1.Commands()...).Expect(activate2.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "subscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "subscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "psubscribe"},
-					{typ: '+', string: "2"},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "psubscribe"),
+					redisMessageContainString('+', "2"),
 					{typ: ':', integer: 2},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "message"},
-					{typ: '+', string: "1"},
-					{typ: '+', string: "11"},
-				}},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "pmessage"},
-					{typ: '+', string: "2"},
-					{typ: '+', string: "22"},
-					{typ: '+', string: "222"},
-				}},
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "message"),
+					redisMessageContainString('+', "1"),
+					redisMessageContainString('+', "11"),
+				}),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "pmessage"),
+					redisMessageContainString('+', "2"),
+					redisMessageContainString('+', "22"),
+					redisMessageContainString('+', "222"),
+				}),
 			)
 			mock.Expect(deactivate1.Commands()...).Expect(cmds.PingCmd.Commands()...).Expect(deactivate2.Commands()...).Expect(cmds.PingCmd.Commands()...).Reply(
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "unsubscribe"},
-					{typ: '+', string: "1"},
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "unsubscribe"),
+					redisMessageContainString('+', "1"),
 					{typ: ':', integer: 1},
-				}},
-				RedisMessage{typ: '+', string: "PONG"},
-				RedisMessage{typ: '>', values: []RedisMessage{
-					{typ: '+', string: "punsubscribe"},
-					{typ: '+', string: "2"},
+				}),
+				redisMessageContainString('+', "PONG"),
+				redisMessageContainSlice('>', []RedisMessage{
+					redisMessageContainString('+', "punsubscribe"),
+					redisMessageContainString('+', "2"),
 					{typ: ':', integer: 2},
-				}},
-				RedisMessage{typ: '+', string: "PONG"},
+				}),
+				redisMessageContainString('+', "PONG"),
 			)
 			cancel()
 		}()
@@ -4281,8 +4281,8 @@ func TestCloseAndWaitPendingCMDs(t *testing.T) {
 	for i := 0; i < loop; i++ {
 		go func() {
 			defer wg.Done()
-			if v, _ := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).ToMessage(); v.string != "b" {
-				t.Errorf("unexpected GET result %v", v.string)
+			if v, _ := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).ToMessage(); v.string() != "b" {
+				t.Errorf("unexpected GET result %v", v.string())
 			}
 		}()
 	}
@@ -5085,19 +5085,19 @@ func TestPipe_CleanSubscriptions_6(t *testing.T) {
 		p.CleanSubscriptions()
 	}()
 	mock.Expect("UNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("PUNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("DISCARD").Reply(
-		RedisMessage{typ: '>', values: []RedisMessage{
-			{typ: '+', string: "unsubscribe"},
+		redisMessageContainSlice('>', []RedisMessage{
+			redisMessageContainString('+', "unsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 1},
-		}},
-		RedisMessage{typ: '+', string: "PONG"},
-		RedisMessage{typ: '>', values: []RedisMessage{
-			{typ: '+', string: "punsubscribe"},
+		}),
+		redisMessageContainString('+', "PONG"),
+		redisMessageContainSlice('>', []RedisMessage{
+			redisMessageContainString('+', "punsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 2},
-		}},
-		RedisMessage{typ: '+', string: "PONG"},
-		RedisMessage{typ: '+', string: "OK"},
+		}),
+		redisMessageContainString('+', "PONG"),
+		redisMessageContainString('+', "OK"),
 	)
 }
 
@@ -5128,25 +5128,25 @@ func TestPipe_CleanSubscriptions_7(t *testing.T) {
 		p.CleanSubscriptions()
 	}()
 	mock.Expect("UNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("PUNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("SUNSUBSCRIBE").Expect(cmds.PingCmd.Commands()...).Expect("DISCARD").Reply(
-		RedisMessage{typ: '>', values: []RedisMessage{
-			{typ: '+', string: "unsubscribe"},
+		redisMessageContainSlice('>', []RedisMessage{
+			redisMessageContainString('+', "unsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 1},
-		}},
-		RedisMessage{typ: '+', string: "PONG"},
-		RedisMessage{typ: '>', values: []RedisMessage{
-			{typ: '+', string: "punsubscribe"},
+		}),
+		redisMessageContainString('+', "PONG"),
+		redisMessageContainSlice('>', []RedisMessage{
+			redisMessageContainString('+', "punsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 2},
-		}},
-		RedisMessage{typ: '+', string: "PONG"},
-		RedisMessage{typ: '>', values: []RedisMessage{
-			{typ: '+', string: "sunsubscribe"},
+		}),
+		redisMessageContainString('+', "PONG"),
+		redisMessageContainSlice('>', []RedisMessage{
+			redisMessageContainString('+', "sunsubscribe"),
 			{typ: '_'},
 			{typ: ':', integer: 3},
-		}},
-		RedisMessage{typ: '+', string: "PONG"},
-		RedisMessage{typ: '+', string: "OK"},
+		}),
+		redisMessageContainString('+', "PONG"),
+		redisMessageContainString('+', "OK"),
 	)
 }
 

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -88,7 +88,7 @@ func (r *redisExpect) ReplyError(replies ...string) *redisExpect {
 func (r *redisExpect) ReplyInteger(replies ...int64) *redisExpect {
 	for _, reply := range replies {
 		if r.err == nil {
-			r.Reply(RedisMessage{typ: ':', integer: reply})
+			r.Reply(RedisMessage{typ: ':', intlen: reply})
 		}
 	}
 	return r
@@ -116,7 +116,7 @@ func write(o io.Writer, m RedisMessage) (err error) {
 	case '+', '-', '_':
 		_, err = o.Write(append([]byte(m.string()), '\r', '\n'))
 	case ':':
-		_, err = o.Write(append([]byte(strconv.FormatInt(m.integer, 10)), '\r', '\n'))
+		_, err = o.Write(append([]byte(strconv.FormatInt(m.intlen, 10)), '\r', '\n'))
 	case '%', '>', '*':
 		size := int64(len(m.values()))
 		if m.typ == '%' {
@@ -153,7 +153,7 @@ func setup(t *testing.T, option ClientOption) (*pipe, *redisMock, func(), func()
 					strmsg('+', "version"),
 					strmsg('+', "6.0.0"),
 					strmsg('+', "proto"),
-					{typ: ':', integer: 3},
+					{typ: ':', intlen: 3},
 				},
 			))
 		if option.ClientTrackingOptions != nil {
@@ -213,7 +213,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						RedisMessage{typ: ':', integer: 3},
+						RedisMessage{typ: ':', intlen: 3},
 						strmsg('+', "availability_zone"),
 						strmsg('+', "us-west-1a"),
 					},
@@ -262,7 +262,7 @@ func TestNewPipe(t *testing.T) {
 					'*',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 2},
+						{typ: ':', intlen: 2},
 						strmsg('+', "availability_zone"),
 						strmsg('+', "us-west-1a"),
 					},
@@ -311,7 +311,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 3},
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
@@ -350,7 +350,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 3},
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
@@ -390,7 +390,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 3},
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN", "NOLOOP").
@@ -421,7 +421,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 3},
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
@@ -460,7 +460,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 3},
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
@@ -525,7 +525,7 @@ func TestNewPipe(t *testing.T) {
 					'%',
 					[]RedisMessage{
 						strmsg('+', "proto"),
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 3},
 					},
 				))
 			mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
@@ -601,7 +601,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 					strmsg('+', "server"),
 					strmsg('+', "redis"),
 					strmsg('+', "proto"),
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2},
 					strmsg('+', "availability_zone"),
 					strmsg('+', "us-west-1a"),
 				}))
@@ -614,7 +614,7 @@ func TestNewRESP2Pipe(t *testing.T) {
 					strmsg('+', "server"),
 					strmsg('+', "redis"),
 					strmsg('+', "proto"),
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2},
 					strmsg('+', "availability_zone"),
 					strmsg('+', "us-west-1a"),
 				}))
@@ -1222,7 +1222,7 @@ func TestNoReplyExceedRingSize(t *testing.T) {
 		mock.Expect("UNSUBSCRIBE").Reply(slicemsg('>', []RedisMessage{
 			strmsg('+', "unsubscribe"),
 			strmsg('+', "1"),
-			{typ: ':', integer: 0},
+			{typ: ':', intlen: 0},
 		})).Expect(cmds.PingCmd.Commands()...).Reply(strmsg('+', "PONG"))
 	}
 	<-wait
@@ -1286,7 +1286,7 @@ func TestClientSideCaching(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: ttl},
+				{typ: ':', intlen: ttl},
 				strmsg('+', resp),
 			}))
 	}
@@ -1378,7 +1378,7 @@ func TestClientSideCachingBCAST(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: ttl},
+				{typ: ':', intlen: ttl},
 				strmsg('+', resp),
 			}))
 	}
@@ -1470,7 +1470,7 @@ func TestClientSideCachingOPTOUT(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: ttl},
+				{typ: ':', intlen: ttl},
 				strmsg('+', resp),
 			}))
 	}
@@ -1641,13 +1641,13 @@ func TestClientSideCachingMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 1000},
-				{typ: ':', integer: 2000},
-				{typ: ':', integer: 3000},
+				{typ: ':', intlen: 1000},
+				{typ: ':', intlen: 2000},
+				{typ: ':', intlen: 3000},
 				slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 1},
-					{typ: ':', integer: 2},
-					{typ: ':', integer: 3},
+					{typ: ':', intlen: 1},
+					{typ: ':', intlen: 2},
+					{typ: ':', intlen: 3},
 				}),
 			}))
 	}()
@@ -1661,8 +1661,8 @@ func TestClientSideCachingMGet(t *testing.T) {
 			t.Errorf("unexpected cached mget length, expected 3, got %v", len(arr))
 		}
 		for i, v := range arr {
-			if v.integer != int64(i+1) {
-				t.Errorf("unexpected cached mget response, expected %v, got %v", i+1, v.integer)
+			if v.intlen != int64(i+1) {
+				t.Errorf("unexpected cached mget response, expected %v, got %v", i+1, v.intlen)
 			}
 		}
 		if ttl := p.cache.(*lru).GetTTL("a1", "GET"); !roughly(ttl, time.Second) {
@@ -1704,11 +1704,11 @@ func TestClientSideCachingMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 10000},
-				{typ: ':', integer: 30000},
+				{typ: ':', intlen: 10000},
+				{typ: ':', intlen: 30000},
 				slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 10},
-					{typ: ':', integer: 30},
+					{typ: ':', intlen: 10},
+					{typ: ':', intlen: 30},
 				}),
 			}))
 	}()
@@ -1725,14 +1725,14 @@ func TestClientSideCachingMGet(t *testing.T) {
 	if len(arr) != 3 {
 		t.Errorf("unexpected cached mget length, expected 3, got %v", len(arr))
 	}
-	if arr[1].integer != 2 {
-		t.Errorf("unexpected cached mget response, expected %v, got %v", 2, arr[1].integer)
+	if arr[1].intlen != 2 {
+		t.Errorf("unexpected cached mget response, expected %v, got %v", 2, arr[1].intlen)
 	}
-	if arr[0].integer != 10 {
-		t.Errorf("unexpected cached mget response, expected %v, got %v", 10, arr[0].integer)
+	if arr[0].intlen != 10 {
+		t.Errorf("unexpected cached mget response, expected %v, got %v", 10, arr[0].intlen)
 	}
-	if arr[2].integer != 30 {
-		t.Errorf("unexpected cached mget response, expected %v, got %v", 30, arr[2].integer)
+	if arr[2].intlen != 30 {
+		t.Errorf("unexpected cached mget response, expected %v, got %v", 30, arr[2].intlen)
 	}
 	if ttl := p.cache.(*lru).GetTTL("a1", "GET"); !roughly(ttl, time.Second*10) {
 		t.Errorf("unexpected ttl %v", ttl)
@@ -1775,13 +1775,13 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 1000},
-				{typ: ':', integer: 2000},
-				{typ: ':', integer: 3000},
+				{typ: ':', intlen: 1000},
+				{typ: ':', intlen: 2000},
+				{typ: ':', intlen: 3000},
 				slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 1},
-					{typ: ':', integer: 2},
-					{typ: ':', integer: 3},
+					{typ: ':', intlen: 1},
+					{typ: ':', intlen: 2},
+					{typ: ':', intlen: 3},
 				}),
 			}))
 	}()
@@ -1795,8 +1795,8 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			t.Errorf("unexpected cached mget length, expected 3, got %v", len(arr))
 		}
 		for i, v := range arr {
-			if v.integer != int64(i+1) {
-				t.Errorf("unexpected cached mget response, expected %v, got %v", i+1, v.integer)
+			if v.intlen != int64(i+1) {
+				t.Errorf("unexpected cached mget response, expected %v, got %v", i+1, v.intlen)
 			}
 		}
 		if ttl := p.cache.(*lru).GetTTL("a1", "JSON.GET$"); !roughly(ttl, time.Second) {
@@ -1838,11 +1838,11 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: 10000},
-				{typ: ':', integer: 30000},
+				{typ: ':', intlen: 10000},
+				{typ: ':', intlen: 30000},
 				slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 10},
-					{typ: ':', integer: 30},
+					{typ: ':', intlen: 10},
+					{typ: ':', intlen: 30},
 				}),
 			}))
 	}()
@@ -1859,14 +1859,14 @@ func TestClientSideCachingJSONMGet(t *testing.T) {
 	if len(arr) != 3 {
 		t.Errorf("unexpected cached mget length, expected 3, got %v", len(arr))
 	}
-	if arr[1].integer != 2 {
-		t.Errorf("unexpected cached mget response, expected %v, got %v", 2, arr[1].integer)
+	if arr[1].intlen != 2 {
+		t.Errorf("unexpected cached mget response, expected %v, got %v", 2, arr[1].intlen)
 	}
-	if arr[0].integer != 10 {
-		t.Errorf("unexpected cached mget response, expected %v, got %v", 10, arr[0].integer)
+	if arr[0].intlen != 10 {
+		t.Errorf("unexpected cached mget response, expected %v, got %v", 10, arr[0].intlen)
 	}
-	if arr[2].integer != 30 {
-		t.Errorf("unexpected cached mget response, expected %v, got %v", 30, arr[2].integer)
+	if arr[2].intlen != 30 {
+		t.Errorf("unexpected cached mget response, expected %v, got %v", 30, arr[2].intlen)
 	}
 	if ttl := p.cache.(*lru).GetTTL("a1", "JSON.GET$"); !roughly(ttl, time.Second*10) {
 		t.Errorf("unexpected ttl %v", ttl)
@@ -2044,24 +2044,24 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				Reply(slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 1000},
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1000},
+					{typ: ':', intlen: 1},
 				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				Reply(slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 2000},
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2000},
+					{typ: ':', intlen: 2},
 				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				Reply(slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 3000},
-					{typ: ':', integer: 3},
+					{typ: ':', intlen: 3000},
+					{typ: ':', intlen: 3},
 				}))
 		}()
 		// single flight
@@ -2077,8 +2077,8 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				t.Errorf("unexpected cached mget length, expected 3, got %v", len(arr))
 			}
 			for i, v := range arr {
-				if v.val.integer != int64(i+1) {
-					t.Errorf("unexpected cached mget response, expected %v, got %v", i+1, v.val.integer)
+				if v.val.intlen != int64(i+1) {
+					t.Errorf("unexpected cached mget response, expected %v, got %v", i+1, v.val.intlen)
 				}
 				if v.val.IsCacheHit() {
 					atomic.AddUint64(&hits, 1)
@@ -2123,16 +2123,16 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				Reply(slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 10000},
-					{typ: ':', integer: 10},
+					{typ: ':', intlen: 10000},
+					{typ: ':', intlen: 10},
 				})).
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				ReplyString("OK").
 				Reply(slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 30000},
-					{typ: ':', integer: 30},
+					{typ: ':', intlen: 30000},
+					{typ: ':', intlen: 30},
 				}))
 		}()
 
@@ -2155,14 +2155,14 @@ func TestClientSideCachingDoMultiCache(t *testing.T) {
 		if len(arr) != 3 {
 			t.Errorf("unexpected cached mget length, expected 3, got %v", len(arr))
 		}
-		if arr[1].val.integer != 2 {
-			t.Errorf("unexpected cached mget response, expected %v, got %v", 2, arr[1].val.integer)
+		if arr[1].val.intlen != 2 {
+			t.Errorf("unexpected cached mget response, expected %v, got %v", 2, arr[1].val.intlen)
 		}
-		if arr[0].val.integer != 10 {
-			t.Errorf("unexpected cached mget response, expected %v, got %v", 10, arr[0].val.integer)
+		if arr[0].val.intlen != 10 {
+			t.Errorf("unexpected cached mget response, expected %v, got %v", 10, arr[0].val.intlen)
 		}
-		if arr[2].val.integer != 30 {
-			t.Errorf("unexpected cached mget response, expected %v, got %v", 30, arr[2].val.integer)
+		if arr[2].val.intlen != 30 {
+			t.Errorf("unexpected cached mget response, expected %v, got %v", 30, arr[2].val.intlen)
 		}
 		if ttl := time.Duration(arr[0].CachePTTL()) * time.Millisecond; !roughly(ttl, time.Second*10) {
 			t.Errorf("unexpected ttl %v", ttl)
@@ -2213,8 +2213,8 @@ func TestClientSideCachingExecAbortDoMultiCache(t *testing.T) {
 				ReplyString("OK").
 				ReplyString("OK").
 				Reply(slicemsg('*', []RedisMessage{
-					{typ: ':', integer: 1000},
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1000},
+					{typ: ':', intlen: 1},
 				})).
 				ReplyString("OK").
 				ReplyString("OK").
@@ -2236,8 +2236,8 @@ func TestClientSideCachingExecAbortDoMultiCache(t *testing.T) {
 		for i, resp := range arr {
 			v, err := resp.ToMessage()
 			if i == 0 {
-				if v.integer != 1 {
-					t.Errorf("unexpected cached response, expected %v, got %v", 1, v.integer)
+				if v.intlen != 1 {
+					t.Errorf("unexpected cached response, expected %v, got %v", 1, v.intlen)
 				}
 			} else if i == 1 {
 				if err != ErrDoCacheAborted {
@@ -2257,8 +2257,8 @@ func TestClientSideCachingExecAbortDoMultiCache(t *testing.T) {
 				}
 			}
 		}
-		if v, entry := p.cache.Flight("a1", "GET", time.Second, time.Now()); v.integer != 1 {
-			t.Errorf("unexpected cache value and entry %v %v", v.integer, entry)
+		if v, entry := p.cache.Flight("a1", "GET", time.Second, time.Now()); v.intlen != 1 {
+			t.Errorf("unexpected cache value and entry %v %v", v.intlen, entry)
 		}
 		if ttl := time.Duration(arr[0].CachePTTL()) * time.Millisecond; !roughly(ttl, time.Second) {
 			t.Errorf("unexpected ttl %v", ttl)
@@ -2397,7 +2397,7 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					Reply(slicemsg('*', []RedisMessage{
-						{typ: ':', integer: pttl},
+						{typ: ':', intlen: pttl},
 						strmsg('+', key),
 					}))
 			}
@@ -2437,9 +2437,9 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					Reply(slicemsg('*', []RedisMessage{
-						{typ: ':', integer: -1},
-						{typ: ':', integer: 1000},
-						{typ: ':', integer: 20000},
+						{typ: ':', intlen: -1},
+						{typ: ':', intlen: 1000},
+						{typ: ':', intlen: 20000},
 						slicemsg('*', []RedisMessage{
 							strmsg('+', "a"),
 							strmsg('+', "b"),
@@ -2482,24 +2482,24 @@ func TestClientSideCachingMissCacheTTL(t *testing.T) {
 					ReplyString("OK").
 					ReplyString("OK").
 					Reply(slicemsg('*', []RedisMessage{
-						{typ: ':', integer: -1},
-						{typ: ':', integer: 1},
+						{typ: ':', intlen: -1},
+						{typ: ':', intlen: 1},
 					})).
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
 					Reply(slicemsg('*', []RedisMessage{
-						{typ: ':', integer: 1000},
-						{typ: ':', integer: 2},
+						{typ: ':', intlen: 1000},
+						{typ: ':', intlen: 2},
 					})).
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
 					ReplyString("OK").
 					Reply(slicemsg('*', []RedisMessage{
-						{typ: ':', integer: 20000},
-						{typ: ':', integer: 3},
+						{typ: ':', intlen: 20000},
+						{typ: ':', intlen: 3},
 					}))
 			}()
 			arr := p.DoMultiCache(context.Background(), []CacheableTTL{
@@ -2554,7 +2554,7 @@ func TestClientSideCachingRedis6InvalidationBug1(t *testing.T) {
 						slicemsg('*', []RedisMessage{strmsg('+', "a")}),
 					},
 				),
-				{typ: ':', integer: -2},
+				{typ: ':', intlen: -2},
 			})).Reply(RedisMessage{typ: '_'})
 	}
 
@@ -2609,7 +2609,7 @@ func TestClientSideCachingRedis6InvalidationBug2(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: -2},
+				{typ: ':', intlen: -2},
 				slicemsg(
 					'>',
 					[]RedisMessage{
@@ -2670,7 +2670,7 @@ func TestClientSideCachingRedis6InvalidationBugErr(t *testing.T) {
 			ReplyString("OK").
 			ReplyString("OK").
 			Reply(slicemsg('*', []RedisMessage{
-				{typ: ':', integer: -2},
+				{typ: ':', intlen: -2},
 				slicemsg(
 					'>',
 					[]RedisMessage{
@@ -2885,7 +2885,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "subscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "message"),
@@ -2897,7 +2897,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "unsubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				}),
 			).Reply(strmsg('+', "PONG"))
 		}()
@@ -2926,7 +2926,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "ssubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "smessage"),
@@ -2938,7 +2938,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "sunsubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				}),
 			).Reply(strmsg('+', "PONG"))
 		}()
@@ -2967,7 +2967,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "psubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "pmessage"),
@@ -2980,7 +2980,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "punsubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				}),
 			).Reply(strmsg('+', "PONG"))
 		}()
@@ -3031,7 +3031,7 @@ func TestPubSub(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "subscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "message"),
@@ -3103,17 +3103,17 @@ func TestPubSub(t *testing.T) {
 						slicemsg('>', []RedisMessage{
 							strmsg('+', "unsubscribe"),
 							strmsg('+', "a"),
-							{typ: ':', integer: 1},
+							{typ: ':', intlen: 1},
 						}),
 						slicemsg('>', []RedisMessage{ // skip
 							strmsg('+', "unsubscribe"),
 							strmsg('+', "b"),
-							{typ: ':', integer: 1},
+							{typ: ':', intlen: 1},
 						}),
 						slicemsg('>', []RedisMessage{ // skip
 							strmsg('+', "unsubscribe"),
 							strmsg('+', "c"),
-							{typ: ':', integer: 1},
+							{typ: ':', intlen: 1},
 						}),
 					).Reply(strmsg('+', "PONG")).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				} else {
@@ -3121,17 +3121,17 @@ func TestPubSub(t *testing.T) {
 						slicemsg('>', []RedisMessage{
 							strmsg('+', "subscribe"),
 							strmsg('+', "a"),
-							{typ: ':', integer: 1},
+							{typ: ':', intlen: 1},
 						}),
 						slicemsg('>', []RedisMessage{ // skip
 							strmsg('+', "subscribe"),
 							strmsg('+', "b"),
-							{typ: ':', integer: 1},
+							{typ: ':', intlen: 1},
 						}),
 						slicemsg('>', []RedisMessage{ // skip
 							strmsg('+', "subscribe"),
 							strmsg('+', "c"),
-							{typ: ':', integer: 1},
+							{typ: ':', intlen: 1},
 						}),
 					).Expect(cmd2.Commands()...).ReplyString(strconv.Itoa(i))
 				}
@@ -3164,7 +3164,7 @@ func TestPubSub(t *testing.T) {
 				[]RedisMessage{
 					strmsg('+', "unsubscribe"),
 					{typ: '_'},
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				},
 			),
 		}, {
@@ -3173,7 +3173,7 @@ func TestPubSub(t *testing.T) {
 				[]RedisMessage{
 					strmsg('+', "punsubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				},
 			),
 		}, {
@@ -3182,7 +3182,7 @@ func TestPubSub(t *testing.T) {
 				[]RedisMessage{
 					strmsg('+', "sunsubscribe"),
 					strmsg('+', "2"),
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				},
 			),
 			slicemsg(
@@ -3190,7 +3190,7 @@ func TestPubSub(t *testing.T) {
 				[]RedisMessage{
 					strmsg('+', "sunsubscribe"),
 					strmsg('+', "3"),
-					{typ: ':', integer: 0},
+					{typ: ':', intlen: 0},
 				},
 			),
 		}}
@@ -3234,7 +3234,7 @@ func TestPubSub(t *testing.T) {
 							[]RedisMessage{
 								strmsg('+', command),
 								strmsg('+', "1"),
-								{typ: ':', integer: 0},
+								{typ: ':', intlen: 0},
 							},
 						),
 						slicemsg( // proactive unsubscribe before user unsubscribe
@@ -3242,7 +3242,7 @@ func TestPubSub(t *testing.T) {
 							[]RedisMessage{
 								strmsg('+', command),
 								strmsg('+', "2"),
-								{typ: ':', integer: 0},
+								{typ: ':', intlen: 0},
 							},
 						),
 						slicemsg( // user unsubscribe
@@ -3250,7 +3250,7 @@ func TestPubSub(t *testing.T) {
 							[]RedisMessage{
 								strmsg('+', command),
 								{typ: '_'},
-								{typ: ':', integer: 0},
+								{typ: ':', intlen: 0},
 							},
 						),
 						slicemsg( // proactive unsubscribe after user unsubscribe
@@ -3258,7 +3258,7 @@ func TestPubSub(t *testing.T) {
 							[]RedisMessage{
 								strmsg('+', command),
 								{typ: '_'},
-								{typ: ':', integer: 0},
+								{typ: ':', intlen: 0},
 							},
 						),
 					},
@@ -3268,7 +3268,7 @@ func TestPubSub(t *testing.T) {
 							[]RedisMessage{
 								strmsg('+', "ssubscribe"),
 								strmsg('+', "3"),
-								{typ: ':', integer: 0},
+								{typ: ':', intlen: 0},
 							},
 						),
 						slicemsg( // proactive unsubscribe after user ssubscribe
@@ -3276,7 +3276,7 @@ func TestPubSub(t *testing.T) {
 							[]RedisMessage{
 								strmsg('+', command),
 								strmsg('+', "3"),
-								{typ: ':', integer: 0},
+								{typ: ':', intlen: 0},
 							},
 						),
 					},
@@ -3290,7 +3290,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', command),
 						strmsg('+', "0"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				))
 
@@ -3335,7 +3335,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "a"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				slicemsg( // proactive unsubscribe before user unsubscribe
@@ -3343,7 +3343,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "b"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				strmsg( // user unsubscribe, but error
@@ -3361,7 +3361,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "c"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 			}, {
@@ -3370,7 +3370,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				strmsg('+', "mk"),
@@ -3385,7 +3385,7 @@ func TestPubSub(t *testing.T) {
 			[]RedisMessage{
 				strmsg('+', "sunsubscribe"),
 				strmsg('+', "0"),
-				{typ: ':', integer: 0},
+				{typ: ':', intlen: 0},
 			},
 		))
 
@@ -3493,7 +3493,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "a"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				slicemsg( // proactive unsubscribe before user unsubscribe
@@ -3501,7 +3501,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "b"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 			}, {
@@ -3512,7 +3512,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				strmsg('+', "mk"),
@@ -3527,7 +3527,7 @@ func TestPubSub(t *testing.T) {
 			[]RedisMessage{
 				strmsg('+', "sunsubscribe"),
 				strmsg('+', "0"),
-				{typ: ':', integer: 0},
+				{typ: ':', intlen: 0},
 			},
 		))
 
@@ -3580,7 +3580,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "a"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				slicemsg( // proactive unsubscribe before user unsubscribe
@@ -3588,7 +3588,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "b"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 			}, {
@@ -3599,7 +3599,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				strmsg('+', "mk"),
@@ -3614,7 +3614,7 @@ func TestPubSub(t *testing.T) {
 			[]RedisMessage{
 				strmsg('+', "sunsubscribe"),
 				strmsg('+', "0"),
-				{typ: ':', integer: 0},
+				{typ: ':', intlen: 0},
 			},
 		))
 
@@ -3667,7 +3667,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "a"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				slicemsg( // proactive unsubscribe before user unsubscribe
@@ -3675,7 +3675,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						strmsg('+', "b"),
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 			}, {
@@ -3686,7 +3686,7 @@ func TestPubSub(t *testing.T) {
 					[]RedisMessage{
 						strmsg('+', "sunsubscribe"),
 						{typ: '_'},
-						{typ: ':', integer: 0},
+						{typ: ':', intlen: 0},
 					},
 				),
 				strmsg('+', "mk"),
@@ -3701,7 +3701,7 @@ func TestPubSub(t *testing.T) {
 			[]RedisMessage{
 				strmsg('+', "sunsubscribe"),
 				strmsg('+', "0"),
-				{typ: ':', integer: 0},
+				{typ: ':', intlen: 0},
 			},
 		))
 
@@ -3929,12 +3929,12 @@ func TestPubSubHooks(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "subscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "psubscribe"),
 					strmsg('+', "2"),
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "message"),
@@ -3952,13 +3952,13 @@ func TestPubSubHooks(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "unsubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				strmsg('+', "PONG"),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "punsubscribe"),
 					strmsg('+', "2"),
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2},
 				}),
 				strmsg('+', "PONG"),
 			)
@@ -4018,12 +4018,12 @@ func TestPubSubHooks(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "subscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "psubscribe"),
 					strmsg('+', "2"),
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2},
 				}),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "message"),
@@ -4041,13 +4041,13 @@ func TestPubSubHooks(t *testing.T) {
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "unsubscribe"),
 					strmsg('+', "1"),
-					{typ: ':', integer: 1},
+					{typ: ':', intlen: 1},
 				}),
 				strmsg('+', "PONG"),
 				slicemsg('>', []RedisMessage{
 					strmsg('+', "punsubscribe"),
 					strmsg('+', "2"),
-					{typ: ':', integer: 2},
+					{typ: ':', intlen: 2},
 				}),
 				strmsg('+', "PONG"),
 			)
@@ -5088,13 +5088,13 @@ func TestPipe_CleanSubscriptions_6(t *testing.T) {
 		slicemsg('>', []RedisMessage{
 			strmsg('+', "unsubscribe"),
 			{typ: '_'},
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		}),
 		strmsg('+', "PONG"),
 		slicemsg('>', []RedisMessage{
 			strmsg('+', "punsubscribe"),
 			{typ: '_'},
-			{typ: ':', integer: 2},
+			{typ: ':', intlen: 2},
 		}),
 		strmsg('+', "PONG"),
 		strmsg('+', "OK"),
@@ -5131,19 +5131,19 @@ func TestPipe_CleanSubscriptions_7(t *testing.T) {
 		slicemsg('>', []RedisMessage{
 			strmsg('+', "unsubscribe"),
 			{typ: '_'},
-			{typ: ':', integer: 1},
+			{typ: ':', intlen: 1},
 		}),
 		strmsg('+', "PONG"),
 		slicemsg('>', []RedisMessage{
 			strmsg('+', "punsubscribe"),
 			{typ: '_'},
-			{typ: ':', integer: 2},
+			{typ: ':', intlen: 2},
 		}),
 		strmsg('+', "PONG"),
 		slicemsg('>', []RedisMessage{
 			strmsg('+', "sunsubscribe"),
 			{typ: '_'},
-			{typ: ':', integer: 3},
+			{typ: ':', intlen: 3},
 		}),
 		strmsg('+', "PONG"),
 		strmsg('+', "OK"),

--- a/redis_test.go
+++ b/redis_test.go
@@ -620,8 +620,8 @@ func testMultiExec(t *testing.T, client Client) {
 			if err != nil {
 				t.Fatalf("unexpected exec response %v", err)
 			}
-			if resps[1].integer != v {
-				t.Fatalf("unexpected ttl response %v %v", v, resps[1].integer)
+			if resps[1].intlen != v {
+				t.Fatalf("unexpected ttl response %v %v", v, resps[1].intlen)
 			}
 			if resps[2].string() != strconv.FormatInt(v, 10) {
 				t.Fatalf("unexpected get response %v %v", v, resps[2].string())

--- a/redis_test.go
+++ b/redis_test.go
@@ -532,7 +532,7 @@ func testMultiSETGETHelpers(t *testing.T, client Client, csc bool) {
 				t.Fatalf("unexpected result %v not found\n", key)
 			}
 			if exp, ok := kvs[key]; ok {
-				if exp != ret.string {
+				if exp != ret.string() {
 					t.Fatalf("unexpected result %v wrong value %v\n", key, exp)
 				}
 			} else {
@@ -623,8 +623,8 @@ func testMultiExec(t *testing.T, client Client) {
 			if resps[1].integer != v {
 				t.Fatalf("unexpected ttl response %v %v", v, resps[1].integer)
 			}
-			if resps[2].string != strconv.FormatInt(v, 10) {
-				t.Fatalf("unexpected get response %v %v", v, resps[2].string)
+			if resps[2].string() != strconv.FormatInt(v, 10) {
+				t.Fatalf("unexpected get response %v %v", v, resps[2].string())
 			}
 		}
 	}

--- a/resp.go
+++ b/resp.go
@@ -95,9 +95,8 @@ func readBlobString(i *bufio.Reader) (m RedisMessage, err error) {
 				return RedisMessage{}, err
 			}
 			if length == 0 {
-				var ret RedisMessage
-				ret.setString(sb.String())
-				return ret, nil
+				m.setString(sb.String())
+				return m, nil
 			}
 			sb.Grow(int(length))
 			if _, err = io.CopyN(&sb, i, length); err != nil {

--- a/resp.go
+++ b/resp.go
@@ -224,17 +224,15 @@ func readB(i *bufio.Reader) (*byte, int64, error) {
 
 func readE(i *bufio.Reader) (*RedisMessage, int64, error) {
 	v := make([]RedisMessage, 0)
-	length := 0
 	for {
 		n, err := readNextMessage(i)
 		if err != nil {
 			return nil, 0, err
 		}
 		if n.typ == '.' {
-			return unsafe.SliceData(v), int64(length), err
+			return unsafe.SliceData(v), int64(len(v)), err
 		}
 		v = append(v, n)
-		length++
 	}
 }
 

--- a/resp_test.go
+++ b/resp_test.go
@@ -134,15 +134,15 @@ func TestWriteCmdAndRead(t *testing.T) {
 			t.Fatalf("unexpected err %v", err)
 		} else if m.typ != '*' {
 			t.Fatalf("unexpected m.typ: expected *, got %v", m.typ)
-		} else if len(m.values) != len(cmd) {
-			t.Fatalf("unexpected m.values: expected %v, got %v", len(cmd), len(m.values))
+		} else if len(m.values()) != len(cmd) {
+			t.Fatalf("unexpected m.values: expected %v, got %v", len(cmd), len(m.values()))
 		} else {
-			for i, v := range m.values {
+			for i, v := range m.values() {
 				if v.typ != '$' {
 					t.Fatalf("unexpected v.values: expected $, got %v", v.typ)
 				}
-				if v.string != cmd[i] {
-					t.Fatalf("unexpected v.string\n expected %v \n got %v", cmd[i], v.string)
+				if v.string() != cmd[i] {
+					t.Fatalf("unexpected v.string\n expected %v \n got %v", cmd[i], v.string())
 				}
 			}
 		}
@@ -199,8 +199,8 @@ func TestReadString(t *testing.T) {
 			if m.typ != '+' {
 				t.Fatalf("unexpected msg type %v", m.typ)
 			}
-			if m.string != "Hello word" {
-				t.Fatalf("unexpected msg string %v", m.string)
+			if m.string() != "Hello word" {
+				t.Fatalf("unexpected msg string %v", m.string())
 			}
 		}
 	}
@@ -363,8 +363,8 @@ func TestReadChunkedString(t *testing.T) {
 			if m.typ != '$' {
 				t.Fatalf("unexpected msg type %v", m.typ)
 			}
-			if m.string != "Hello word" {
-				t.Fatalf("unexpected msg string %v", m.string)
+			if m.string() != "Hello word" {
+				t.Fatalf("unexpected msg string %v", m.string())
 			}
 		}
 	}
@@ -412,12 +412,12 @@ func TestReadChunkedArray(t *testing.T) {
 			if m.typ != '*' {
 				t.Fatalf("unexpected msg type %v", m.typ)
 			}
-			if len(m.values) != 3 {
-				t.Fatalf("unexpected msg values length %v", len(m.values))
+			if len(m.values()) != 3 {
+				t.Fatalf("unexpected msg values length %v", len(m.values()))
 			}
-			for i, v := range m.values {
+			for i, v := range m.values() {
 				if v.typ != ':' || v.integer != int64(i+1) {
-					t.Fatalf("unexpected msg values %v", m.values)
+					t.Fatalf("unexpected msg values %v", m.values())
 				}
 			}
 		}
@@ -440,12 +440,12 @@ func TestReadChunkedMap(t *testing.T) {
 			if m.typ != '%' {
 				t.Fatalf("unexpected msg type %v", m.typ)
 			}
-			if len(m.values) != 4 {
-				t.Fatalf("unexpected msg values length %v", len(m.values))
+			if len(m.values()) != 4 {
+				t.Fatalf("unexpected msg values length %v", len(m.values()))
 			}
-			for i, v := range m.values {
+			for i, v := range m.values() {
 				if v.typ != ':' || v.integer != int64(i+1) {
-					t.Fatalf("unexpected msg values %v", m.values)
+					t.Fatalf("unexpected msg values %v", m.values())
 				}
 			}
 		}
@@ -469,21 +469,21 @@ func TestReadAttr(t *testing.T) {
 			if m.typ != '*' {
 				t.Fatalf("unexpected msg type %v", m.typ)
 			}
-			if m.values[0].integer != 2039123 {
-				t.Fatalf("unexpected msg values[0] %v", m.values[0])
+			if m.values()[0].integer != 2039123 {
+				t.Fatalf("unexpected msg values[0] %v", m.values()[0])
 			}
-			if m.values[1].integer != 9543892 {
-				t.Fatalf("unexpected msg values[0] %v", m.values[1])
+			if m.values()[1].integer != 9543892 {
+				t.Fatalf("unexpected msg values[0] %v", m.values()[1])
 			}
-			if !reflect.DeepEqual(*m.attrs, RedisMessage{typ: '|', values: []RedisMessage{
-				{typ: '+', string: "key-popularity"},
-				{typ: '%', values: []RedisMessage{
-					{typ: '$', string: "a"},
-					{typ: ',', string: "0.1923"},
-					{typ: '$', string: "b"},
-					{typ: ',', string: "0.0012"},
-				}},
-			}}) {
+			if !reflect.DeepEqual(*m.attrs, redisMessageContainSlice('|', []RedisMessage{
+				redisMessageContainString('+', "key-popularity"),
+				redisMessageContainSlice('%', []RedisMessage{
+					redisMessageContainString('$', "a"),
+					redisMessageContainString(',', "0.1923"),
+					redisMessageContainString('$', "b"),
+					redisMessageContainString(',', "0.0012"),
+				}),
+			})) {
 				t.Fatalf("unexpected msg attr %v", m.attrs)
 			}
 		}
@@ -571,14 +571,14 @@ func TestReadRESP2NullStringInArray(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(m, RedisMessage{
-				typ: '*',
-				values: []RedisMessage{
-					{typ: '$', string: "hello"},
+			if !reflect.DeepEqual(m, redisMessageContainSlice(
+				'*',
+				[]RedisMessage{
+					redisMessageContainString('$', "hello"),
 					{typ: '_'},
-					{typ: '$', string: "world"},
+					redisMessageContainString('$', "world"),
 				},
-			}) {
+			)) {
 				t.Fatalf("unexpected msg %v", m)
 			}
 		}

--- a/resp_test.go
+++ b/resp_test.go
@@ -475,13 +475,13 @@ func TestReadAttr(t *testing.T) {
 			if m.values()[1].integer != 9543892 {
 				t.Fatalf("unexpected msg values[0] %v", m.values()[1])
 			}
-			if !reflect.DeepEqual(*m.attrs, redisMessageContainSlice('|', []RedisMessage{
-				redisMessageContainString('+', "key-popularity"),
-				redisMessageContainSlice('%', []RedisMessage{
-					redisMessageContainString('$', "a"),
-					redisMessageContainString(',', "0.1923"),
-					redisMessageContainString('$', "b"),
-					redisMessageContainString(',', "0.0012"),
+			if !reflect.DeepEqual(*m.attrs, slicemsg('|', []RedisMessage{
+				strmsg('+', "key-popularity"),
+				slicemsg('%', []RedisMessage{
+					strmsg('$', "a"),
+					strmsg(',', "0.1923"),
+					strmsg('$', "b"),
+					strmsg(',', "0.0012"),
 				}),
 			})) {
 				t.Fatalf("unexpected msg attr %v", m.attrs)
@@ -571,12 +571,12 @@ func TestReadRESP2NullStringInArray(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(m, redisMessageContainSlice(
+			if !reflect.DeepEqual(m, slicemsg(
 				'*',
 				[]RedisMessage{
-					redisMessageContainString('$', "hello"),
+					strmsg('$', "hello"),
 					{typ: '_'},
-					redisMessageContainString('$', "world"),
+					strmsg('$', "world"),
 				},
 			)) {
 				t.Fatalf("unexpected msg %v", m)

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -55,7 +55,7 @@ func accept(t *testing.T, ln net.Listener) (*redisMock, error) {
 			'%',
 			[]RedisMessage{
 				strmsg('+', "proto"),
-				{typ: ':', integer: 3},
+				{typ: ':', intlen: 3},
 			},
 		))
 	mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -51,13 +51,13 @@ func accept(t *testing.T, ln net.Listener) (*redisMock, error) {
 		conn: conn,
 	}
 	mock.Expect("HELLO", "3").
-		Reply(RedisMessage{
-			typ: '%',
-			values: []RedisMessage{
-				{typ: '+', string: "proto"},
+		Reply(redisMessageContainSlice(
+			'%',
+			[]RedisMessage{
+				redisMessageContainString('+', "proto"),
 				{typ: ':', integer: 3},
 			},
-		})
+		))
 	mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
 		ReplyString("OK")
 	return mock, nil
@@ -118,7 +118,7 @@ func TestNewClusterClientError(t *testing.T) {
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 				ReplyError("UNKNOWN COMMAND")
-			mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "other error"})
+			mock.Expect("CLUSTER", "SLOTS").Reply(redisMessageContainString('-', "other error"))
 			mock.Expect("PING").ReplyString("OK")
 			mock.Close()
 			close(done)
@@ -222,7 +222,7 @@ func TestFallBackSingleClient(t *testing.T) {
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 			ReplyError("UNKNOWN COMMAND")
-		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "ERR This instance has cluster support disabled"})
+		mock.Expect("CLUSTER", "SLOTS").Reply(redisMessageContainString('-', "ERR This instance has cluster support disabled"))
 		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)
@@ -341,7 +341,7 @@ func TestTLSClient(t *testing.T) {
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 			ReplyError("UNKNOWN COMMAND")
-		mock.Expect("CLUSTER", "SLOTS").Reply(RedisMessage{typ: '-', string: "ERR This instance has cluster support disabled"})
+		mock.Expect("CLUSTER", "SLOTS").Reply(redisMessageContainString('-', "ERR This instance has cluster support disabled"))
 		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -51,10 +51,10 @@ func accept(t *testing.T, ln net.Listener) (*redisMock, error) {
 		conn: conn,
 	}
 	mock.Expect("HELLO", "3").
-		Reply(redisMessageContainSlice(
+		Reply(slicemsg(
 			'%',
 			[]RedisMessage{
-				redisMessageContainString('+', "proto"),
+				strmsg('+', "proto"),
 				{typ: ':', integer: 3},
 			},
 		))
@@ -118,7 +118,7 @@ func TestNewClusterClientError(t *testing.T) {
 				ReplyError("UNKNOWN COMMAND")
 			mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 				ReplyError("UNKNOWN COMMAND")
-			mock.Expect("CLUSTER", "SLOTS").Reply(redisMessageContainString('-', "other error"))
+			mock.Expect("CLUSTER", "SLOTS").Reply(strmsg('-', "other error"))
 			mock.Expect("PING").ReplyString("OK")
 			mock.Close()
 			close(done)
@@ -222,7 +222,7 @@ func TestFallBackSingleClient(t *testing.T) {
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 			ReplyError("UNKNOWN COMMAND")
-		mock.Expect("CLUSTER", "SLOTS").Reply(redisMessageContainString('-', "ERR This instance has cluster support disabled"))
+		mock.Expect("CLUSTER", "SLOTS").Reply(strmsg('-', "ERR This instance has cluster support disabled"))
 		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)
@@ -341,7 +341,7 @@ func TestTLSClient(t *testing.T) {
 			ReplyError("UNKNOWN COMMAND")
 		mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
 			ReplyError("UNKNOWN COMMAND")
-		mock.Expect("CLUSTER", "SLOTS").Reply(redisMessageContainString('-', "ERR This instance has cluster support disabled"))
+		mock.Expect("CLUSTER", "SLOTS").Reply(strmsg('-', "ERR This instance has cluster support disabled"))
 		mock.Expect("PING").ReplyString("OK")
 		mock.Close()
 		close(done)

--- a/sentinel.go
+++ b/sentinel.go
@@ -292,10 +292,10 @@ func (c *sentinelClient) _switchTarget(addr string) (err error) {
 		return err
 	}
 
-	if c.replica && resp[0].string != "slave" {
+	if c.replica && resp[0].string() != "slave" {
 		target.Close()
 		return errNotSlave
-	} else if !c.replica && resp[0].string != "master" {
+	} else if !c.replica && resp[0].string() != "master" {
 		target.Close()
 		return errNotMaster
 	}

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -66,10 +66,10 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
 					newErrResult(v),
@@ -80,14 +80,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "3"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "3"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "5"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "5"),
 					})},
 				}}
 			},
@@ -96,14 +96,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "4"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "6"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "6"),
 					})},
 				}}
 			},
@@ -112,14 +112,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "2"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "7"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "7"),
 					})},
 				}}
 			},
@@ -150,14 +150,14 @@ func TestSentinelClientInit(t *testing.T) {
 				if dst == ":6" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
+							return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "slave")})}
 						},
 					}
 				}
 				if dst == ":7" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+							return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 						},
 					}
 				}
@@ -192,10 +192,10 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
 					newErrResult(v),
@@ -206,16 +206,16 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "3"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "3"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "6"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "6"),
 						}),
 					})},
 				}}
@@ -228,29 +228,29 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "4"),
 						}),
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "32"),
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "32"),
 						}),
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "31"),
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "31"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "6"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "6"),
 						}),
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "8"),
-							redisMessageContainString('+', "s-down-time"), redisMessageContainString('+', "1"),
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "8"),
+							strmsg('+', "s-down-time"), strmsg('+', "1"),
 						}),
 					})},
 				}}
@@ -260,17 +260,17 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "32"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "32"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "8"),
-							redisMessageContainString('+', "s-down-time"), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "8"),
+							strmsg('+', "s-down-time"), strmsg('+', "1"),
 						}),
 					})},
 				}}
@@ -281,13 +281,13 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "4"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
+					{val: slicemsg('*', []RedisMessage{
 						RedisMessage(*Nil),
 					})},
 				}}
@@ -297,16 +297,16 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "5"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "5"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "7"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "7"),
 						}),
 					})},
 				}}
@@ -316,16 +316,16 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "2"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "8"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "8"),
 						}),
 					})},
 				}}
@@ -369,14 +369,14 @@ func TestSentinelClientInit(t *testing.T) {
 				if dst == ":7" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+							return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 						},
 					}
 				}
 				if dst == ":8" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
+							return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "slave")})}
 						},
 					}
 				}
@@ -406,14 +406,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "1"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "2"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "2"),
 					})},
 				}}
 			},
@@ -422,14 +422,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "3"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "3"),
 					})},
 				}}
 			},
@@ -451,7 +451,7 @@ func TestSentinelClientInit(t *testing.T) {
 				if dst == ":3" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+							return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 						},
 					}
 				}
@@ -485,14 +485,14 @@ func TestSentinelClientInit(t *testing.T) {
 			},
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "1"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "3"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "3"),
 					})},
 				}}
 			},
@@ -510,14 +510,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "2"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "3"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "3"),
 					})},
 				}}
 			},
@@ -526,14 +526,14 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "0"),
 						}),
 					})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "4"),
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "4"),
 					})},
 				}}
 			},
@@ -543,7 +543,7 @@ func TestSentinelClientInit(t *testing.T) {
 				if atomic.LoadInt32(&disconnect) == 1 {
 					return newErrResult(errors.New("die"))
 				}
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			},
 			CloseFn: func() {
 				atomic.StoreInt32(&r3closed, 1)
@@ -557,7 +557,7 @@ func TestSentinelClientInit(t *testing.T) {
 		}
 		r4 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			},
 		}
 		client, err := newSentinelClient(
@@ -613,9 +613,9 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 			if first {
 				first = true
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "1"),
 					})},
 				}}
 			}
@@ -624,7 +624,7 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 	}
 	m := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+			return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 		},
 	}
 	client, err := newSentinelClient(
@@ -656,9 +656,9 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			return &redisresults{s: []RedisResult{
-				{val: redisMessageContainSlice('*', []RedisMessage{})},
-				{val: redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+				{val: slicemsg('*', []RedisMessage{})},
+				{val: slicemsg('*', []RedisMessage{
+					strmsg('+', ""), strmsg('+', "1"),
 				})},
 			}}
 		},
@@ -667,7 +667,7 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 		DoFn: func(cmd Completed) RedisResult {
 			if first {
 				first = false
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			}
 			return newErrResult(ErrClosing)
 		},
@@ -701,16 +701,16 @@ func TestSentinelClientDelegate(t *testing.T) {
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			return &redisresults{s: []RedisResult{
-				{val: redisMessageContainSlice('*', []RedisMessage{})},
-				{val: redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+				{val: slicemsg('*', []RedisMessage{})},
+				{val: slicemsg('*', []RedisMessage{
+					strmsg('+', ""), strmsg('+', "1"),
 				})},
 			}}
 		},
 	}
 	m := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+			return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 		},
 		AddrFn: func() string { return ":1" },
 	}
@@ -759,7 +759,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
 			return &redisresults{s: []RedisResult{
-				newResult(redisMessageContainString('+', "master"), nil),
+				newResult(strmsg('+', "master"), nil),
 			}}
 		}
 
@@ -769,7 +769,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 		}
 
 		expected := map[string]RedisMessage{
-			"key1": redisMessageContainString('+', "master"),
+			"key1": strmsg('+', "master"),
 		}
 		if !reflect.DeepEqual(ret, expected) {
 			t.Fatalf("unexpected result %v, expected %v", ret, expected)
@@ -794,7 +794,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(redisMessageContainString('+', "Do"), nil)
+			return newResult(strmsg('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -817,7 +817,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Do"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -846,7 +846,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(redisMessageContainString('+', "DoCache"), nil)
+			return newResult(strmsg('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -859,7 +859,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "DoCache"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -915,10 +915,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicated Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -964,10 +964,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicate Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(redisMessageContainString('+', "Delegate"), nil)
+				return newResult(strmsg('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1019,16 +1019,16 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				if atomic.LoadUint32(&retry) == 0 {
 					return &redisresults{s: []RedisResult{
-						{val: redisMessageContainSlice('*', []RedisMessage{})},
-						{val: redisMessageContainSlice('*', []RedisMessage{
-							redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+						{val: slicemsg('*', []RedisMessage{})},
+						{val: slicemsg('*', []RedisMessage{
+							strmsg('+', ""), strmsg('+', "1"),
 						})},
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "2"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "2"),
 					})},
 				}}
 			},
@@ -1045,7 +1045,7 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 		m1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
 				if cmd == cmds.RoleCmd {
-					return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+					return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 				}
 				atomic.AddUint32(&retry, 1)
 				return newErrResult(ErrClosing)
@@ -1066,15 +1066,15 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 		m2 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
 				if cmd == cmds.RoleCmd {
-					return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+					return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 				}
-				return RedisResult{val: redisMessageContainString('+', "OK")}
+				return RedisResult{val: strmsg('+', "OK")}
 			},
 			DoMultiFn: func(multi ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{{val: redisMessageContainString('+', "OK")}}}
+				return &redisresults{s: []RedisResult{{val: strmsg('+', "OK")}}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return RedisResult{val: redisMessageContainString('+', "OK")}
+				return RedisResult{val: strmsg('+', "OK")}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return nil
@@ -1184,16 +1184,16 @@ func TestSentinelClientPubSub(t *testing.T) {
 			count := atomic.AddInt32(&s0count, 1)
 			if (count-1)%2 == 0 {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "1"),
 					})},
 				}}
 			}
 			return &redisresults{s: []RedisResult{
-				{val: redisMessageContainSlice('*', []RedisMessage{})},
-				{val: redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', ""), redisMessageContainString('+', "2"),
+				{val: slicemsg('*', []RedisMessage{})},
+				{val: slicemsg('*', []RedisMessage{
+					strmsg('+', ""), strmsg('+', "2"),
 				})},
 			}}
 		},
@@ -1208,9 +1208,9 @@ func TestSentinelClientPubSub(t *testing.T) {
 	m1 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			}
-			return RedisResult{val: redisMessageContainString('+', "OK")}
+			return RedisResult{val: strmsg('+', "OK")}
 		},
 		CloseFn: func() {
 			atomic.AddInt32(&m1close, 1)
@@ -1218,7 +1218,7 @@ func TestSentinelClientPubSub(t *testing.T) {
 	}
 	m2 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
+			return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "slave")})}
 		},
 		CloseFn: func() { atomic.AddInt32(&m2close, 1) },
 	}
@@ -1228,9 +1228,9 @@ func TestSentinelClientPubSub(t *testing.T) {
 	m4 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			}
-			return RedisResult{val: redisMessageContainString('+', "OK4")}
+			return RedisResult{val: strmsg('+', "OK4")}
 		},
 		CloseFn: func() { atomic.AddInt32(&m4close, 1) },
 	}
@@ -1335,31 +1335,31 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 			remainder := (count - 1) % 3
 			if remainder == 0 {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "1"),
 						}),
 					})},
 				}}
 			} else if remainder == 1 {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "2"),
 						}),
 					})},
 				}}
 			} else {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainSlice('%', []RedisMessage{
-							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
-							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						slicemsg('%', []RedisMessage{
+							strmsg('+', "ip"), strmsg('+', ""),
+							strmsg('+', "port"), strmsg('+', "4"),
 						}),
 					})},
 				}}
@@ -1376,9 +1376,9 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	slave1 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "slave")})}
 			}
-			return RedisResult{val: redisMessageContainString('+', "OK")}
+			return RedisResult{val: strmsg('+', "OK")}
 		},
 		CloseFn: func() {
 			atomic.AddInt32(&slave1close, 1)
@@ -1386,7 +1386,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	}
 	slave2 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+			return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 		},
 		CloseFn: func() { atomic.AddInt32(&slave2close, 1) },
 	}
@@ -1396,9 +1396,9 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	slave4 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "slave")})}
 			}
-			return RedisResult{val: redisMessageContainString('+', "OK4")}
+			return RedisResult{val: strmsg('+', "OK4")}
 		},
 		CloseFn: func() { atomic.AddInt32(&slave4close, 1) },
 	}
@@ -1518,15 +1518,15 @@ func TestSentinelClientRetry(t *testing.T) {
 	SetupClientRetry(t, func(m *mockConn) Client {
 		m.DoOverride = map[string]func(cmd Completed) RedisResult{
 			"SENTINEL SENTINELS masters": func(cmd Completed) RedisResult {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{})}
 			},
 			"SENTINEL GET-MASTER-ADDR-BY-NAME masters": func(cmd Completed) RedisResult {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
-					redisMessageContainString('+', ""), redisMessageContainString('+', "5"),
+				return RedisResult{val: slicemsg('*', []RedisMessage{
+					strmsg('+', ""), strmsg('+', "5"),
 				})}
 			},
 			"ROLE": func(cmd Completed) RedisResult {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			},
 		}
 		m.ReceiveOverride = map[string]func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error{
@@ -1559,9 +1559,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: redisMessageContainSlice('*', []RedisMessage{})},
-					{val: redisMessageContainSlice('*', []RedisMessage{
-						redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+					{val: slicemsg('*', []RedisMessage{})},
+					{val: slicemsg('*', []RedisMessage{
+						strmsg('+', ""), strmsg('+', "1"),
 					})},
 				}}
 			},
@@ -1569,7 +1569,7 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
 				if cmd == cmds.RoleCmd {
-					return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+					return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 				}
 				return RedisResult{}
 			},
@@ -1598,13 +1598,13 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		attempts := 0
 		m1.DoFn = func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1620,13 +1620,13 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		attempts := 0
 		m1.DoFn = func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "ERR some other error"), nil)
+				return newResult(strmsg('-', "ERR some other error"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1643,9 +1643,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1664,9 +1664,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1681,9 +1681,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1701,13 +1701,13 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		attempts := 0
 		m1.DoFn = func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
+				return newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(redisMessageContainString('+', "OK"), nil)
+			return newResult(strmsg('+', "OK"), nil)
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoFn: m1.DoFn} }
 
@@ -1728,9 +1728,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
+				return &redisresults{s: []RedisResult{newResult(strmsg('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoMultiFn: m1.DoMultiFn} }
 

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -66,12 +66,12 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "0"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+						}),
+					})},
 					newErrResult(v),
 				}}
 			},
@@ -80,15 +80,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "3"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "5"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "3"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "5"),
+					})},
 				}}
 			},
 		}
@@ -96,15 +96,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "4"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "6"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "6"),
+					})},
 				}}
 			},
 		}
@@ -112,15 +112,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "2"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "7"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "7"),
+					})},
 				}}
 			},
 		}
@@ -150,14 +150,14 @@ func TestSentinelClientInit(t *testing.T) {
 				if dst == ":6" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "slave"}}}}
+							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
 						},
 					}
 				}
 				if dst == ":7" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 						},
 					}
 				}
@@ -192,12 +192,12 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "0"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+						}),
+					})},
 					newErrResult(v),
 				}}
 			},
@@ -206,18 +206,18 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "3"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "6"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "3"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "6"),
+						}),
+					})},
 				}}
 			},
 		}
@@ -228,31 +228,31 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "4"},
-						}},
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "32"},
-						}},
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "31"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "6"},
-						}},
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "8"},
-							{typ: '+', string: "s-down-time"}, {typ: '+', string: "1"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+						}),
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "32"),
+						}),
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "31"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "6"),
+						}),
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "8"),
+							redisMessageContainString('+', "s-down-time"), redisMessageContainString('+', "1"),
+						}),
+					})},
 				}}
 			},
 		}
@@ -260,19 +260,19 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "32"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "8"},
-							{typ: '+', string: "s-down-time"}, {typ: '+', string: "1"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "32"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "8"),
+							redisMessageContainString('+', "s-down-time"), redisMessageContainString('+', "1"),
+						}),
+					})},
 				}}
 			},
 		}
@@ -281,15 +281,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "4"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
 						RedisMessage(*Nil),
-					}}},
+					})},
 				}}
 			},
 		}
@@ -297,18 +297,18 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "5"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "7"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "5"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "7"),
+						}),
+					})},
 				}}
 			},
 		}
@@ -316,18 +316,18 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "2"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "8"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "8"),
+						}),
+					})},
 				}}
 			},
 		}
@@ -369,14 +369,14 @@ func TestSentinelClientInit(t *testing.T) {
 				if dst == ":7" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 						},
 					}
 				}
 				if dst == ":8" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "slave"}}}}
+							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
 						},
 					}
 				}
@@ -406,15 +406,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "1"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "2"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "1"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "2"),
+					})},
 				}}
 			},
 		}
@@ -422,15 +422,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "0"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "3"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "3"),
+					})},
 				}}
 			},
 		}
@@ -451,7 +451,7 @@ func TestSentinelClientInit(t *testing.T) {
 				if dst == ":3" {
 					return &mockConn{
 						DoFn: func(cmd Completed) RedisResult {
-							return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+							return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 						},
 					}
 				}
@@ -485,15 +485,15 @@ func TestSentinelClientInit(t *testing.T) {
 			},
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "1"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "3"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "1"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "3"),
+					})},
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -510,15 +510,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "2"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "3"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "3"),
+					})},
 				}}
 			},
 		}
@@ -526,15 +526,15 @@ func TestSentinelClientInit(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "0"},
-						}},
-					}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "4"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "0"),
+						}),
+					})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "4"),
+					})},
 				}}
 			},
 		}
@@ -543,7 +543,7 @@ func TestSentinelClientInit(t *testing.T) {
 				if atomic.LoadInt32(&disconnect) == 1 {
 					return newErrResult(errors.New("die"))
 				}
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			},
 			CloseFn: func() {
 				atomic.StoreInt32(&r3closed, 1)
@@ -557,7 +557,7 @@ func TestSentinelClientInit(t *testing.T) {
 		}
 		r4 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			},
 		}
 		client, err := newSentinelClient(
@@ -613,10 +613,10 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 			if first {
 				first = true
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "1"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+					})},
 				}}
 			}
 			return &redisresults{s: []RedisResult{newErrResult(ErrClosing), newErrResult(ErrClosing)}}
@@ -624,7 +624,7 @@ func TestSentinelRefreshAfterClose(t *testing.T) {
 	}
 	m := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 		},
 	}
 	client, err := newSentinelClient(
@@ -656,10 +656,10 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			return &redisresults{s: []RedisResult{
-				{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-				{val: RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '+', string: ""}, {typ: '+', string: "1"},
-				}}},
+				{val: redisMessageContainSlice('*', []RedisMessage{})},
+				{val: redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+				})},
 			}}
 		},
 	}
@@ -667,7 +667,7 @@ func TestSentinelSwitchAfterClose(t *testing.T) {
 		DoFn: func(cmd Completed) RedisResult {
 			if first {
 				first = false
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			}
 			return newErrResult(ErrClosing)
 		},
@@ -701,16 +701,16 @@ func TestSentinelClientDelegate(t *testing.T) {
 		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 		DoMultiFn: func(multi ...Completed) *redisresults {
 			return &redisresults{s: []RedisResult{
-				{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-				{val: RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '+', string: ""}, {typ: '+', string: "1"},
-				}}},
+				{val: redisMessageContainSlice('*', []RedisMessage{})},
+				{val: redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+				})},
 			}}
 		},
 	}
 	m := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 		},
 		AddrFn: func() string { return ":1" },
 	}
@@ -759,7 +759,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
 			return &redisresults{s: []RedisResult{
-				newResult(RedisMessage{typ: '+', string: "master"}, nil),
+				newResult(redisMessageContainString('+', "master"), nil),
 			}}
 		}
 
@@ -769,7 +769,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 		}
 
 		expected := map[string]RedisMessage{
-			"key1": {typ: '+', string: "master"},
+			"key1": redisMessageContainString('+', "master"),
 		}
 		if !reflect.DeepEqual(ret, expected) {
 			t.Fatalf("unexpected result %v, expected %v", ret, expected)
@@ -794,7 +794,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return newResult(RedisMessage{typ: '+', string: "Do"}, nil)
+			return newResult(redisMessageContainString('+', "Do"), nil)
 		}
 		if v, err := client.Do(context.Background(), c).ToString(); err != nil || v != "Do" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -817,7 +817,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd[0].Commands(), c.Commands()) {
 				t.Fatalf("unexpected command %v", cmd)
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Do"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Do"), nil)}}
 		}
 		if len(client.DoMulti(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -846,7 +846,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(cmd.Commands(), c.Commands()) || ttl != 100 {
 				t.Fatalf("unexpected command %v, %v", cmd, ttl)
 			}
-			return newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)
+			return newResult(redisMessageContainString('+', "DoCache"), nil)
 		}
 		if v, err := client.DoCache(context.Background(), c, 100).ToString(); err != nil || v != "DoCache" {
 			t.Fatalf("unexpected response %v %v", v, err)
@@ -859,7 +859,7 @@ func TestSentinelClientDelegate(t *testing.T) {
 			if !reflect.DeepEqual(multi[0].Cmd.Commands(), c.Commands()) || multi[0].TTL != 100 {
 				t.Fatalf("unexpected command %v, %v", multi[0].Cmd, multi[0].TTL)
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "DoCache"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "DoCache"), nil)}}
 		}
 		if len(client.DoMultiCache(context.Background())) != 0 {
 			t.Fatalf("unexpected response length")
@@ -915,10 +915,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicated Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -964,10 +964,10 @@ func TestSentinelClientDelegate(t *testing.T) {
 	t.Run("Dedicate Delegate", func(t *testing.T) {
 		w := &mockWire{
 			DoFn: func(cmd Completed) RedisResult {
-				return newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)
+				return newResult(redisMessageContainString('+', "Delegate"), nil)
 			},
 			DoMultiFn: func(cmd ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "Delegate"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "Delegate"), nil)}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return ErrClosing
@@ -1019,17 +1019,17 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				if atomic.LoadUint32(&retry) == 0 {
 					return &redisresults{s: []RedisResult{
-						{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-						{val: RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: ""}, {typ: '+', string: "1"},
-						}}},
+						{val: redisMessageContainSlice('*', []RedisMessage{})},
+						{val: redisMessageContainSlice('*', []RedisMessage{
+							redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+						})},
 					}}
 				}
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "2"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "2"),
+					})},
 				}}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -1045,7 +1045,7 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 		m1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
 				if cmd == cmds.RoleCmd {
-					return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+					return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 				}
 				atomic.AddUint32(&retry, 1)
 				return newErrResult(ErrClosing)
@@ -1066,15 +1066,15 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 		m2 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
 				if cmd == cmds.RoleCmd {
-					return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+					return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 				}
-				return RedisResult{val: RedisMessage{typ: '+', string: "OK"}}
+				return RedisResult{val: redisMessageContainString('+', "OK")}
 			},
 			DoMultiFn: func(multi ...Completed) *redisresults {
-				return &redisresults{s: []RedisResult{{val: RedisMessage{typ: '+', string: "OK"}}}}
+				return &redisresults{s: []RedisResult{{val: redisMessageContainString('+', "OK")}}}
 			},
 			DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
-				return RedisResult{val: RedisMessage{typ: '+', string: "OK"}}
+				return RedisResult{val: redisMessageContainString('+', "OK")}
 			},
 			ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
 				return nil
@@ -1184,17 +1184,17 @@ func TestSentinelClientPubSub(t *testing.T) {
 			count := atomic.AddInt32(&s0count, 1)
 			if (count-1)%2 == 0 {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "1"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+					})},
 				}}
 			}
 			return &redisresults{s: []RedisResult{
-				{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-				{val: RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '+', string: ""}, {typ: '+', string: "2"},
-				}}},
+				{val: redisMessageContainSlice('*', []RedisMessage{})},
+				{val: redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', ""), redisMessageContainString('+', "2"),
+				})},
 			}}
 		},
 		ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
@@ -1208,9 +1208,9 @@ func TestSentinelClientPubSub(t *testing.T) {
 	m1 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			}
-			return RedisResult{val: RedisMessage{typ: '+', string: "OK"}}
+			return RedisResult{val: redisMessageContainString('+', "OK")}
 		},
 		CloseFn: func() {
 			atomic.AddInt32(&m1close, 1)
@@ -1218,7 +1218,7 @@ func TestSentinelClientPubSub(t *testing.T) {
 	}
 	m2 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "slave"}}}}
+			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
 		},
 		CloseFn: func() { atomic.AddInt32(&m2close, 1) },
 	}
@@ -1228,9 +1228,9 @@ func TestSentinelClientPubSub(t *testing.T) {
 	m4 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			}
-			return RedisResult{val: RedisMessage{typ: '+', string: "OK4"}}
+			return RedisResult{val: redisMessageContainString('+', "OK4")}
 		},
 		CloseFn: func() { atomic.AddInt32(&m4close, 1) },
 	}
@@ -1335,33 +1335,33 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 			remainder := (count - 1) % 3
 			if remainder == 0 {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "1"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "1"),
+						}),
+					})},
 				}}
 			} else if remainder == 1 {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "2"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "2"),
+						}),
+					})},
 				}}
 			} else {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '%', values: []RedisMessage{
-							{typ: '+', string: "ip"}, {typ: '+', string: ""},
-							{typ: '+', string: "port"}, {typ: '+', string: "4"},
-						}},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainSlice('%', []RedisMessage{
+							redisMessageContainString('+', "ip"), redisMessageContainString('+', ""),
+							redisMessageContainString('+', "port"), redisMessageContainString('+', "4"),
+						}),
+					})},
 				}}
 			}
 		},
@@ -1376,9 +1376,9 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	slave1 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "slave"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
 			}
-			return RedisResult{val: RedisMessage{typ: '+', string: "OK"}}
+			return RedisResult{val: redisMessageContainString('+', "OK")}
 		},
 		CloseFn: func() {
 			atomic.AddInt32(&slave1close, 1)
@@ -1386,7 +1386,7 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	}
 	slave2 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
-			return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+			return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 		},
 		CloseFn: func() { atomic.AddInt32(&slave2close, 1) },
 	}
@@ -1396,9 +1396,9 @@ func TestSentinelReplicaOnlyClientPubSub(t *testing.T) {
 	slave4 := &mockConn{
 		DoFn: func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "slave"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "slave")})}
 			}
-			return RedisResult{val: RedisMessage{typ: '+', string: "OK4"}}
+			return RedisResult{val: redisMessageContainString('+', "OK4")}
 		},
 		CloseFn: func() { atomic.AddInt32(&slave4close, 1) },
 	}
@@ -1518,15 +1518,15 @@ func TestSentinelClientRetry(t *testing.T) {
 	SetupClientRetry(t, func(m *mockConn) Client {
 		m.DoOverride = map[string]func(cmd Completed) RedisResult{
 			"SENTINEL SENTINELS masters": func(cmd Completed) RedisResult {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{})}
 			},
 			"SENTINEL GET-MASTER-ADDR-BY-NAME masters": func(cmd Completed) RedisResult {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{
-					{typ: '+', string: ""}, {typ: '+', string: "5"},
-				}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{
+					redisMessageContainString('+', ""), redisMessageContainString('+', "5"),
+				})}
 			},
 			"ROLE": func(cmd Completed) RedisResult {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			},
 		}
 		m.ReceiveOverride = map[string]func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error{
@@ -1559,17 +1559,17 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 			DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
 			DoMultiFn: func(multi ...Completed) *redisresults {
 				return &redisresults{s: []RedisResult{
-					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-					{val: RedisMessage{typ: '*', values: []RedisMessage{
-						{typ: '+', string: ""}, {typ: '+', string: "1"},
-					}}},
+					{val: redisMessageContainSlice('*', []RedisMessage{})},
+					{val: redisMessageContainSlice('*', []RedisMessage{
+						redisMessageContainString('+', ""), redisMessageContainString('+', "1"),
+					})},
 				}}
 			},
 		}
 		m1 := &mockConn{
 			DoFn: func(cmd Completed) RedisResult {
 				if cmd == cmds.RoleCmd {
-					return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+					return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 				}
 				return RedisResult{}
 			},
@@ -1598,13 +1598,13 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		attempts := 0
 		m1.DoFn = func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		if v, err := client.Do(context.Background(), client.B().Get().Key("test").Build()).ToString(); err != nil || v != "OK" {
@@ -1620,13 +1620,13 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		attempts := 0
 		m1.DoFn = func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "ERR some other error"}, nil)
+				return newResult(redisMessageContainString('-', "ERR some other error"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		if err := client.Do(context.Background(), client.B().Get().Key("test").Build()).Error(); err == nil {
@@ -1643,9 +1643,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Build()
@@ -1664,9 +1664,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoCacheFn = func(cmd Cacheable, ttl time.Duration) RedisResult {
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1681,9 +1681,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiCacheFn = func(multi ...CacheableTTL) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 
 		cmd := client.B().Get().Key("test").Cache()
@@ -1701,13 +1701,13 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		attempts := 0
 		m1.DoFn = func(cmd Completed) RedisResult {
 			if cmd == cmds.RoleCmd {
-				return RedisResult{val: RedisMessage{typ: '*', values: []RedisMessage{{typ: '+', string: "master"}}}}
+				return RedisResult{val: redisMessageContainSlice('*', []RedisMessage{redisMessageContainString('+', "master")})}
 			}
 			attempts++
 			if attempts == 1 {
-				return newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)
+				return newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)
 			}
-			return newResult(RedisMessage{typ: '+', string: "OK"}, nil)
+			return newResult(redisMessageContainString('+', "OK"), nil)
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoFn: m1.DoFn} }
 
@@ -1728,9 +1728,9 @@ func TestSentinelClientLoadingRetry(t *testing.T) {
 		m1.DoMultiFn = func(multi ...Completed) *redisresults {
 			attempts++
 			if attempts == 1 {
-				return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '-', string: "LOADING Redis is loading the dataset in memory"}, nil)}}
+				return &redisresults{s: []RedisResult{newResult(redisMessageContainString('-', "LOADING Redis is loading the dataset in memory"), nil)}}
 			}
-			return &redisresults{s: []RedisResult{newResult(RedisMessage{typ: '+', string: "OK"}, nil)}}
+			return &redisresults{s: []RedisResult{newResult(redisMessageContainString('+', "OK"), nil)}}
 		}
 		m1.AcquireFn = func() wire { return &mockWire{DoMultiFn: m1.DoMultiFn} }
 


### PR DESCRIPTION
Replace the fields in `RedisMessage` with `*byte` and `*RedisMessage` in conjunction with integer to save the size of struct.
Use `unsafe.String()` or `unsafe.Slice()` to recover back to the original `string` or `[]RedisMessage` accordingly.

related issue: https://github.com/redis/rueidis/issues/789