### PR TITLE
Add retry logic of connection lifetime to cluster client and sentinel client

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -7752,6 +7752,98 @@ func TestClusterClientConnLifetime(t *testing.T) {
 		}
 	})
 
+	t.Run("DoMulti ConnLifetime Transaction Block", func(t *testing.T) {
+		client, m := setup()
+		var (
+			attempts int64
+			orgMulti []Completed
+		)
+		m.DoFn = func(cmd Completed) RedisResult { return slotsMultiResp }
+		m.DoMultiFn = func(multi ...Completed) *redisresults {
+			switch atomic.AddInt64(&attempts, 1) {
+			case 1: // errConnExpired at the head of processing
+				orgMulti = multi
+				return &redisresults{s: []RedisResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+			case 2: // errConnExpired at Multi command
+				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at the head of proccessing, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 3: // errConnExpired in the middle of transaction block
+				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 4: // errConnExpired at Exec Command
+				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 5: // errConnExpired at end of processing
+				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []RedisMessage{
+						strmsg('+', "2"),
+						strmsg('+', "3"),
+					}), nil),
+					newErrResult(errConnExpired),
+				}}
+			case 6:
+				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
+				}
+			}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "4"), nil)}}
+		}
+		multi := []Completed{
+			client.B().Get().Key("1{t}").Build(),
+			client.B().Multi().Build(),
+			client.B().Incr().Key("2{t}").Build(),
+			client.B().Incr().Key("3{t}").Build(),
+			client.B().Exec().Build(),
+			client.B().Get().Key("4{t}").Build(),
+		}
+		resps := client.DoMulti(context.Background(), multi...)
+		if len(resps) != 6 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		if v, err := resps[0].ToString(); err != nil || v != "1" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[1].ToString(); err != nil || v != "OK" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[2].ToString(); err != nil || v != "QUEUE" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[3].ToString(); err != nil || v != "QUEUE" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[4].AsStrSlice(); err != nil || !reflect.DeepEqual(v, []string{"2", "3"}) {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[5].ToString(); err != nil || v != "4" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+	})
+
 	t.Run("DoMulti ConnLifetime in ASK - in the middle of processing", func(t *testing.T) {
 		client, m := setup()
 		var attempts int64
@@ -7785,6 +7877,119 @@ func TestClusterClientConnLifetime(t *testing.T) {
 			if err != nil || i == 1 && v != "b" {
 				t.Fatalf("unexpected response %v %v", v, err)
 			}
+		}
+	})
+
+	t.Run("DoMulti ConnLifetime Transaction Block in ASK", func(t *testing.T) {
+		client, m := setup()
+		var (
+			attempts int64
+			orgMulti []Completed
+		)
+		m.DoFn = func(cmd Completed) RedisResult { return slotsMultiResp }
+		m.DoMultiFn = func(multi ...Completed) *redisresults {
+			switch atomic.AddInt64(&attempts, 1) {
+			case 1:
+				ret := make([]RedisResult, len(multi))
+				for i := range ret {
+					if isMulti(multi[i]) || isExec(multi[i]) {
+						ret[i] = newResult(strmsg('+', "OK"), nil)
+						continue
+					}
+					ret[i] = newResult(strmsg('-', "ASK 0 :1"), nil)
+				}
+				return &redisresults{s: ret}
+			case 2: // errConnExpired at the head of processing
+				orgMulti = multi
+				return &redisresults{s: []RedisResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+			case 3: // errConnExpired at Asking command before Multi command
+				if len(multi) != 9 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at the head of proccessing, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 4: // errConnExpired at Multi command
+				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at Asking command before Multi command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 5: // errConnExpired in the middle of transaction block
+				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 6: // errConnExpired at Exec Command
+				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 7: // errConnExpired at end of processing
+				if len(multi) != 7 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[2].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []RedisMessage{
+						strmsg('+', "2"),
+						strmsg('+', "3"),
+					}), nil),
+					newResult(strmsg('+', "OK"), nil),
+					newErrResult(errConnExpired),
+				}}
+			case 8:
+				if len(multi) != 2 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[7].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
+				}
+			}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "4"), nil)}}
+		}
+		multi := []Completed{
+			client.B().Get().Key("1{t}").Build(),
+			client.B().Multi().Build(),
+			client.B().Incr().Key("2{t}").Build(),
+			client.B().Incr().Key("3{t}").Build(),
+			client.B().Exec().Build(),
+			client.B().Get().Key("4{t}").Build(),
+		}
+		resps := client.DoMulti(context.Background(), multi...)
+		if len(resps) != 6 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		if v, err := resps[0].ToString(); err != nil || v != "1" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[1].ToString(); err != nil || v != "OK" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[2].ToString(); err != nil || v != "QUEUE" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[3].ToString(); err != nil || v != "QUEUE" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[4].AsStrSlice(); err != nil || !reflect.DeepEqual(v, []string{"2", "3"}) {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[5].ToString(); err != nil || v != "4" {
+			t.Errorf("unexpected response %v %v", v, err)
 		}
 	})
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -99,10 +99,21 @@ retry:
 		var ml []Completed
 	recover:
 		ml = ml[:0]
