### PR TITLE
Support Lua scripts without SHA-1 usage for FIPS compliancy

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -12,35 +12,71 @@ import (
 
 // NewLuaScript creates a Lua instance whose Lua.Exec uses EVALSHA and EVAL.
 func NewLuaScript(script string) *Lua {
-	sum := sha1.Sum([]byte(script))
-	return &Lua{script: script, sha1: hex.EncodeToString(sum[:]), maxp: runtime.GOMAXPROCS(0)}
+	return newLuaScript(script, false, false)
 }
 
 // NewLuaScriptReadOnly creates a Lua instance whose Lua.Exec uses EVALSHA_RO and EVAL_RO.
 func NewLuaScriptReadOnly(script string) *Lua {
-	lua := NewLuaScript(script)
-	lua.readonly = true
-	return lua
+	return newLuaScript(script, true, false)
 }
 
-// Lua represents a redis lua script. It should be created from the NewLuaScript() or NewLuaScriptReadOnly()
+// NewLuaScriptNoSha creates a Lua instance whose Lua.Exec uses EVAL.
+// Sha1 is not calculated, SCRIPT LOAD is not used, no EVALSHA is used.
+// The main motivation is to be FIPS compliant, also avoid tiny chance of SHA-1 collisions.
+// This comes with a performance cost as the script is sent to a server every time.
+func NewLuaScriptNoSha(script string) *Lua {
+	return newLuaScript(script, false, true)
+}
+
+// NewLuaScriptReadOnlyNoSha creates a Lua instance whose Lua.Exec uses EVAL_RO.
+// Sha1 is not calculated, SCRIPT LOAD is not used, no EVALSHA_RO is used.
+// The main motivation is to be FIPS compliant, also avoid tiny chance of SHA-1 collisions.
+// This comes with a performance cost as the script is sent to a server every time.
+func NewLuaScriptReadOnlyNoSha(script string) *Lua {
+	return newLuaScript(script, true, true)
+}
+
+func newLuaScript(script string, readonly bool, noSha1 bool) *Lua {
+	var sha1Hex string
+	if !noSha1 {
+		// It's important to avoid calling sha1 methods since Go will panic in FIPS mode.
+		sum := sha1.Sum([]byte(script))
+		sha1Hex = hex.EncodeToString(sum[:])
+	}
+	return &Lua{
+		script:   script,
+		sha1:     sha1Hex,
+		maxp:     runtime.GOMAXPROCS(0),
+		readonly: readonly,
+		nosha1:   noSha1,
+	}
+}
+
+// Lua represents a redis lua script. It should be created from the NewLuaScript() or NewLuaScriptReadOnly().
 type Lua struct {
 	script   string
 	sha1     string
 	maxp     int
 	readonly bool
+	nosha1   bool
 }
 
 // Exec the script to the given Client.
 // It will first try with the EVALSHA/EVALSHA_RO and then EVAL/EVAL_RO if first try failed.
+// If Lua is initialized with disabled SHA1, it will use EVAL/EVAL_RO without EVALSHA/EVALSHA_RO attempt.
 // Cross slot keys are prohibited if the Client is a cluster client.
 func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp RedisResult) {
-	if s.readonly {
-		resp = c.Do(ctx, c.B().EvalshaRo().Sha1(s.sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
-	} else {
-		resp = c.Do(ctx, c.B().Evalsha().Sha1(s.sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
+	var isNoScript bool
+	if !s.nosha1 {
+		if s.readonly {
+			resp = c.Do(ctx, c.B().EvalshaRo().Sha1(s.sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
+		} else {
+			resp = c.Do(ctx, c.B().Evalsha().Sha1(s.sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
+		}
+		err, isErr := IsRedisErr(resp.Error())
+		isNoScript = isErr && err.IsNoScript()
 	}
-	if err, ok := IsRedisErr(resp.Error()); ok && err.IsNoScript() {
+	if s.nosha1 || isNoScript {
 		if s.readonly {
 			resp = c.Do(ctx, c.B().EvalRo().Script(s.script).Numkeys(int64(len(keys))).Key(keys...).Arg(args...).Build())
 		} else {
@@ -50,7 +86,7 @@ func (s *Lua) Exec(ctx context.Context, c Client, keys, args []string) (resp Red
 	return resp
 }
 
-// LuaExec is a single execution unit of Lua.ExecMulti
+// LuaExec is a single execution unit of Lua.ExecMulti.
 type LuaExec struct {
 	Keys []string
 	Args []string
@@ -58,29 +94,38 @@ type LuaExec struct {
 
 // ExecMulti exec the script multiple times by the provided LuaExec to the given Client.
 // It will first try SCRIPT LOAD the script to all redis nodes and then exec it with the EVALSHA/EVALSHA_RO.
+// If Lua is initialized with disabled SHA1, it will use EVAL/EVAL_RO and no script loading.
 // Cross slot keys within single LuaExec are prohibited if the Client is a cluster client.
 func (s *Lua) ExecMulti(ctx context.Context, c Client, multi ...LuaExec) (resp []RedisResult) {
-	var e atomic.Value
-	util.ParallelVals(s.maxp, c.Nodes(), func(n Client) {
-		if err := n.Do(ctx, n.B().ScriptLoad().Script(s.script).Build()).Error(); err != nil {
-			e.CompareAndSwap(nil, &errs{error: err})
+	if !s.nosha1 {
+		var e atomic.Value
+		util.ParallelVals(s.maxp, c.Nodes(), func(n Client) {
+			if err := n.Do(ctx, n.B().ScriptLoad().Script(s.script).Build()).Error(); err != nil {
+				e.CompareAndSwap(nil, &errs{error: err})
+			}
+		})
+		if err := e.Load(); err != nil {
+			resp = make([]RedisResult, len(multi))
+			for i := 0; i < len(resp); i++ {
+				resp[i] = newErrResult(err.(*errs).error)
+			}
+			return
 		}
-	})
-	if err := e.Load(); err != nil {
-		resp = make([]RedisResult, len(multi))
-		for i := 0; i < len(resp); i++ {
-			resp[i] = newErrResult(err.(*errs).error)
-		}
-		return
 	}
 	cmds := make(Commands, 0, len(multi))
-	if s.readonly {
-		for _, m := range multi {
-			cmds = append(cmds, c.B().EvalshaRo().Sha1(s.sha1).Numkeys(int64(len(m.Keys))).Key(m.Keys...).Arg(m.Args...).Build())
-		}
-	} else {
-		for _, m := range multi {
-			cmds = append(cmds, c.B().Evalsha().Sha1(s.sha1).Numkeys(int64(len(m.Keys))).Key(m.Keys...).Arg(m.Args...).Build())
+	for _, m := range multi {
+		if !s.nosha1 {
+			if s.readonly {
+				cmds = append(cmds, c.B().EvalshaRo().Sha1(s.sha1).Numkeys(int64(len(m.Keys))).Key(m.Keys...).Arg(m.Args...).Build())
+			} else {
+				cmds = append(cmds, c.B().Evalsha().Sha1(s.sha1).Numkeys(int64(len(m.Keys))).Key(m.Keys...).Arg(m.Args...).Build())
+			}
+		} else {
+			if s.readonly {
+				cmds = append(cmds, c.B().EvalRo().Script(s.script).Numkeys(int64(len(m.Keys))).Key(m.Keys...).Arg(m.Args...).Build())
+			} else {
+				cmds = append(cmds, c.B().Eval().Script(s.script).Numkeys(int64(len(m.Keys))).Key(m.Keys...).Arg(m.Args...).Build())
+			}
 		}
 	}
 	return c.DoMulti(ctx, cmds...)

--- a/lua_test.go
+++ b/lua_test.go
@@ -75,6 +75,37 @@ func TestNewLuaScript(t *testing.T) {
 	}
 }
 
+func TestNewLuaScriptNoSha(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	body := strconv.Itoa(rand.Int())
+	sum := sha1.Sum([]byte(body))
+	sha := hex.EncodeToString(sum[:])
+
+	k := []string{"1", "2"}
+	a := []string{"3", "4"}
+
+	c := &client{
+		BFn: func() Builder {
+			return cmds.NewBuilder(cmds.NoSlot)
+		},
+		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
+			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA", sha, "2", "1", "2", "3", "4"}) {
+				t.Fatal("EVALSHA must not be called")
+			}
+			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
+				return newResult(RedisMessage{typ: '_'}, nil)
+			}
+			return newResult(strmsg('+', "unexpected"), nil)
+		},
+	}
+
+	script := NewLuaScriptNoSha(body)
+
+	if err, ok := IsRedisErr(script.Exec(context.Background(), c, k, a).Error()); ok && !err.IsNil() {
+		t.Fatalf("ret mistmatch")
+	}
+}
+
 func TestNewLuaScriptReadOnly(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	body := strconv.Itoa(rand.Int())
@@ -103,6 +134,37 @@ func TestNewLuaScriptReadOnly(t *testing.T) {
 	}
 
 	script := NewLuaScriptReadOnly(body)
+
+	if err, ok := IsRedisErr(script.Exec(context.Background(), c, k, a).Error()); ok && !err.IsNil() {
+		t.Fatalf("ret mistmatch")
+	}
+}
+
+func TestNewLuaScriptReadOnlyNoSha(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	body := strconv.Itoa(rand.Int())
+	sum := sha1.Sum([]byte(body))
+	sha := hex.EncodeToString(sum[:])
+
+	k := []string{"1", "2"}
+	a := []string{"3", "4"}
+
+	c := &client{
+		BFn: func() Builder {
+			return cmds.NewBuilder(cmds.NoSlot)
+		},
+		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
+			if reflect.DeepEqual(cmd.Commands(), []string{"EVALSHA_RO", sha, "2", "1", "2", "3", "4"}) {
+				t.Fatal("EVALSHA_RO must not be called")
+			}
+			if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
+				return newResult(RedisMessage{typ: '_'}, nil)
+			}
+			return newResult(strmsg('+', "unexpected"), nil)
+		},
+	}
+
+	script := NewLuaScriptReadOnlyNoSha(body)
 
 	if err, ok := IsRedisErr(script.Exec(context.Background(), c, k, a).Error()); ok && !err.IsNil() {
 		t.Fatalf("ret mistmatch")
@@ -163,6 +225,36 @@ func TestNewLuaScriptExecMulti(t *testing.T) {
 	}
 }
 
+func TestNewLuaScriptExecMultiNoSha(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	body := strconv.Itoa(rand.Int())
+
+	k := []string{"1", "2"}
+	a := []string{"3", "4"}
+
+	c := &client{
+		BFn: func() Builder {
+			return cmds.NewBuilder(cmds.NoSlot)
+		},
+		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
+			return newResult(strmsg('+', "OK"), nil)
+		},
+		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []RedisResult) {
+			for _, cmd := range multi {
+				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL", body, "2", "1", "2", "3", "4"}) {
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+				}
+			}
+			return resp
+		},
+	}
+
+	script := NewLuaScriptNoSha(body)
+	if v, err := script.ExecMulti(context.Background(), c, LuaExec{Keys: k, Args: a})[0].ToString(); err != nil || v != "OK" {
+		t.Fatalf("ret mistmatch")
+	}
+}
+
 func TestNewLuaScriptExecMultiRo(t *testing.T) {
 	defer ShouldNotLeaked(SetupLeakDetection())
 	body := strconv.Itoa(rand.Int())
@@ -190,6 +282,36 @@ func TestNewLuaScriptExecMultiRo(t *testing.T) {
 	}
 
 	script := NewLuaScriptReadOnly(body)
+	if v, err := script.ExecMulti(context.Background(), c, LuaExec{Keys: k, Args: a})[0].ToString(); err != nil || v != "OK" {
+		t.Fatalf("ret mistmatch")
+	}
+}
+
+func TestNewLuaScriptExecMultiRoNoSha(t *testing.T) {
+	defer ShouldNotLeaked(SetupLeakDetection())
+	body := strconv.Itoa(rand.Int())
+
+	k := []string{"1", "2"}
+	a := []string{"3", "4"}
+
+	c := &client{
+		BFn: func() Builder {
+			return cmds.NewBuilder(cmds.NoSlot)
+		},
+		DoFn: func(ctx context.Context, cmd Completed) (resp RedisResult) {
+			return newResult(strmsg('+', "OK"), nil)
+		},
+		DoMultiFn: func(ctx context.Context, multi ...Completed) (resp []RedisResult) {
+			for _, cmd := range multi {
+				if reflect.DeepEqual(cmd.Commands(), []string{"EVAL_RO", body, "2", "1", "2", "3", "4"}) {
+					resp = append(resp, newResult(strmsg('+', "OK"), nil))
+				}
+			}
+			return resp
+		},
+	}
+
+	script := NewLuaScriptReadOnlyNoSha(body)
 	if v, err := script.ExecMulti(context.Background(), c, LuaExec{Keys: k, Args: a})[0].ToString(); err != nil || v != "OK" {
 		t.Fatalf("ret mistmatch")
 	}


### PR DESCRIPTION
Hello,

First of all, sorry for bringing some mess to rueidis 🙏  But generally this change can be useful for many other users too, especially those from enterprise environments.

[FIPS 140-3 Compliance](https://go.dev/doc/security/fips140) document, which is part of the Go 1.24 release defines runtime GODEBUG runtime toggles for [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) compliance.

SHA-1 is not a FIPS-approved algorithm, so using it in integrations with Redis complicates compliancy audit. And also Go runtime panics in case of using Redis Lua with `fips140=only` mode: https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/crypto/sha1/sha1.go;l=273

This PR adds support to avoid SHA-1 usage by introducing a couple of new constructors for Lua scripts: `NewLuaScriptNoSha` and `NewLuaScriptReadOnlyNoSha`. This will allow `rueidis` users avoid SHA-1 usage when really required, without adding any FIPS knowledge to the library itself. Probably a better way to organize API exists.

Not using `EVALSHA` introduces performance overhead, I tried to run one of the benchmarks which uses Lua call:

```
name                           old time/op    new time/op    delta
RedisPresence_1Ch/rd_single-8    3.30µs ± 1%    4.88µs ± 1%  +47.84%  (p=0.000 n=9+10)

name                           old alloc/op   new alloc/op   delta
RedisPresence_1Ch/rd_single-8      638B ± 0%      640B ± 0%   +0.38%  (p=0.006 n=10+8)

name                           old allocs/op  new allocs/op  delta
RedisPresence_1Ch/rd_single-8      10.0 ± 0%      10.0 ± 0%     ~     (all equal)
```

So it's sth like 300k ops/sec -> 200k ops/sec for this specific script, but the compliance is priority here for enterprises to simplify FIPS audit.

I think ideally, this should be addressed by Redis – by introducing SHA-2 support for Lua scripting maybe. But given we now have many Redis-compatible storages the process will take a lot of time definitely. Linking to the related issue in Redis BTW - https://github.com/redis/redis/issues/12690