### PR TITLE
fix: add expiration key to rate limit script execution

### DIFF
--- a/rueidislimiter/limiter.go
+++ b/rueidislimiter/limiter.go
@@ -115,6 +115,11 @@ func (l *rateLimiter) AllowN(ctx context.Context, identifier string, n int64, op
 	key := rueidis.BinaryString(bufs.keyBuf[offset:])
 
 	offset = len(bufs.keyBuf)
+	bufs.keyBuf = append(bufs.keyBuf, key...)
+	bufs.keyBuf = append(bufs.keyBuf, ":ex"...)
+	expiresAtKey := rueidis.BinaryString(bufs.keyBuf[offset:])
+
+	offset = len(bufs.keyBuf)
 	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, n, 10)
 	arg1 := rueidis.BinaryString(bufs.keyBuf[offset:])
 
@@ -126,7 +131,7 @@ func (l *rateLimiter) AllowN(ctx context.Context, identifier string, n int64, op
 	bufs.keyBuf = strconv.AppendInt(bufs.keyBuf, now.UnixMilli(), 10)
 	arg3 := rueidis.BinaryString(bufs.keyBuf[offset:])
 
-	resp := rateLimitScript.Exec(ctx, l.client, []string{key}, []string{arg1, arg2, arg3})
+	resp := rateLimitScript.Exec(ctx, l.client, []string{key, expiresAtKey}, []string{arg1, arg2, arg3})
 	if err := resp.Error(); err != nil {
 		return Result{}, err
 	}

--- a/rueidislimiter/limiter.go
+++ b/rueidislimiter/limiter.go
@@ -166,7 +166,7 @@ local rate_limit_key = KEYS[1]
 local increment_amount = tonumber(ARGV[1])
 local next_expires_at = tonumber(ARGV[2])
 local current_time = tonumber(ARGV[3])
-local expires_at_key = rate_limit_key .. ":ex"
+local expires_at_key = KEYS[2]
 local expires_at = tonumber(redis.call("get", expires_at_key))
 if not expires_at or expires_at < current_time then
   redis.call("set", rate_limit_key, 0, "pxat", next_expires_at + 1000)


### PR DESCRIPTION
Error:
 
```
{
  "value": "Error running script (call to ...): @user_script:8: script tried accessing undeclared key, key: arl:{...}:ex",
  "key": "exception.message"
}
```

Solution:
Adding generated ex key in lua script to arguments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to Redis Lua script invocation to satisfy key declaration requirements. Main risk is behavior differences if callers/keys are constructed inconsistently, but logic is otherwise unchanged.
> 
> **Overview**
> Fixes Redis Lua script execution by explicitly passing the `:ex` (expires-at) key as `KEYS[2]` instead of deriving it inside the script.
> 
> `AllowN` now constructs `expiresAtKey` alongside the main rate-limit key and executes `rateLimitScript` with both keys, preventing "undeclared key" errors under strict key access modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c513b1dbb34abe39a6df0da82fe475a1035d777. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->