### PR TITLE
perf: skip retry sleep if context deadline is too short

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -72,14 +72,14 @@ func (r *retryer) WaitForRetry(ctx context.Context, duration time.Duration) {
 	}
 }
 
-func (r *retryer) WaitOrSkipRetry(
-	ctx context.Context, attempts int, cmd Completed, err error,
-) bool {
-	if delay := r.RetryDelay(attempts, cmd, err); delay == 0 {
+func (r *retryer) WaitOrSkipRetry(ctx context.Context, attempts int, cmd Completed, err error) bool {
+	delay := r.RetryDelay(attempts, cmd, err)
+	if delay == 0 {
 		runtime.Gosched()
 		return true
-	} else if delay > 0 {
-		if dl, ok := ctx.Deadline(); !ok || time.Until(dl) > delay {
+	}
+	if delay > 0 {
+		if dl, ok := ctx.Deadline(); !ok || time.Until(dl) > (delay+(100*time.Microsecond)) {
 			r.WaitForRetry(ctx, delay)
 			return true
 		}

--- a/retryer_custom_test.go
+++ b/retryer_custom_test.go
@@ -1,0 +1,27 @@
+package rueidis
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitOrSkipRetry_DeadlineBuffer(t *testing.T) {
+	r := newRetryer(func(attempts int, cmd Completed, err error) time.Duration {
+		return 10 * time.Millisecond // This will force a 10ms delay.
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	start := time.Now() // Returns false immediately b/c 5ms < 10ms + buffer inherently
+	retriable := r.WaitOrSkipRetry(ctx, 1, Completed{}, nil)
+	duration := time.Since(start)
+
+	if retriable {
+		t.Errorf("Expected retriable to be false when deadline is shorter than delay")
+	}
+	if duration > 2*time.Millisecond {
+		t.Errorf("Expected function to return immediately, but it took %v", duration)
+	}
+}


### PR DESCRIPTION
Problem: The current WaitOrSkipRetry implementation may initiate a sleep/wait even if the context.Deadline is guaranteed to expire before the sleep finishes. This leads to unnecessary timer allocations and goroutine parking in scenarios where a retry is inherently impossible.

Solution: Introduce a 100us buffer to account for runtime and scheduling overhead. If the remaining time in the context is less than the calculated delay + buffer, the function returns false immediately to fail-fast.

Verification: Added TestWaitOrSkipRetry_DeadlineBuffer to validate the early-exit logic. Verified that all integration tests (cluster, sentinel, locking) pass locally on darwin/arm64.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk perf tweak limited to retry backoff gating; main risk is behavior change at tight deadlines potentially reducing retry attempts in edge timing cases.
> 
> **Overview**
> `WaitOrSkipRetry` now *fails fast* when the remaining `context` deadline is shorter than the computed retry delay plus a small (100µs) buffer, avoiding unnecessary timer/sleep work when a retry cannot realistically complete.
> 
> Adds `TestWaitOrSkipRetry_DeadlineBuffer` to assert the function returns immediately (and non-retriable) when the deadline is shorter than the delay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6777b0746b87d7efb6c60455c00197d924599191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->