### PR TITLE
feat: commands add ToRetryable

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,15 @@ to make sure manually cancellation is respected, especially for blocking request
 All read-only commands are automatically retried on failures by default before their context deadlines exceeded.
 You can disable this by setting `DisableRetry` or adjust the number of retries and durations between retries using `RetryDelay` function.
 
+### Retryable Commands
+
+Write commands can set Retryable to automatically retried on failures like read-only commands. Make sure you only use this feature with idempotent operations.
+
+```golang
+client.Do(ctx, client.B().Set().Key("key").Value("val").Build().ToRetryable())
+client.DoMulti(ctx, client.B().Set().Key("key").Value("val").Build().ToRetryable())
+```
+
 ## Pub/Sub
 
 To receive messages from channels, `client.Receive()` should be used. It supports `SUBSCRIBE`, `PSUBSCRIBE`, and Redis 7.0's `SSUBSCRIBE`:

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -3,14 +3,15 @@ package cmds
 import "strings"
 
 const (
-	optInTag = uint16(1 << 15)
-	blockTag = uint16(1 << 14)
-	readonly = uint16(1 << 13)
-	noRetTag = uint16(1<<12) | readonly | pipeTag // make noRetTag can also be retried and auto pipelining
-	mtGetTag = uint16(1<<11) | readonly           // make mtGetTag can also be retried
-	scrRoTag = uint16(1<<10) | readonly           // make scrRoTag can also be retried
-	unsubTag = uint16(1<<9) | noRetTag
-	pipeTag  = uint16(1 << 8) // make blocking mode request can use auto pipelining
+	optInTag     = uint16(1 << 15)
+	blockTag     = uint16(1 << 14)
+	readonly     = uint16(1<<13) | retryableTag
+	noRetTag     = uint16(1<<12) | readonly | pipeTag // make noRetTag can also be retried and auto pipelining
+	mtGetTag     = uint16(1<<11) | readonly           // make mtGetTag can also be retried
+	scrRoTag     = uint16(1<<10) | readonly           // make scrRoTag can also be retried
+	unsubTag     = uint16(1<<9) | noRetTag
+	pipeTag      = uint16(1 << 8) // make blocking mode request can use auto pipelining
+	retryableTag = uint16(1 << 7) // make command retryable
 	// InitSlot indicates that the command be sent to any redis node in cluster
 	InitSlot = uint16(1 << 14)
 	// NoSlot indicates that the command has no key slot specified
@@ -123,6 +124,12 @@ func (c Completed) ToPipe() Completed {
 	return c
 }
 
+// ToRetryable return a new command with retryableTag
+func (c Completed) ToRetryable() Completed {
+	c.cf |= retryableTag
+	return c
+}
+
 // IsEmpty checks if it is an empty command.
 func (c *Completed) IsEmpty() bool {
 	return c.cs == nil || len(c.cs.s) == 0
@@ -161,6 +168,11 @@ func (c *Completed) IsWrite() bool {
 // IsPipe checks if it is set pipeTag which prefers auto pipelining
 func (c *Completed) IsPipe() bool {
 	return c.cf&pipeTag == pipeTag
+}
+
+// IsRetryable checks if it is set retryableTag
+func (c *Completed) IsRetryable() bool {
+	return c.cf&retryableTag == retryableTag
 }
 
 // Commands returns the commands as []string.

--- a/sentinel.go
+++ b/sentinel.go
@@ -86,7 +86,7 @@ retry:
 		if err == errConnExpired {
 			goto retry
 		}
-		if c.retry && cmd.IsReadOnly() && c.isRetryable(err, ctx) {
+		if c.retry && cmd.IsRetryable() && c.isRetryable(err, ctx) {
 			if c.retryHandler.WaitOrSkipRetry(ctx, attempts, cmd, err) {
 				attempts++
 				goto retry
@@ -136,7 +136,7 @@ retry:
 			goto recover
 		}
 	}
-	if c.retry && allReadOnly(multi) {
+	if c.retry && allRetryable(multi) {
 		for i, resp := range resps.s {
 			if c.isRetryable(resp.Error(), ctx) {
 				shouldRetry := c.retryHandler.WaitOrSkipRetry(


### PR DESCRIPTION
For #919

- command control flag add retryableTag
- let readonly tag also retryable
- use `IsRetryable` instead of `IsReadOnly` to check if we should retry commands
- add some testcase for making Write command ( like `Set` ) retryable and verify it retry under some redis retryable issues
- update doc README for this feature