+		var txIdx int // check transaction block, if zero then not in transaction
 		for i, resp := range resps.s {
 			if resp.Error() == errConnExpired {
-				ml = multi[i:]
+				if txIdx > 0 {
+					ml = multi[txIdx:]
+				} else {
+					ml = multi[i:]
+				}
 				break
+			}
+			// if no error then check if transaction block
+			if isMulti(multi[i]) {
+				txIdx = i
+			} else if isExec(multi[i]) {
+				txIdx = 0
 			}
 		}
 		if len(ml) > 0 {

--- a/sentinel.go
+++ b/sentinel.go
@@ -25,6 +25,7 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		sentinels:    list.New(),
 		retry:        !opt.DisableRetry,
 		retryHandler: retryer,
+		hasLftm:      opt.ConnLifetime > 0,
 		replica:      opt.ReplicaOnly,
 	}
 
@@ -55,6 +56,7 @@ type sentinelClient struct {
 	stop         uint32
 	cmd          Builder
 	retry        bool
+	hasLftm      bool
 	replica      bool
 }
 
@@ -66,6 +68,9 @@ func (c *sentinelClient) Do(ctx context.Context, cmd Completed) (resp RedisResul
 	attempts := 1
 retry:
 	resp = c.mConn.Load().(conn).Do(ctx, cmd)
+	if resp.Error() == errConnExpired {
+		goto retry
+	}
 	if c.retry && cmd.IsReadOnly() && c.isRetryable(resp.Error(), ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(
 			ctx, attempts, cmd, resp.Error(),
@@ -88,7 +93,24 @@ func (c *sentinelClient) DoMulti(ctx context.Context, multi ...Completed) []Redi
 
 	attempts := 1
 retry:
-	resps := c.mConn.Load().(conn).DoMulti(ctx, multi...)
+	cc := c.mConn.Load().(conn)
+	resps := cc.DoMulti(ctx, multi...)
+	if c.hasLftm {
+		var ml []Completed
+	recover:
+		ml = ml[:0]
+		for i, resp := range resps.s {
+			if resp.Error() == errConnExpired {
+				ml = multi[i:]
+				break
+			}
+		}
+		if len(ml) > 0 {
+			rs := cc.DoMulti(ctx, ml...).s
+			resps.s = append(resps.s[:len(resps.s)-len(rs)], rs...)
+			goto recover
+		}
+	}
 	if c.retry && allReadOnly(multi) {
 		for i, resp := range resps.s {
 			if c.isRetryable(resp.Error(), ctx) {
@@ -115,6 +137,9 @@ func (c *sentinelClient) DoCache(ctx context.Context, cmd Cacheable, ttl time.Du
 	attempts := 1
 retry:
 	resp = c.mConn.Load().(conn).DoCache(ctx, cmd, ttl)
+	if resp.Error() == errConnExpired {
+		goto retry
+	}
 	if c.retry && c.isRetryable(resp.Error(), ctx) {
 		shouldRetry := c.retryHandler.WaitOrSkipRetry(ctx, attempts, Completed(cmd), resp.Error())
 		if shouldRetry {
@@ -135,7 +160,24 @@ func (c *sentinelClient) DoMultiCache(ctx context.Context, multi ...CacheableTTL
 	}
 	attempts := 1
 retry:
-	resps := c.mConn.Load().(conn).DoMultiCache(ctx, multi...)
+	cc := c.mConn.Load().(conn)
+	resps := cc.DoMultiCache(ctx, multi...)
+	if c.hasLftm {
+		var ml []CacheableTTL
+	recover:
+		ml = ml[:0]
+		for i, resp := range resps.s {
+			if resp.Error() == errConnExpired {
+				ml = multi[i:]
+				break
+			}
+		}
+		if len(ml) > 0 {
+			rs := cc.DoMultiCache(ctx, ml...).s
+			resps.s = append(resps.s[:len(resps.s)-len(rs)], rs...)
+			goto recover
+		}
+	}
 	if c.retry {
 		for i, resp := range resps.s {
 			if c.isRetryable(resp.Error(), ctx) {
@@ -162,6 +204,9 @@ func (c *sentinelClient) Receive(ctx context.Context, subscribe Completed, fn fu
 	attempts := 1
 retry:
 	err = c.mConn.Load().(conn).Receive(ctx, subscribe, fn)
+	if err == errConnExpired {
+		goto retry
+	}
 	if c.retry {
 		if _, ok := err.(*RedisError); !ok && c.isRetryable(err, ctx) {
 			shouldRetry := c.retryHandler.WaitOrSkipRetry(

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -1855,6 +1855,96 @@ func TestSentinelClientConnLifetime(t *testing.T) {
 		}
 	})
 
+	t.Run("DoMulti ConnLifetime Transaction Block", func(t *testing.T) {
+		client, _, m := setup()
+		var (
+			attempts int64
+			orgMulti []Completed
+		)
+		m.DoMultiFn = func(multi ...Completed) *redisresults {
+			switch atomic.AddInt64(&attempts, 1) {
+			case 1: // errConnExpired at the head of processing
+				orgMulti = multi
+				return &redisresults{s: []RedisResult{newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+			case 2: // errConnExpired at Multi Command
+				if len(multi) != 6 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[0].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at the head of proccessing, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "1"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 3: // errConnExpired in the middle of transaction block
+				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at Multi Command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired), newErrResult(errConnExpired),
+				}}
+			case 4: // errConnExpired at Exec Command
+				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred in the middle of transaction block, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newErrResult(errConnExpired), newErrResult(errConnExpired)}}
+			case 5: // errConnExpired at end of processing
+				if len(multi) != 5 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[1].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at at Exec Command, %v", multi)
+				}
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(strmsg('+', "QUEUE"), nil),
+					newResult(slicemsg('*', []RedisMessage{
+						strmsg('+', "2"),
+						strmsg('+', "3"),
+					}), nil),
+					newErrResult(errConnExpired),
+				}}
+			case 6:
+				if len(multi) != 1 || !reflect.DeepEqual(multi[0].Commands(), orgMulti[5].Commands()) {
+					t.Fatalf("unexpected multi when errConnExpired occurred at end of processing, %v", multi)
+				}
+			}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "4"), nil)}}
+		}
+		multi := []Completed{
+			client.B().Get().Key("1{t}").Build(),
+			client.B().Multi().Build(),
+			client.B().Get().Key("2{t}").Build(),
+			client.B().Get().Key("3{t}").Build(),
+			client.B().Exec().Build(),
+			client.B().Get().Key("4{t}").Build(),
+		}
+		resps := client.DoMulti(context.Background(), multi...)
+		if len(resps) != 6 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		if v, err := resps[0].ToString(); err != nil || v != "1" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[1].ToString(); err != nil || v != "OK" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[2].ToString(); err != nil || v != "QUEUE" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[3].ToString(); err != nil || v != "QUEUE" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[4].AsStrSlice(); err != nil || !reflect.DeepEqual(v, []string{"2", "3"}) {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+		if v, err := resps[5].ToString(); err != nil || v != "4" {
+			t.Errorf("unexpected response %v %v", v, err)
+		}
+	})
+
 	t.Run("DoMultiCache ConnLifetime - at the head of processing", func(t *testing.T) {
 		client, _, m := setup()
 		var attempts int64


### PR DESCRIPTION
This is follow-up PR regarding #727 .

See https://github.com/redis/rueidis/pull/727#issuecomment-2823047261.
 