### PR TITLE
Use FT._LIST in CreateAndAliasIndex

### DIFF
--- a/om/hash.go
+++ b/om/hash.go
@@ -2,15 +2,14 @@ package om
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 
 	"github.com/redis/rueidis"
+	"github.com/redis/rueidis/internal/cmds"
 )
 
 // NewHashRepository creates a HashRepository.
@@ -162,74 +161,13 @@ func (r *HashRepository[T]) CreateIndex(ctx context.Context, cmdFn func(schema F
 
 // CreateAndAliasIndex creates a new index, aliases it, and drops the old index if needed.
 func (r *HashRepository[T]) CreateAndAliasIndex(ctx context.Context, cmdFn func(schema FtCreateSchema) rueidis.Completed) error {
-	alias := r.idx
-
-	var currentIndex string
-	aliasExists := false
-	infoCmd := r.client.B().FtInfo().Index(alias).Build()
-	infoResp, err := r.client.Do(ctx, infoCmd).ToMap()
-	if err != nil {
-		if strings.Contains(err.Error(), "Unknown index name") {
-			// This is expected when the alias doesn't exist yet
-			aliasExists = false
-		} else {
-			// This is an unexpected error (network, connection, etc.)
-			return fmt.Errorf("failed to check if index exists: %w", err)
-		}
-	} else {
-		aliasExists = true
-	}
-
-	if aliasExists {
-		message, ok := infoResp["index_name"]
-		if !ok {
-			return fmt.Errorf("index_name not found in FT.INFO response")
-		}
-
-		currentIndex, err = message.ToString()
-		if err != nil {
-			return fmt.Errorf("failed to convert index_name to string: %w", err)
-		}
-	}
-
-	newIndex := alias + "_v1"
-	if aliasExists && currentIndex != "" {
-		// Find the last occurrence of "_v" followed by digits
-		lastVersionIndex := strings.LastIndex(currentIndex, "_v")
-		if lastVersionIndex != -1 && lastVersionIndex+2 < len(currentIndex) {
-			versionStr := currentIndex[lastVersionIndex+2:]
-			if version, err := strconv.Atoi(versionStr); err == nil {
-				newIndex = fmt.Sprintf("%s_v%d", alias, version+1)
-			}
-		}
-	}
-
-	// Create the new index
-	cmd := r.client.B().FtCreate().Index(newIndex).OnHash().Prefix(1).Prefix(r.prefix + ":")
-	if err := r.client.Do(ctx, cmdFn(cmd.Schema())).Error(); err != nil {
-		return err
-	}
-
-	// Update or add the alias
-	var aliasErr error
-	if aliasExists {
-		aliasErr = r.client.Do(ctx, r.client.B().FtAliasupdate().Alias(alias).Index(newIndex).Build()).Error()
-	} else {
-		aliasErr = r.client.Do(ctx, r.client.B().FtAliasadd().Alias(alias).Index(newIndex).Build()).Error()
-	}
-
-	if aliasErr != nil {
-		return fmt.Errorf("failed to update alias: %w", aliasErr)
-	}
-
-	// Drop the old index if it exists and differs from the new one
-	if aliasExists && currentIndex != "" && currentIndex != newIndex {
-		if err := r.client.Do(ctx, r.client.B().FtDropindex().Index(currentIndex).Build()).Error(); err != nil {
-			return fmt.Errorf("failed to drop old index: %w", err)
-		}
-	}
-
-	return nil
+	return createAndAliasIndex(ctx, r.idx, r.client, func(idx string) cmds.FtCreatePrefixPrefix {
+		return r.client.B().FtCreate().
+			Index(idx).
+			OnHash().
+			Prefix(1).
+			Prefix(r.prefix + ":")
+	}, cmdFn)
 }
 
 // DropIndex uses FT.DROPINDEX from the RediSearch module to drop the index whose name is `hashidx:{prefix}`

--- a/om/hash_test.go
+++ b/om/hash_test.go
@@ -697,32 +697,46 @@ func TestNewHashRepositoryTTL(t *testing.T) {
 func TestCreateAndAliasIndex(t *testing.T) {
 	ctx := context.Background()
 
-	client := setup(t)
-	client.Do(ctx, client.B().Flushall().Build())
-	defer client.Close()
+	testCases := []struct {
+		name       string
+		clientOpts []option
+	}{
+		{
+			name: "RediSearch 2.8.4",
+		},
+		{
+			name:       "Redis 8.6.0",
+			clientOpts: []option{withRedis86},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("CreateAndAliasIndex: %s", tc.name), func(t *testing.T) {
+			client := setup(t, tc.clientOpts...)
+			client.Do(ctx, client.B().Flushall().Build())
+			defer client.Close()
 
-	repo := NewHashRepository("hashalias", HashTestStruct{}, client)
+			repo := NewHashRepository("hashalias", HashTestStruct{}, client)
 
-	t.Run("CreateAndAliasIndex", func(t *testing.T) {
-		err := repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
-			return schema.FieldName("Val").Text().Build()
+			err := repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
+				return schema.FieldName("Val").Text().Build()
+			})
+			if err != nil {
+				t.Fatalf("failed to create and alias index: %v", err)
+			}
+
+			verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v1")
+
+			// Step 3: Create new index version and update alias
+			err = repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
+				return schema.FieldName("Val").Text().Build()
+			})
+			if err != nil {
+				t.Fatalf("failed to create and alias new index version: %v", err)
+			}
+
+			verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v2")
 		})
-		if err != nil {
-			t.Fatalf("failed to create and alias index: %v", err)
-		}
-
-		verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v1")
-
-		// Step 3: Create new index version and update alias
-		err = repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
-			return schema.FieldName("Val").Text().Build()
-		})
-		if err != nil {
-			t.Fatalf("failed to create and alias new index version: %v", err)
-		}
-
-		verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v2")
-	})
+	}
 }
 
 // Helper to verify that alias points to the expected index name

