### PR TITLE
fix: syntax of the MAXAGE option in the CLIENT KILL command is aligned with the redis docs

### DIFF
--- a/hack/cmds/commands.json
+++ b/hack/cmds/commands.json
@@ -725,9 +725,9 @@
         "optional": true
       },
       {
-        "name": "MAXAGE",
+        "command": "MAXAGE",
+        "name": "maxage",
         "type": "integer",
-        "token": "MAXAGE",
         "optional": true
       }
     ],

--- a/internal/cmds/gen_connection.go
+++ b/internal/cmds/gen_connection.go
@@ -209,7 +209,7 @@ func (c ClientKill) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKill) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -236,7 +236,7 @@ func (c ClientKillAddr) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillAddr) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -293,7 +293,7 @@ func (c ClientKillId) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillId) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -355,7 +355,7 @@ func (c ClientKillIpPort) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillIpPort) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -377,7 +377,7 @@ func (c ClientKillLaddr) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillLaddr) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -396,7 +396,7 @@ func (c ClientKillMaxage) Build() Completed {
 type ClientKillSkipmeNo Incomplete
 
 func (c ClientKillSkipmeNo) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -408,7 +408,7 @@ func (c ClientKillSkipmeNo) Build() Completed {
 type ClientKillSkipmeYes Incomplete
 
 func (c ClientKillSkipmeYes) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -445,7 +445,7 @@ func (c ClientKillTypeMaster) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillTypeMaster) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -482,7 +482,7 @@ func (c ClientKillTypeNormal) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillTypeNormal) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -519,7 +519,7 @@ func (c ClientKillTypePubsub) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillTypePubsub) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -556,7 +556,7 @@ func (c ClientKillTypeReplica) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillTypeReplica) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 
@@ -588,7 +588,7 @@ func (c ClientKillUser) SkipmeNo() ClientKillSkipmeNo {
 }
 
 func (c ClientKillUser) Maxage(maxage int64) ClientKillMaxage {
-	c.cs.s = append(c.cs.s, strconv.FormatInt(maxage, 10))
+	c.cs.s = append(c.cs.s, "MAXAGE", strconv.FormatInt(maxage, 10))
 	return (ClientKillMaxage)(c)
 }
 


### PR DESCRIPTION
According to the redis documentation, the CLIENT KILL command has the following syntax:

`
CLIENT KILL <ip:port | <[ID client-id] | [TYPE <NORMAL | MASTER |
  SLAVE | REPLICA | PUBSUB>] | [USER username] | [ADDR ip:port] |
  [LADDR ip:port] | [SKIPME <YES | NO>] | [MAXAGE maxage]
  [[ID client-id] | [TYPE <NORMAL | MASTER | SLAVE | REPLICA |
  PUBSUB>] | [USER username] | [ADDR ip:port] | [LADDR ip:port] |
  [SKIPME <YES | NO>] | [MAXAGE maxage] ...]>>
`

Currently in the builder in the function `.Maxage(maxage int64)` the keyword "MAXAGE" is not formed.

Because of this, redis returns the error "ERR syntax error" in the new format of the KILL command and the error "ERR No such client" in the old format.