### PR TITLE
Ensure that monitored lock keys expiration is always ahead of current time by KeyValidity duration

### DIFF
--- a/rueidislock/lock.go
+++ b/rueidislock/lock.go
@@ -270,7 +270,7 @@ func (m *locker) try(ctx context.Context, cancel context.CancelFunc, name string
 				case <-ctx.Done():
 					err = ctx.Err()
 				case <-timer.C:
-					deadline = deadline.Add(m.interval)
+					deadline = time.Now().Add(m.validity)
 					if err = m.script(ctx, extend, key, val, deadline); err == nil {
 						timer.Reset(m.interval)
 					}


### PR DESCRIPTION
Ref issue #923