### PR TITLE
fix: handle nil options in TFunctionLoadArgs

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -3483,8 +3483,10 @@ func (c *Compat) TFunctionLoad(ctx context.Context, lib string) *StatusCmd {
 	return newStatusCmd(resp)
 }
 
-// FIXME: should check nil of options
 func (c *Compat) TFunctionLoadArgs(ctx context.Context, lib string, options *TFunctionLoadOptions) *StatusCmd {
+	if options == nil {
+		return c.TFunctionLoad(ctx, lib)
+	}
 	b := c.client.B()
 	var cmd cmds.Completed
 	if options.Replace {

--- a/rueidiscompat/adapter_test.go
+++ b/rueidiscompat/adapter_test.go
@@ -9498,6 +9498,7 @@ func testAdapterCache(resp3 bool) {
 			Expect(adapter.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 			adapter.TFunctionDelete(ctx, "lib1")
 			adapter.TFunctionDelete(ctx, "lib2")
+			adapter.TFunctionDelete(ctx, "lib3")
 		})
 		// Copied from go-redis
 		// https://github.com/redis/go-redis/blob/f994ff1cd96299a5c8029ae3403af7b17ef06e8a/gears_commands_test.go
@@ -9511,6 +9512,10 @@ func testAdapterCache(resp3 bool) {
 			Expect(resultAdd).To(BeEquivalentTo("OK"))
 			opt.Replace = false
 			resultAdd, err = adapter.TFunctionLoadArgs(ctx, libCodeWithConfig("lib2"), opt).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resultAdd).To(BeEquivalentTo("OK"))
+			// Test nil options - should behave like TFunctionLoad
+			resultAdd, err = adapter.TFunctionLoadArgs(ctx, libCode("lib3"), nil).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resultAdd).To(BeEquivalentTo("OK"))
 		})


### PR DESCRIPTION
## Summary

- Fix potential panic in `TFunctionLoadArgs` when `nil` options are passed
- Add nil check that delegates to `TFunctionLoad` when options is nil
- Add test case for nil options scenario

## Motivation

There was a `FIXME` comment indicating that nil options check was needed:

```go
// FIXME: should check nil of options
func (c *Compat) TFunctionLoadArgs(ctx context.Context, lib string, options *TFunctionLoadOptions) *StatusCmd {
    // ...
    if options.Replace { // <- panic if options is nil
When nil is passed as options, accessing options.Replace causes a panic.
```

## Changes
This PR follows the same pattern used in other functions like HGetEXWithArgs and HSetEXWithArgs:
```
func (c *Compat) TFunctionLoadArgs(ctx context.Context, lib string, options *TFunctionLoadOptions) *StatusCmd {
    if options == nil {
        return c.TFunctionLoad(ctx, lib)
    }
    // ...
}
```