### PR TITLE
Support FieldValueIter for Hsetex

### DIFF
--- a/internal/cmds/iter.go
+++ b/internal/cmds/iter.go
@@ -21,6 +21,13 @@ func (c HsetFieldValue) FieldValueIter(seq iter.Seq2[string, string]) HsetFieldV
 	return c
 }
 
+func (c HsetexFieldValue) FieldValueIter(seq iter.Seq2[string, string]) HsetexFieldValue {
+	for field, value := range seq {
+		c.cs.s = append(c.cs.s, field, value)
+	}
+	return c
+}
+
 func (c XaddFieldValue) FieldValueIter(seq iter.Seq2[string, string]) XaddFieldValue {
 	for field, value := range seq {
 		c.cs.s = append(c.cs.s, field, value)

--- a/internal/cmds/iter_test.go
+++ b/internal/cmds/iter_test.go
@@ -10,6 +10,7 @@ import (
 func iter0(s Builder) {
 	s.Hmset().Key("1").FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
 	s.Hset().Key("1").FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
+	s.Hsetex().Key("1").Fields().Numfields(1).FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
 	s.Xadd().Key("1").Id("*").FieldValue().FieldValueIter(maps.All(map[string]string{"1": "1"})).Build()
 	s.Zadd().Key("1").ScoreMember().ScoreMemberIter(maps.All(map[string]float64{"1": float64(1)})).Build()
 }


### PR DESCRIPTION
- Added `hsetex` method to the `iter.go`.
- Created a new test case for it.