### PR TITLE
Fix url parser write_timeout parameter

### DIFF
--- a/url.go
+++ b/url.go
@@ -82,7 +82,7 @@ func ParseURL(str string) (opt ClientOption, err error) {
 		}
 	}
 	if q.Has("write_timeout") {
-		if opt.Dialer.Timeout, err = time.ParseDuration(q.Get("write_timeout")); err != nil {
+		if opt.ConnWriteTimeout, err = time.ParseDuration(q.Get("write_timeout")); err != nil {
 			return opt, fmt.Errorf("redis: invalid write timeout: %q", q.Get("write_timeout"))
 		}
 	}


### PR DESCRIPTION
## Summary
- correct `write_timeout` query parameter to update `ConnWriteTimeout`

## Testing
- `go test ./internal/...` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684518cd994c8324b49170153c43591a