--- a/om/indexes.go
+++ b/om/indexes.go
@@ -11,7 +11,8 @@ import (
 	"github.com/redis/rueidis/internal/cmds"
 )
 
-// createAndAliasIndex creates a new index, aliases it, and drops the old index if needed.
+// createAndAliasIndex creates a new versioned index, aliases it to idx, and then drops all
+// existing versioned indexes (idx_vN) that were previously associated with that alias.
 func createAndAliasIndex(ctx context.Context, idx string, client rueidis.Client, createCmd func(idx string) cmds.FtCreatePrefixPrefix, cmdFn func(schema FtCreateSchema) rueidis.Completed) error {
 	idxRE, err := regexp.Compile("^" + regexp.QuoteMeta(idx) + "_v(\\d+)$")
 	if err != nil {

--- a/om/indexes.go
+++ b/om/indexes.go
@@ -1,0 +1,66 @@
+package om
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+
+	"github.com/redis/rueidis"
+	"github.com/redis/rueidis/internal/cmds"
+)
+
+// createAndAliasIndex creates a new index, aliases it, and drops the old index if needed.
+func createAndAliasIndex(ctx context.Context, idx string, client rueidis.Client, createCmd func(idx string) cmds.FtCreatePrefixPrefix, cmdFn func(schema FtCreateSchema) rueidis.Completed) error {
+	idxRE, err := regexp.Compile("^" + regexp.QuoteMeta(idx) + "_v(\\d+)$")
+	if err != nil {
+		return fmt.Errorf("failed to compile regular expression: %w", err)
+	}
+
+	listCmd := client.B().FtList().Build()
+	listResp, err := client.Do(ctx, listCmd).ToArray()
+	if err != nil {
+		return fmt.Errorf("failed to list indexes: %w", err)
+	}
+
+	currVers := make([]int, 0)
+	for _, message := range listResp {
+		n, err := message.ToString()
+		if err != nil {
+			return fmt.Errorf("FT._LIST retured non-string response: %w", err)
+		}
+		match := idxRE.FindStringSubmatch(n)
+		if len(match) < 2 {
+			continue
+		}
+		ver, err := strconv.Atoi(match[1])
+		if err != nil {
+			return fmt.Errorf("failed converting version number for index %q: %w", n, err)
+		}
+		currVers = append(currVers, ver)
+	}
+
+	newIndex := idx + "_v1"
+	if len(currVers) > 0 {
+		newIndex = fmt.Sprintf("%s_v%d", idx, slices.Max(currVers)+1)
+	}
+
+	// Create the new index
+	if err := client.Do(ctx, cmdFn(createCmd(newIndex).Schema())).Error(); err != nil {
+		return err
+	}
+
+	if err := client.Do(ctx, client.B().FtAliasupdate().Alias(idx).Index(newIndex).Build()).Error(); err != nil {
+		return fmt.Errorf("failed to update alias: %w", err)
+	}
+
+	for _, ver := range currVers {
+		currIdx := fmt.Sprintf("%s_v%d", idx, ver)
+		if err := client.Do(ctx, client.B().FtDropindex().Index(currIdx).Build()).Error(); err != nil {
+			return fmt.Errorf("failed to drop old index %q: %w", currIdx, err)
+		}
+	}
+
+	return nil
+}

--- a/om/indexes.go
+++ b/om/indexes.go
@@ -16,20 +16,20 @@ import (
 func createAndAliasIndex(ctx context.Context, idx string, client rueidis.Client, createCmd func(idx string) cmds.FtCreatePrefixPrefix, cmdFn func(schema FtCreateSchema) rueidis.Completed) error {
 	idxRE, err := regexp.Compile("^" + regexp.QuoteMeta(idx) + "_v(\\d+)$")
 	if err != nil {
-		return fmt.Errorf("failed to compile regular expression: %w", err)
+		return fmt.Errorf("compiling regular expression: %w", err)
 	}
 
 	listCmd := client.B().FtList().Build()
 	listResp, err := client.Do(ctx, listCmd).ToArray()
 	if err != nil {
-		return fmt.Errorf("failed to list indexes: %w", err)
+		return fmt.Errorf("listing indexes: %w", err)
 	}
 
 	currVers := make([]int, 0)
 	for _, message := range listResp {
 		n, err := message.ToString()
 		if err != nil {
-			return fmt.Errorf("FT._LIST retured non-string response: %w", err)
+			return fmt.Errorf("FT._LIST returned non-string response: %w", err)
 		}
 		match := idxRE.FindStringSubmatch(n)
 		if len(match) < 2 {
@@ -37,7 +37,7 @@ func createAndAliasIndex(ctx context.Context, idx string, client rueidis.Client,
 		}
 		ver, err := strconv.Atoi(match[1])
 		if err != nil {
-			return fmt.Errorf("failed converting version number for index %q: %w", n, err)
+			return fmt.Errorf("converting version number for index %q: %w", n, err)
 		}
 		currVers = append(currVers, ver)
 	}
@@ -49,17 +49,17 @@ func createAndAliasIndex(ctx context.Context, idx string, client rueidis.Client,
 
 	// Create the new index
 	if err := client.Do(ctx, cmdFn(createCmd(newIndex).Schema())).Error(); err != nil {
-		return err
+		return fmt.Errorf("creating new index: %w", err)
 	}
 
 	if err := client.Do(ctx, client.B().FtAliasupdate().Alias(idx).Index(newIndex).Build()).Error(); err != nil {
-		return fmt.Errorf("failed to update alias: %w", err)
+		return fmt.Errorf("updating alias: %w", err)
 	}
 
 	for _, ver := range currVers {
 		currIdx := fmt.Sprintf("%s_v%d", idx, ver)
 		if err := client.Do(ctx, client.B().FtDropindex().Index(currIdx).Build()).Error(); err != nil {
-			return fmt.Errorf("failed to drop old index %q: %w", currIdx, err)
+			return fmt.Errorf("dropping old index %q: %w", currIdx, err)
 		}
 	}
 

--- a/om/json.go
+++ b/om/json.go
@@ -3,7 +3,6 @@ package om
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
+	"github.com/redis/rueidis/internal/cmds"
 )
 
 // NewJSONRepository creates a JSONRepository.
@@ -157,75 +157,13 @@ func (r *JSONRepository[T]) CreateIndex(ctx context.Context, cmdFn func(schema F
 
 // CreateAndAliasIndex creates a new index, aliases it, and drops the old index if needed.
 func (r *JSONRepository[T]) CreateAndAliasIndex(ctx context.Context, cmdFn func(schema FtCreateSchema) rueidis.Completed) error {
-	alias := r.idx
-
-	var currentIndex string
-	aliasExists := false
-	infoCmd := r.client.B().FtInfo().Index(alias).Build()
-	infoResp, err := r.client.Do(ctx, infoCmd).ToMap()
-	if err != nil {
-		if strings.Contains(err.Error(), "Unknown index name") {
-			aliasExists = false
-		} else {
-			return fmt.Errorf("failed to check if index exists: %w", err)
-		}
-	} else {
-		aliasExists = true
-	}
-
-	if aliasExists {
-		message, ok := infoResp["index_name"]
-		if !ok {
-			return fmt.Errorf("index_name not found in FT.INFO response")
-		}
-		currentIndex, err = message.ToString()
-		if err != nil {
-			return fmt.Errorf("failed to convert index_name to string: %w", err)
-		}
-	}
-
-	// Compute new index version name
-	newIndex := alias + "_v1"
-	if aliasExists && currentIndex != "" {
-		lastVersionIndex := strings.LastIndex(currentIndex, "_v")
-		if lastVersionIndex != -1 && lastVersionIndex+2 < len(currentIndex) {
-			versionStr := currentIndex[lastVersionIndex+2:]
-			if version, err := strconv.Atoi(versionStr); err == nil {
-				newIndex = fmt.Sprintf("%s_v%d", alias, version+1)
-			}
-		}
-	}
-
-	// Create the new index with schema
-	createCmd := r.client.B().FtCreate().
-		Index(newIndex).
-		OnJson().
-		Prefix(1).
-		Prefix(r.prefix + ":")
-	if err := r.client.Do(ctx, cmdFn(createCmd.Schema())).Error(); err != nil {
-		return fmt.Errorf("failed to create index %s: %w", newIndex, err)
-	}
-
-	// Set alias to point to new index
-	var aliasErr error
-	if aliasExists {
-		aliasErr = r.client.Do(ctx, r.client.B().FtAliasupdate().Alias(alias).Index(newIndex).Build()).Error()
-	} else {
-		aliasErr = r.client.Do(ctx, r.client.B().FtAliasadd().Alias(alias).Index(newIndex).Build()).Error()
-	}
-
-	if aliasErr != nil {
-		return fmt.Errorf("failed to update alias: %w", aliasErr)
-	}
-
-	// Drop old index if it's different from the new one
-	if aliasExists && currentIndex != "" && currentIndex != newIndex {
-		if err := r.client.Do(ctx, r.client.B().FtDropindex().Index(currentIndex).Build()).Error(); err != nil {
-			return fmt.Errorf("failed to drop old index: %w", err)
-		}
-	}
-
-	return nil
+	return createAndAliasIndex(ctx, r.idx, r.client, func(idx string) cmds.FtCreatePrefixPrefix {
+		return r.client.B().FtCreate().
+			Index(idx).
+			OnJson().
+			Prefix(1).
+			Prefix(r.prefix + ":")
+	}, cmdFn)
 }
 
 // DropIndex uses FT.DROPINDEX from the RediSearch module to drop the index whose name is `jsonidx:{prefix}`

--- a/om/json_test.go
+++ b/om/json_test.go
@@ -692,31 +692,45 @@ func TestNewJSONTTLRepository(t *testing.T) {
 func TestCreateAndAliasIndex_JSON(t *testing.T) {
 	ctx := context.Background()
 
-	client := setup(t)
-	client.Do(ctx, client.B().Flushall().Build())
-	defer client.Close()
+	testCases := []struct {
+		name       string
+		clientOpts []option
+	}{
+		{
+			name: "RediSearch 2.8.4",
+		},
+		{
+			name:       "Redis 8.6.0",
+			clientOpts: []option{withRedis86},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("CreateAndAliasIndex: %s", tc.name), func(t *testing.T) {
+			client := setup(t)
+			client.Do(ctx, client.B().Flushall().Build())
+			defer client.Close()
 
-	repo := NewJSONRepository("jsonalias", JSONTestStruct{}, client)
+			repo := NewJSONRepository("jsonalias", JSONTestStruct{}, client)
 
-	t.Run("CreateAndAliasIndex_JSON", func(t *testing.T) {
-		err := repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
-			return schema.FieldName("$.val").As("val").Text().Build()
+			err := repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
+				return schema.FieldName("$.val").As("val").Text().Build()
+			})
+			if err != nil {
+				t.Fatalf("failed to create and alias JSON index: %v", err)
+			}
+
+			verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v1")
+
+			err = repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
+				return schema.FieldName("$.val").As("val").Text().Build()
+			})
+			if err != nil {
+				t.Fatalf("failed to create and alias new JSON index version: %v", err)
+			}
+
+			verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v2")
 		})
-		if err != nil {
-			t.Fatalf("failed to create and alias JSON index: %v", err)
-		}
-
-		verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v1")
-
-		err = repo.CreateAndAliasIndex(ctx, func(schema FtCreateSchema) rueidis.Completed {
-			return schema.FieldName("$.val").As("val").Text().Build()
-		})
-		if err != nil {
-			t.Fatalf("failed to create and alias new JSON index version: %v", err)
-		}
-
-		verifyAliasTarget(t, ctx, client, repo.IndexName(), repo.IndexName()+"_v2")
-	})
+	}
 }
 
 type JSONTestVerlessTTLStruct struct {

--- a/om/json_test.go
+++ b/om/json_test.go
@@ -706,7 +706,7 @@ func TestCreateAndAliasIndex_JSON(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("CreateAndAliasIndex: %s", tc.name), func(t *testing.T) {
-			client := setup(t)
+			client := setup(t, tc.clientOpts...)
 			client.Do(ctx, client.B().Flushall().Build())
 			defer client.Close()
 

--- a/om/repo_test.go
+++ b/om/repo_test.go
@@ -6,8 +6,18 @@ import (
 	"github.com/redis/rueidis"
 )
 
-func setup(t *testing.T) rueidis.Client {
-	client, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6377"}})
+type option func(*rueidis.ClientOption)
+
+func withRedis86(c *rueidis.ClientOption) {
+	c.InitAddress = []string{"127.0.0.1:6382"}
+}
+
+func setup(t *testing.T, opts ...option) rueidis.Client {
+	clientOption := &rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6377"}}
+	for _, opt := range opts {
+		opt(clientOption)
+	}
+	client, err := rueidis.NewClient(*clientOption)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #969.
The current implementation fails tests when running against Redis 8 (presumably the version in which the error message from `FT.INFO` changed).

Introduced a new implementation for `CreateAndAliasIndex` which does the following:
1. Query `FT._LIST`.
2. Finds all existing indexes which match the versioned index pattern (index + "_v" + version).
3. Creates a new index with the latest version + 1 (or 1 if no existing index).
4. Updates the alias to point to the new index (works whether or not the alias already exists).
5. Drops all the old indexes.

The implementation is shared between Hash and JSON repositories to avoid duplication.
The new implementation passes the tests against Redis 8 and redis-stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RediSearch index rotation logic (create/alias/drop), which could impact index availability or unexpectedly drop indexes if naming matches; behavior is exercised by updated tests across two Redis versions.
> 
> **Overview**
> Fixes `CreateAndAliasIndex` for both Hash and JSON repositories by replacing the `FT.INFO`/error-string-based flow with a shared implementation that uses `FT._LIST` to discover existing `*_vN` indexes, create the next version, `FT.ALIASUPDATE` the alias, and drop prior versions.
> 
> Updates tests to run the alias/versioning behavior against both redis-stack (RediSearch 2.8.4) and Redis 8.6.0, and refactors test client setup to support multiple server targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da04f17bcbcab63ab0d39140c2aba4bb36a2b70f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->