### PR TITLE
fix: correctly handle early exit in `Scanner` iterators

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -302,7 +302,10 @@ func (s *Scanner) scan() iter.Seq[[]string] {
 func (s *Scanner) Iter() iter.Seq[string] {
 	return func(yield func(string) bool) {
 		for vs := range s.scan() {
-			for i := 0; i < len(vs) && yield(vs[i]); i++ {
+			for _, v := range vs {
+				if !yield(v) {
+					return
+				}
 			}
 		}
 	}
@@ -311,7 +314,10 @@ func (s *Scanner) Iter() iter.Seq[string] {
 func (s *Scanner) Iter2() iter.Seq2[string, string] {
 	return func(yield func(string, string) bool) {
 		for vs := range s.scan() {
-			for i := 0; i+1 < len(vs) && yield(vs[i], vs[i+1]); i += 2 {
+			for i := 0; i+1 < len(vs); i += 2 {
+				if !yield(vs[i], vs[i+1]) {
+					return
+				}
 			}
 		}
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -1534,6 +1534,27 @@ func TestScannerIter(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("early exit", func(t *testing.T) {
+		callCount := 0
+		entries := []ScanEntry{
+			{Elements: []string{"key1"}, Cursor: 10},
+		}
+		scanner := NewScanner(func(cursor uint64) (ScanEntry, error) {
+			if callCount >= len(entries) {
+				return ScanEntry{}, errors.New("unexpected call")
+			}
+			entry := entries[callCount]
+			callCount++
+			return entry, nil
+		})
+		for range scanner.Iter() {
+			break
+		}
+		if scanner.Err() != nil {
+			t.Errorf("unexpected error: %v", scanner.Err())
+		}
+	})
 }
 
 func TestScannerIter2(t *testing.T) {
@@ -1623,4 +1644,25 @@ func TestScannerIter2(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("early exit", func(t *testing.T) {
+		callCount := 0
+		entries := []ScanEntry{
+			{Elements: []string{"field1", "value1"}, Cursor: 10},
+		}
+		scanner := NewScanner(func(cursor uint64) (ScanEntry, error) {
+			if callCount >= len(entries) {
+				return ScanEntry{}, errors.New("unexpected call")
+			}
+			entry := entries[callCount]
+			callCount++
+			return entry, nil
+		})
+		for range scanner.Iter2() {
+			break
+		}
+		if scanner.Err() != nil {
+			t.Errorf("unexpected error: %v", scanner.Err())
+		}
+	})
 }


### PR DESCRIPTION
Both inner and outer `for` must be exited when `yield` returns `false`.