### PR TITLE
perf: put aware context before set command

### DIFF
--- a/pipe_test.go
+++ b/pipe_test.go
@@ -3501,7 +3501,7 @@ func TestPubSub(t *testing.T) {
 
 			p, mock, _, _ := setup(t, ClientOption{})
 			atomic.StoreInt32(&p.state, 1)
-			p.queue.PutOne(push)
+			p.queue.PutOne(context.Background(), push)
 			_, _, ch := p.queue.NextWriteCmd()
 			go func() {
 				mock.Expect().Reply(strmsg(
@@ -3531,8 +3531,8 @@ func TestPubSub(t *testing.T) {
 
 			p, mock, _, _ := setup(t, ClientOption{})
 			atomic.StoreInt32(&p.state, 1)
-			p.queue.PutOne(push)
-			p.queue.PutOne(cmds.PingCmd)
+			p.queue.PutOne(context.Background(), push)
+			p.queue.PutOne(context.Background(), cmds.PingCmd)
 			_, _, ch := p.queue.NextWriteCmd()
 			_, _, _ = p.queue.NextWriteCmd()
 			go func() {
@@ -3824,7 +3824,7 @@ func TestPubSub(t *testing.T) {
 
 			p, mock, _, _ := setup(t, ClientOption{})
 			atomic.StoreInt32(&p.state, 1)
-			p.queue.PutOne(builder.Get().Key("a").Build())
+			p.queue.PutOne(context.Background(), builder.Get().Key("a").Build())
 			p.queue.NextWriteCmd()
 			go func() {
 				mock.Expect().Reply(slicemsg(
@@ -3854,7 +3854,7 @@ func TestPubSub(t *testing.T) {
 
 			p, mock, _, _ := setup(t, ClientOption{})
 			atomic.StoreInt32(&p.state, 1)
-			p.queue.PutOne(cmd)
+			p.queue.PutOne(context.Background(), cmd)
 			p.queue.NextWriteCmd()
 			go func() {
 				mock.Expect().Reply(strmsg('+', "QUEUED"))


### PR DESCRIPTION
tiny improvement about [the issue](https://github.com/redis/rueidis/issues/858)

This PR doesn't solve above issue. To solve the issue, I think rewriting ring buffer is needed. But That's quite huge.

This PR improves two things.
1. Do not use command if context is done.
2. do not make waiting coroutine if context is done.

I think this tiny improvement is helpful for very rare situation, that buffer is full and lots of requests are waiting other requests. 

