### PR TITLE
Update package name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you need to reference them afterward (e.g. to retrieve the key), use the `Pin
 
 ```golang
 // Create pinned commands to preserve them from being recycled
-cmds := make(valkey.Commands, 0, 10)
+cmds := make(rueidis.Commands, 0, 10)
 for i := 0; i < 10; i++ {
 	cmds = append(cmds, client.B().Get().Key(strconv.Itoa(i)).Build().Pin())
 }


### PR DESCRIPTION
Changed `valkey.Commands` to `rueidis.Commands` in the pinned commands example.