### PR TITLE
add Az awareness helpers

### DIFF
--- a/rueidis.go
+++ b/rueidis.go
@@ -93,6 +93,10 @@ var (
 	DisableClientSetInfo = make([]string, 0)
 )
 
+// Define distinct types for safety.
+type ReadNodeSelectorFunc func(slot uint16, nodes []NodeInfo) int
+type ReplicaSelectorFunc func(slot uint16, replicas []NodeInfo) int
+
 // ClientOption should be passed to NewClient to construct a Client
 type ClientOption struct {
 	TLSConfig *tls.Config
@@ -135,7 +139,7 @@ type ClientOption struct {
 	// Each ReplicaInfo must not be modified.
 	// NOTE: This function can't be used with ReplicaOnly option.
 	// NOTE: This function must be used with the SendToReplicas function.
-	ReplicaSelector func(slot uint16, replicas []NodeInfo) int
+	ReplicaSelector ReplicaSelectorFunc
 
 	// ReadNodeSelector returns index of node selected for a read only command.
 	// If set, ReadNodeSelector is prioritized over ReplicaSelector.
@@ -143,7 +147,7 @@ type ClientOption struct {
 	// The function is called only when SendToReplicas returns true.
 	// Each NodeInfo must not be modified.
 	// NOTE: This function can't be used with ReplicaSelector option.
-	ReadNodeSelector func(slot uint16, nodes []NodeInfo) int
+	ReadNodeSelector ReadNodeSelectorFunc
 
 	// Sentinel options, including MasterSet and Auth options
 	Sentinel SentinelOption

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -34,6 +34,16 @@ func ShouldNotLeak(g gomega.Gomega, snapshot []gleak.Goroutine) {
 	g.Eventually(gleak.Goroutines).WithTimeout(time.Minute).ShouldNot(gleak.HaveLeaked(snapshot))
 }
 
+// ShouldNotAllocate asserts zero heap allocations for f.
+func ShouldNotAllocate(f func()) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+		if avg := testing.AllocsPerRun(10, f); avg > 0 {
+			t.Errorf("Expected 0 allocs, got %f", avg)
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	g, snap := SetupLeakDetection()
 	code := m.Run()


### PR DESCRIPTION
- Add `AZAffinityNodeSelector` to prioritize replicas in the same Availability
  Zone.
- Add `AZAffinityReplicasAndPrimaryNodeSelector` for granular control,
  prioritizing local replicas, then local primaries, before falling back to
  remote nodes.
- Add `PreferReplicaNodeSelector` for explicit routing requirements.
- Update `ClientOption` to use strict function types (`ReadNodeSelectorFunc`)
  for improved type safety.

Depends on https://github.com/redis/rueidis/pull/930