### PR TITLE
fix: don't send READONLY for standalone clients

### DIFF
--- a/standalone.go
+++ b/standalone.go
@@ -21,7 +21,6 @@ func newStandaloneClient(opt *ClientOption, connFn connFn, retryer retryHandler)
 		primary:    newSingleClientWithConn(p, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer, false),
 		replicas:   make([]*singleClient, len(opt.Standalone.ReplicaAddress)),
 	}
-	opt.ReplicaOnly = true
 	for i := range s.replicas {
 		replicaConn := connFn(opt.Standalone.ReplicaAddress[i], opt)
 		if err := replicaConn.Dial(); err != nil {


### PR DESCRIPTION
READONLY is intended for more advanced use cases with Redis Cluster, not
standalone with read replicas. Sending it here appears to be a no-op
that changes the connection flags (from N to r) but otherwise has no
effect.

This also fixes #906, a harmless bug where the primary connection would
unintentionally send READONLY on reconnects due to the shared
ClientOption reference.