### PR TITLE
feat: Add HStrLen command support 

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -155,6 +155,7 @@ type CoreCmdable interface {
 	HIncrByFloat(ctx context.Context, key, field string, incr float64) *FloatCmd
 	HKeys(ctx context.Context, key string) *StringSliceCmd
 	HLen(ctx context.Context, key string) *IntCmd
+	HStrLen(ctx context.Context, key, field string) *IntCmd
 	HMGet(ctx context.Context, key string, fields ...string) *SliceCmd
 	HSet(ctx context.Context, key string, values ...any) *IntCmd
 	HMSet(ctx context.Context, key string, values ...any) *BoolCmd
@@ -1380,6 +1381,12 @@ func (c *Compat) HKeys(ctx context.Context, key string) *StringSliceCmd {
 
 func (c *Compat) HLen(ctx context.Context, key string) *IntCmd {
 	cmd := c.client.B().Hlen().Key(key).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newIntCmd(resp)
+}
+
+func (c *Compat) HStrLen(ctx context.Context, key, field string) *IntCmd {
+	cmd := c.client.B().Hstrlen().Key(key).Field(field).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newIntCmd(resp)
 }
@@ -6046,6 +6053,12 @@ func (c CacheCompat) HKeys(ctx context.Context, key string) *StringSliceCmd {
 
 func (c CacheCompat) HLen(ctx context.Context, key string) *IntCmd {
 	cmd := c.client.B().Hlen().Key(key).Cache()
+	resp := c.client.DoCache(ctx, cmd, c.ttl)
+	return newIntCmd(resp)
+}
+
+func (c CacheCompat) HStrLen(ctx context.Context, key, field string) *IntCmd {
+	cmd := c.client.B().Hstrlen().Key(key).Field(field).Cache()
 	resp := c.client.DoCache(ctx, cmd, c.ttl)
 	return newIntCmd(resp)
 }

--- a/rueidiscompat/adapter_test.go
+++ b/rueidiscompat/adapter_test.go
@@ -3860,6 +3860,15 @@ func testAdapter(resp3 bool) {
 			Expect(sMembers.Err()).NotTo(HaveOccurred())
 			Expect(sMembers.Val()).To(HaveLen(5))
 		})
+
+		It("should HStrLen", func() {
+			hSet := adapter.HSet(ctx, "hash", "field", "hello")
+			Expect(hSet.Err()).NotTo(HaveOccurred())
+
+			hStrLen := adapter.HStrLen(ctx, "hash", "field")
+			Expect(hStrLen.Err()).NotTo(HaveOccurred())
+			Expect(hStrLen.Val()).To(Equal(int64(5)))
+		})
 	})
 
 	Describe("sorted sets", func() {
@@ -8033,6 +8042,15 @@ func testAdapterCache(resp3 bool) {
 			// err = adapter.Cache(time.Hour).HVals(ctx, "hash").ScanSlice(&slice)
 			// Expect(err).NotTo(HaveOccurred())
 			// Expect(slice).To(Equal([]string{"hello1", "hello2"}))
+		})
+
+		It("should HStrLen", func() {
+			hSet := adapter.HSet(ctx, "hash", "field", "hello")
+			Expect(hSet.Err()).NotTo(HaveOccurred())
+
+			hStrLen := adapter.Cache(time.Hour).HStrLen(ctx, "hash", "field")
+			Expect(hStrLen.Err()).NotTo(HaveOccurred())
+			Expect(hStrLen.Val()).To(Equal(int64(5)))
 		})
 	})
 

--- a/rueidiscompat/pipeline.go
+++ b/rueidiscompat/pipeline.go
@@ -631,6 +631,12 @@ func (c *Pipeline) HLen(ctx context.Context, key string) *IntCmd {
 	return ret
 }
 
+func (c *Pipeline) HStrLen(ctx context.Context, key, field string) *IntCmd {
+	ret := c.comp.HStrLen(ctx, key, field)
+	c.rets = append(c.rets, ret)
+	return ret
+}
+
 func (c *Pipeline) HMGet(ctx context.Context, key string, fields ...string) *SliceCmd {
 	ret := c.comp.HMGet(ctx, key, fields...)
 	c.rets = append(c.rets, ret)


### PR DESCRIPTION
This PR adds support for the `HStrLen` Redis command to the rueidiscompat layer providing compatibility with go-redis APIs.

https://github.com/redis/rueidis/issues/884