### PR TITLE
Couple of tweaks for just introduced LuaOption

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -14,24 +14,24 @@ import (
 // LuaOption is a functional option for configuring Lua script behavior.
 type LuaOption func(*Lua)
 
-// WithLoadSha1 enables loading of SHA-1 from Redis via SCRIPT LOAD instead of calculating
+// WithLoadSHA1 allows enabling loading of SHA-1 from Redis via SCRIPT LOAD instead of calculating
 // it on the client side. When enabled, the SHA-1 hash is not calculated client-side (important
 // for FIPS compliance). Instead, on first execution, SCRIPT LOAD is called to obtain the SHA-1
 // from Redis, which is then used for EVALSHA commands in subsequent executions.
-func WithLoadSha1() LuaOption {
+func WithLoadSHA1(enabled bool) LuaOption {
 	return func(l *Lua) {
-		l.loadSha1 = true
+		l.loadSha1 = enabled
 	}
 }
 
 // NewLuaScript creates a Lua instance whose Lua.Exec uses EVALSHA and EVAL.
-// By default, SHA-1 is calculated client-side. Use WithLoadSha1() option to load SHA-1 from Redis instead.
+// By default, SHA-1 is calculated client-side. Use WithLoadSHA1(true) option to load SHA-1 from Redis instead.
 func NewLuaScript(script string, opts ...LuaOption) *Lua {
 	return newLuaScript(script, false, false, opts...)
 }
 
 // NewLuaScriptReadOnly creates a Lua instance whose Lua.Exec uses EVALSHA_RO and EVAL_RO.
-// By default, SHA-1 is calculated client-side. Use WithLoadSha1() option to load SHA-1 from Redis instead.
+// By default, SHA-1 is calculated client-side. Use WithLoadSHA1(true) option to load SHA-1 from Redis instead.
 func NewLuaScriptReadOnly(script string, opts ...LuaOption) *Lua {
 	return newLuaScript(script, true, false, opts...)
 }

--- a/lua_test.go
+++ b/lua_test.go
@@ -330,7 +330,7 @@ type client struct {
 	ModeFn         func() ClientMode
 }
 
-func (c *client) Receive(ctx context.Context, subscribe Completed, fn func(msg PubSubMessage)) error {
+func (c *client) Receive(_ context.Context, _ Completed, _ func(msg PubSubMessage)) error {
 	return nil
 }
 
@@ -355,11 +355,11 @@ func (c *client) DoMulti(ctx context.Context, cmd ...Completed) (resp []RedisRes
 	return nil
 }
 
-func (c *client) DoStream(ctx context.Context, cmd Completed) (resp RedisResultStream) {
+func (c *client) DoStream(_ context.Context, _ Completed) (resp RedisResultStream) {
 	return RedisResultStream{}
 }
 
-func (c *client) DoMultiStream(ctx context.Context, cmd ...Completed) (resp MultiRedisResultStream) {
+func (c *client) DoMultiStream(_ context.Context, _ ...Completed) (resp MultiRedisResultStream) {
 	return MultiRedisResultStream{}
 }
 
@@ -438,7 +438,7 @@ func TestNewLuaScriptWithLoadSha1(t *testing.T) {
 		},
 	}
 
-	script := NewLuaScript(body, WithLoadSha1())
+	script := NewLuaScript(body, WithLoadSHA1(true))
 
 	if v, err := script.Exec(context.Background(), c, k, a).ToString(); err != nil || v != "OK" {
 		t.Fatalf("ret mismatch")
@@ -485,7 +485,7 @@ func TestNewLuaScriptReadOnlyWithLoadSha1(t *testing.T) {
 		},
 	}
 
-	script := NewLuaScriptReadOnly(body, WithLoadSha1())
+	script := NewLuaScriptReadOnly(body, WithLoadSHA1(true))
 
 	if v, err := script.Exec(context.Background(), c, k, a).ToString(); err != nil || v != "OK" {
 		t.Fatalf("ret mismatch")
@@ -527,7 +527,7 @@ func TestNewLuaScriptWithLoadSha1Concurrent(t *testing.T) {
 		},
 	}
 
-	script := NewLuaScript(body, WithLoadSha1())
+	script := NewLuaScript(body, WithLoadSHA1(true))
 
 	// Execute concurrently to verify singleflight works correctly
 	done := make(chan bool)
@@ -583,7 +583,7 @@ func TestNewLuaScriptWithLoadSha1ExecMulti(t *testing.T) {
 		},
 	}
 
-	script := NewLuaScript(body, WithLoadSha1())
+	script := NewLuaScript(body, WithLoadSHA1(true))
 	if v, err := script.ExecMulti(context.Background(), c, LuaExec{Keys: k, Args: a})[0].ToString(); err != nil || v != "OK" {
 		t.Fatalf("ret mismatch")
 	}
@@ -658,7 +658,7 @@ func BenchmarkLuaScript_Exec(b *testing.B) {
 		script *Lua
 	}{
 		{"Default", NewLuaScript(script)},
-		{"LoadSha1", NewLuaScript(script, WithLoadSha1())},
+		{"LoadSHA1", NewLuaScript(script, WithLoadSHA1(true))},
 		{"NoSha", NewLuaScriptNoSha(script)},
 	}
 
@@ -758,7 +758,7 @@ func BenchmarkLuaScript_ExecMulti(b *testing.B) {
 		script *Lua
 	}{
 		{"Default", NewLuaScript(script)},
-		{"LoadSha1", NewLuaScript(script, WithLoadSha1())},
+		{"LoadSHA1", NewLuaScript(script, WithLoadSHA1(true))},
 		{"NoSha", NewLuaScriptNoSha(script)},
 	}
 


### PR DESCRIPTION
A minor follow-up for https://github.com/redis/rueidis/pull/914

 * Use `WithLoadSHA1` instead of `WithLoadSha1` to be more idiomatic for Go
 * Have `WithLoadSHA1(enabled bool)` instead of just `WithLoadSHA1()`. This allows making Lua script in one line `rueidis.NewLuaScript(script, rueidis.WithLoadSHA1(config.LoadSHA1))` instead of dealing with `[]LuaOption` slice and filling it conditionally based on application's `config.LoadSHA1`.