### PR TITLE
docs: fix some broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Once a command is built, use either `client.Do()` or `client.DoMulti()` to send 
 
 To reuse a command, use `Pin()` after `Build()` and it will prevent the command from being recycled.
 
-## [Pipelining](https://redis.io/docs/manual/pipelining/)
+## [Pipelining](https://redis.io/docs/latest/develop/using-commands/pipelining/)
 
 ### Auto Pipelining
 
 All concurrent non-blocking redis commands (such as `GET`, `SET`) are automatically pipelined by default,
 which reduces the overall round trips and system calls and gets higher throughput. You can easily get the benefit
-of [pipelining technique](https://redis.io/docs/manual/pipelining/) by just calling `client.Do()` from multiple goroutines concurrently.
+of [pipelining technique](https://redis.io/docs/latest/develop/using-commands/pipelining/) by just calling `client.Do()` from multiple goroutines concurrently.
 For example:
 
 ```go

--- a/rueidisaside/README.md
+++ b/rueidisaside/README.md
@@ -1,6 +1,6 @@
 # rueidisaside
 
-A Cache-Aside pattern implementation enhanced by [Client Side Caching](https://redis.io/docs/manual/client-side-caching/).
+A Cache-Aside pattern implementation enhanced by [Client Side Caching](https://redis.io/docs/latest/develop/reference/client-side-caching/).
 
 ## Features backed by the Redis Client Side Caching
 

--- a/rueidislock/README.md
+++ b/rueidislock/README.md
@@ -1,6 +1,6 @@
 # rueidislock
 
-A [Redis Distributed Lock Pattern](https://redis.io/docs/latest/develop/use/patterns/distributed-locks/) enhanced by [Client Side Caching](https://redis.io/docs/manual/client-side-caching/).
+A [Redis Distributed Lock Pattern](https://redis.io/docs/latest/develop/use/patterns/distributed-locks/) enhanced by [Client Side Caching](https://redis.io/docs/latest/develop/reference/client-side-caching/).
 
 ```go
 package main


### PR DESCRIPTION
This fixes all broken links that start with `redis.io/docs/manual/`.