### PR TITLE
feat: allow standalone client to have replicas

### DIFF
--- a/standalone.go
+++ b/standalone.go
@@ -1,0 +1,143 @@
+package rueidis
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	"github.com/redis/rueidis/internal/cmds"
+)
+
+func newStandaloneClient(opt *ClientOption, connFn connFn, retryer retryHandler) (*standalone, error) {
+	if len(opt.InitAddress) == 0 {
+		return nil, ErrNoAddr
+	}
+	p := connFn(opt.InitAddress[0], opt)
+	if err := p.Dial(); err != nil {
+		return nil, err
+	}
+	s := &standalone{
+		toReplicas: opt.SendToReplicas,
+		primary:    newSingleClientWithConn(p, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer),
+		replicas:   make([]*singleClient, len(opt.Standalone.ReplicaAddress)),
+	}
+	opt.ReplicaOnly = true
+	for i := range s.replicas {
+		replicaConn := connFn(opt.Standalone.ReplicaAddress[i], opt)
+		if err := replicaConn.Dial(); err != nil {
+			s.primary.Close() // close primary if any replica fails
+			for j := 0; j < i; j++ {
+				s.replicas[j].Close()
+			}
+			return nil, err
+		}
+		s.replicas[i] = newSingleClientWithConn(replicaConn, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer)
+	}
+	return s, nil
+}
+
+type standalone struct {
+	toReplicas func(Completed) bool
+	primary    *singleClient
+	replicas   []*singleClient
+}
+
+func (s *standalone) B() Builder {
+	return s.primary.B()
+}
+
+func (s *standalone) pick() int {
+	if len(s.replicas) == 1 {
+		return 0
+	}
+	return rand.IntN(len(s.replicas))
+}
+
+func (s *standalone) Do(ctx context.Context, cmd Completed) (resp RedisResult) {
+	if s.toReplicas(cmd) {
+		return s.replicas[s.pick()].Do(ctx, cmd)
+	}
+	return s.primary.Do(ctx, cmd)
+}
+
+func (s *standalone) DoMulti(ctx context.Context, multi ...Completed) (resp []RedisResult) {
+	toReplica := true
+	for _, cmd := range multi {
+		if !s.toReplicas(cmd) {
+			toReplica = false
+			break
+		}
+	}
+	if toReplica {
+		return s.replicas[s.pick()].DoMulti(ctx, multi...)
+	}
+	return s.primary.DoMulti(ctx, multi...)
+}
+
+func (s *standalone) Receive(ctx context.Context, subscribe Completed, fn func(msg PubSubMessage)) error {
+	if s.toReplicas(subscribe) {
+		return s.replicas[s.pick()].Receive(ctx, subscribe, fn)
+	}
+	return s.primary.Receive(ctx, subscribe, fn)
+}
+
+func (s *standalone) Close() {
+	s.primary.Close()
+	for _, replica := range s.replicas {
+		replica.Close()
+	}
+}
+
+func (s *standalone) DoCache(ctx context.Context, cmd Cacheable, ttl time.Duration) (resp RedisResult) {
+	return s.primary.DoCache(ctx, cmd, ttl)
+}
+
+func (s *standalone) DoMultiCache(ctx context.Context, multi ...CacheableTTL) (resp []RedisResult) {
+	return s.primary.DoMultiCache(ctx, multi...)
+}
+
+func (s *standalone) DoStream(ctx context.Context, cmd Completed) RedisResultStream {
+	if s.toReplicas(cmd) {
+		return s.replicas[s.pick()].DoStream(ctx, cmd)
+	}
+	return s.primary.DoStream(ctx, cmd)
+}
+
+func (s *standalone) DoMultiStream(ctx context.Context, multi ...Completed) MultiRedisResultStream {
+	toReplica := true
+	for _, cmd := range multi {
+		if !s.toReplicas(cmd) {
+			toReplica = false
+			break
+		}
+	}
+	if toReplica {
+		return s.replicas[s.pick()].DoMultiStream(ctx, multi...)
+	}
+	return s.primary.DoMultiStream(ctx, multi...)
+}
+
+func (s *standalone) Dedicated(fn func(DedicatedClient) error) (err error) {
+	return s.primary.Dedicated(fn)
+}
+
+func (s *standalone) Dedicate() (client DedicatedClient, cancel func()) {
+	return s.primary.Dedicate()
+}
+
+func (s *standalone) Nodes() map[string]Client {
+	nodes := make(map[string]Client, len(s.replicas)+1)
+	for addr, client := range s.primary.Nodes() {
+		nodes[addr] = client
+	}
+	for _, replica := range s.replicas {
+		for addr, client := range replica.Nodes() {
+			nodes[addr] = client
+		}
+	}
+	return nodes
+}
+
+func (s *standalone) Mode() ClientMode {
+	return ClientModeStandalone
+}

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -1,0 +1,243 @@
+package rueidis
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewStandaloneClientNoNode(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	if _, err := newStandaloneClient(
+		&ClientOption{}, func(dst string, opt *ClientOption) conn {
+			return nil
+		}, newRetryer(defaultRetryDelayFn),
+	); err != ErrNoAddr {
+		t.Fatalf("unexpected err %v", err)
+	}
+}
+
+func TestNewStandaloneClientError(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	v := errors.New("dail err")
+	if _, err := newStandaloneClient(
+		&ClientOption{InitAddress: []string{""}}, func(dst string, opt *ClientOption) conn { return &mockConn{DialFn: func() error { return v }} }, newRetryer(defaultRetryDelayFn),
+	); err != v {
+		t.Fatalf("unexpected err %v", err)
+	}
+}
+
+func TestNewStandaloneClientReplicasError(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	v := errors.New("dail err")
+	if _, err := newStandaloneClient(
+		&ClientOption{
+			InitAddress: []string{"1"},
+			Standalone: StandaloneOption{
+				ReplicaAddress: []string{"2", "3"}, // two replicas
+			},
+		}, func(dst string, opt *ClientOption) conn {
+			return &mockConn{DialFn: func() error {
+				if dst == "3" {
+					return v
+				}
+				return nil
+			}}
+		}, newRetryer(defaultRetryDelayFn),
+	); err != v {
+		t.Fatalf("unexpected err %v", err)
+	}
+}
+
+func TestNewStandaloneClientDelegation(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+
+	w := &mockWire{}
+	p := &mockConn{
+		AddrFn: func() string {
+			return "p"
+		},
+		DoFn: func(cmd Completed) RedisResult {
+			return newErrResult(errors.New("primary"))
+		},
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			return &redisresults{s: []RedisResult{newErrResult(errors.New("primary"))}}
+		},
+		DoCacheFn: func(cmd Cacheable, ttl time.Duration) RedisResult {
+			return newErrResult(errors.New("primary"))
+		},
+		DoMultiCacheFn: func(multi ...CacheableTTL) *redisresults {
+			return &redisresults{s: []RedisResult{newErrResult(errors.New("primary"))}}
+		},
+		DoStreamFn: func(cmd Completed) RedisResultStream {
+			return RedisResultStream{e: errors.New("primary")}
+		},
+		DoMultiStreamFn: func(cmd ...Completed) MultiRedisResultStream {
+			return MultiRedisResultStream{e: errors.New("primary")}
+		},
+		ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
+			return errors.New("primary")
+		},
+		AcquireFn: func() wire {
+			return w
+		},
+	}
+	r := &mockConn{
+		AddrFn: func() string {
+			return "r"
+		},
+		DoFn: func(cmd Completed) RedisResult {
+			return newErrResult(errors.New("replica"))
+		},
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			return &redisresults{s: []RedisResult{newErrResult(errors.New("replica"))}}
+		},
+		DoStreamFn: func(cmd Completed) RedisResultStream {
+			return RedisResultStream{e: errors.New("replica")}
+		},
+		DoMultiStreamFn: func(cmd ...Completed) MultiRedisResultStream {
+			return MultiRedisResultStream{e: errors.New("replica")}
+		},
+		ReceiveFn: func(ctx context.Context, subscribe Completed, fn func(message PubSubMessage)) error {
+			return errors.New("replica")
+		},
+	}
+
+	c, err := newStandaloneClient(&ClientOption{
+		InitAddress: []string{"p"},
+		Standalone: StandaloneOption{
+			ReplicaAddress: []string{"r"},
+		},
+		SendToReplicas: func(cmd Completed) bool {
+			return cmd.IsReadOnly() && !cmd.IsUnsub()
+		},
+		DisableRetry: true,
+	}, func(dst string, opt *ClientOption) conn {
+		if dst == "p" {
+			return p
+		}
+		return r
+	}, newRetryer(defaultRetryDelayFn))
+
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	defer c.Close()
+
+	ctx := context.Background()
+	if err := c.Do(ctx, c.B().Get().Key("k").Build()).Error(); err == nil || err.Error() != "replica" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.Do(ctx, c.B().Set().Key("k").Value("v").Build()).Error(); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.DoCache(ctx, c.B().Get().Key("k").Cache(), time.Second).Error(); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.DoMulti(ctx, c.B().Get().Key("k").Build())[0].Error(); err == nil || err.Error() != "replica" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.DoMulti(ctx, c.B().Set().Key("k").Value("v").Build())[0].Error(); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.DoMultiCache(ctx, CT(c.B().Get().Key("k").Cache(), time.Second))[0].Error(); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	stream := c.DoStream(ctx, c.B().Get().Key("k").Build())
+	if err := stream.Error(); err == nil || err.Error() != "replica" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	multiStream := c.DoMultiStream(ctx, c.B().Get().Key("k").Build())
+	if err := multiStream.Error(); err == nil || err.Error() != "replica" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	stream = c.DoStream(ctx, c.B().Set().Key("k").Value("v").Build())
+	if err := stream.Error(); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	multiStream = c.DoMultiStream(ctx, c.B().Set().Key("k").Value("v").Build())
+	if err := multiStream.Error(); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.Receive(ctx, c.B().Subscribe().Channel("ch").Build(), func(msg PubSubMessage) {}); err == nil || err.Error() != "replica" {
+		t.Fatalf("unexpected err %v", err)
+	}
+	if err := c.Receive(ctx, c.B().Unsubscribe().Channel("ch").Build(), func(msg PubSubMessage) {}); err == nil || err.Error() != "primary" {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	if err := c.Dedicated(func(dc DedicatedClient) error {
+		if dc.(*dedicatedSingleClient).wire != w {
+			return errors.New("wire")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	if dc, cancel := c.Dedicate(); dc.(*dedicatedSingleClient).wire != w {
+		t.Fatalf("unexpected wire %v", dc.(*dedicatedSingleClient).wire)
+	} else {
+		cancel()
+	}
+
+	if c.Mode() != ClientModeStandalone {
+		t.Fatalf("unexpected mode: %v", c.Mode())
+	}
+
+	nodes := c.Nodes()
+	if len(nodes) != 2 && nodes["p"].(*singleClient).conn != p && nodes["r"].(*singleClient).conn != r {
+		t.Fatalf("unexpected nodes %v", nodes)
+	}
+}
+
+func TestNewStandaloneClientMultiReplicasDelegation(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+
+	var counts [2]int32
+
+	c, err := newStandaloneClient(&ClientOption{
+		InitAddress: []string{"p"},
+		Standalone: StandaloneOption{
+			ReplicaAddress: []string{"0", "1"},
+		},
+		SendToReplicas: func(cmd Completed) bool {
+			return cmd.IsReadOnly()
+		},
+		DisableRetry: true,
+	}, func(dst string, opt *ClientOption) conn {
+		if dst == "p" {
+			return &mockConn{}
+		}
+		return &mockConn{
+			DoFn: func(cmd Completed) RedisResult {
+				i, _ := strconv.Atoi(dst)
+				atomic.AddInt32(&counts[i], 1)
+				return newErrResult(errors.New("replica"))
+			},
+		}
+	}, newRetryer(defaultRetryDelayFn))
+
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+
+	defer c.Close()
+
+	ctx := context.Background()
+
+	for i := 0; i < 1000; i++ {
+		if err := c.Do(ctx, c.B().Get().Key("k").Build()).Error(); err == nil || err.Error() != "replica" {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	for i := 0; i < len(counts); i++ {
+		if atomic.LoadInt32(&counts[i]) == 0 {
+			t.Fatalf("replica %d was not called", i)
+		}
+	}
+}


### PR DESCRIPTION
Introduce a new `StandaloneOption` mainly for the reader endpoint provided by cloud vendors:

```go
	c, err := rueidis.NewClient(rueidis.ClientOption{
		InitAddress: []string{"writer endpoing"},
		Standalone: rueidis.StandaloneOption{
			ReplicaAddress: []string{"reader endpoint"},
		},
		SendToReplicas: func(cmd rueidis.Completed) bool {
			return cmd.IsReadOnly()
		},
	})
```