### PR TITLE
feat: add XADD IDMP/IDMPAUTO and XCFGSET support

### DIFF
--- a/rueidiscompat/command.go
+++ b/rueidiscompat/command.go
@@ -2272,14 +2272,23 @@ type LPosArgs struct {
 
 // Note: MaxLen/MaxLenApprox and MinID are in conflict, only one of them can be used.
 type XAddArgs struct {
-	Values     any
-	Stream     string
-	MinID      string
-	ID         string
-	MaxLen     int64
-	Limit      int64
-	NoMkStream bool
-	Approx     bool
+	Values         any
+	Stream         string
+	MinID          string
+	ID             string
+	MaxLen         int64
+	Limit          int64
+	NoMkStream     bool
+	Approx         bool
+	ProducerID     string
+	IdempotentID   string
+	IdempotentAuto bool
+}
+
+type XCfgSetArgs struct {
+	Stream   string
+	Duration int64
+	MaxSize  int64
 }
 
 type XReadArgs struct {

--- a/rueidiscompat/pipeline.go
+++ b/rueidiscompat/pipeline.go
@@ -1255,6 +1255,12 @@ func (c *Pipeline) XInfoConsumers(ctx context.Context, key string, group string)
 	return ret
 }
 
+func (c *Pipeline) XCfgSet(ctx context.Context, a XCfgSetArgs) *StatusCmd {
+	ret := c.comp.XCfgSet(ctx, a)
+	c.rets = append(c.rets, ret)
+	return ret
+}
+
 func (c *Pipeline) BZPopMax(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
 	ret := c.comp.BZPopMax(ctx, timeout, keys...)
 	c.rets = append(c.rets, ret)


### PR DESCRIPTION
closes #947

This PR adds Redis Streams idempotent production support to `rueidiscompat`.

Note: `XINFO STREAM` IDMP fields are not implemented in `rueidiscompat` yet, so this PR tests XADD IDMP/IDMPAUTO and XCFGSET without `XInfoStream` assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Redis 8.6+ Streams semantics to `XADD` and introduces `XCFGSET`, which can change write behavior and stream configuration if misused; scope is contained to the compat adapter and tests.
> 
> **Overview**
> Adds Redis 8.6+ Streams *idempotent production* support to `rueidiscompat` by extending `XAddArgs` and emitting `XADD IDMP/IDMPAUTO` when `ProducerID` is provided.
> 
> Introduces `XCFGSET` support via new `XCfgSetArgs` plus `Cmdable`/`Compat`/`Pipeline` methods, and adds a dedicated RESP3 Redis 8.6 test suite to validate `XADD` idempotency and `XCFGSET` option handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1068cce54a88bb7101d2f68969b32681e0b0bc37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->