### PR TITLE
feat: Add TotalNetIn, TotalNetOut, and TotalCmds fields to ClientInfo

### DIFF
--- a/rueidiscompat/command.go
+++ b/rueidiscompat/command.go
@@ -4711,6 +4711,9 @@ type ClientInfo struct {
 	TotalMemory        int           // tot-mem, total memory consumed by this client in its various buffers
 	Redir              int64         // client id of current client tracking redirection
 	Resp               int           // redis version 7.0, client RESP protocol version
+	TotalNetIn         int64         // tot-net-in, total network bytes read from the client connection
+	TotalNetOut        int64         // tot-net-out, total network bytes sent to the client connection
+	TotalCmds          int64         // tot-cmds, number of commands executed by the client connection
 }
 
 type ClientInfoCmd struct {
@@ -4857,6 +4860,12 @@ func stringToClientInfo(txt string) (*ClientInfo, error) {
 			info.LibName = val
 		case "lib-ver":
 			info.LibVer = val
+		case "tot-net-in":
+			info.TotalNetIn, err = strconv.ParseInt(val, 10, 64)
+		case "tot-net-out":
+			info.TotalNetOut, err = strconv.ParseInt(val, 10, 64)
+		case "tot-cmds":
+			info.TotalCmds, err = strconv.ParseInt(val, 10, 64)
 		}
 
 		if err != nil {

--- a/rueidiscompat/command_test.go
+++ b/rueidiscompat/command_test.go
@@ -1151,3 +1151,35 @@ func TestCommandErrorHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestClientInfoParsing(t *testing.T) {
+	// Test case with the new fields
+	testData := "id=123 addr=127.0.0.1:6379 fd=5 name= age=10 idle=5 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=32768 obl=0 oll=0 omem=0 events=r cmd=ping user=default redir=-1 resp=3 lib-name=redis-go lib-ver=8.0.0 tot-net-in=1024 tot-net-out=2048 tot-cmds=100"
+
+	info, err := stringToClientInfo(testData)
+	if err != nil {
+		t.Fatalf("Failed to parse client info: %v", err)
+	}
+
+	// Verify the new fields are parsed correctly
+	if info.TotalNetIn != 1024 {
+		t.Errorf("Expected TotalNetIn to be 1024, got %d", info.TotalNetIn)
+	}
+
+	if info.TotalNetOut != 2048 {
+		t.Errorf("Expected TotalNetOut to be 2048, got %d", info.TotalNetOut)
+	}
+
+	if info.TotalCmds != 100 {
+		t.Errorf("Expected TotalCmds to be 100, got %d", info.TotalCmds)
+	}
+
+	// Verify other fields are still parsed correctly
+	if info.ID != 123 {
+		t.Errorf("Expected ID to be 123, got %d", info.ID)
+	}
+
+	if info.Addr != "127.0.0.1:6379" {
+		t.Errorf("Expected Addr to be '127.0.0.1:6379', got '%s'", info.Addr)
+	}
+}


### PR DESCRIPTION
This PR adds support for the new Redis client information fields introduced in redis/redis#13944.

- `TotalNetIn` (int64): total network bytes read from the client connection
- `TotalNetOut` (int64): total network bytes sent to the client connection  
- `TotalCmds` (int64): number of commands executed by the client connection

https://github.com/redis/rueidis/issues/872