### PR TITLE
fix: premature recycles in MGET/MSET helpers

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -288,19 +288,6 @@ func clusterMGet(client Client, ctx context.Context, keys []string) (ret map[str
 	resps := client.DoMulti(ctx, cmds.s...)
 	defer resultsp.Put(&redisresults{s: resps})
 
-	recycle := true
-	for _, resp := range resps {
-		if resp.NonRedisError() != nil {
-			recycle = false
-			break
-		}
-	}
-	defer func() {
-		if recycle {
-			mgetcmdsp.Put(cmds)
-		}
-	}()
-
 	for i, resp := range resps {
 		arr, err := resp.ToArray()
 		if err != nil {
@@ -309,11 +296,9 @@ func clusterMGet(client Client, ctx context.Context, keys []string) (ret map[str
 		for j, val := range arr {
 			ret[cmds.s[i].Commands()[j+1]] = val
 		}
-	}
-
-	for i := range cmds.s {
 		intl.PutCompletedForce(cmds.s[i])
 	}
+	mgetcmdsp.Put(cmds)
 	return ret, nil
 }
 
@@ -346,19 +331,6 @@ func clusterJsonMGet(client Client, ctx context.Context, keys []string, path str
 	resps := client.DoMulti(ctx, cmds.s...)
 	defer resultsp.Put(&redisresults{s: resps})
 
-	recycle := true
-	for _, resp := range resps {
-		if resp.NonRedisError() != nil {
-			recycle = false
-			break
-		}
-	}
-	defer func() {
-		if recycle {
-			mgetcmdsp.Put(cmds)
-		}
-	}()
-
 	for i, resp := range resps {
 		arr, err := resp.ToArray()
 		if err != nil {
@@ -367,11 +339,9 @@ func clusterJsonMGet(client Client, ctx context.Context, keys []string, path str
 		for j, val := range arr {
 			ret[cmds.s[i].Commands()[j+1]] = val
 		}
-	}
-
-	for i := range cmds.s {
 		intl.PutCompletedForce(cmds.s[i])
 	}
+	mgetcmdsp.Put(cmds)
 	return ret, nil
 }
 

--- a/helper.go
+++ b/helper.go
@@ -66,11 +66,10 @@ func MSet(client Client, ctx context.Context, kvs map[string]string) map[string]
 	}
 
 	cmds := mgetcmdsp.Get(0, len(kvs))
-	defer mgetcmdsp.Put(cmds)
 	for k, v := range kvs {
 		cmds.s = append(cmds.s, client.B().Set().Key(k).Value(v).Build().Pin())
 	}
-	return doMultiSet(client, ctx, cmds.s)
+	return doMultiSet(client, ctx, cmds)
 }
 
 // MDel is a helper that consults the redis directly with multiple keys by grouping keys within the same slot into DELs
@@ -85,11 +84,10 @@ func MDel(client Client, ctx context.Context, keys []string) map[string]error {
 	}
 
 	cmds := mgetcmdsp.Get(len(keys), len(keys))
-	defer mgetcmdsp.Put(cmds)
 	for i, k := range keys {
 		cmds.s[i] = client.B().Del().Key(k).Build().Pin()
 	}
-	return doMultiSet(client, ctx, cmds.s)
+	return doMultiSet(client, ctx, cmds)
 }
 
 // MSetNX is a helper that consults the redis directly with multiple keys by grouping keys within the same slot into MSETNXs or multiple SETNXs
@@ -104,11 +102,10 @@ func MSetNX(client Client, ctx context.Context, kvs map[string]string) map[strin
 	}
 
 	cmds := mgetcmdsp.Get(0, len(kvs))
-	defer mgetcmdsp.Put(cmds)
 	for k, v := range kvs {
 		cmds.s = append(cmds.s, client.B().Set().Key(k).Value(v).Nx().Build().Pin())
 	}
-	return doMultiSet(client, ctx, cmds.s)
+	return doMultiSet(client, ctx, cmds)
 }
 
 // JsonMGetCache is a helper that consults the client-side caches with multiple keys by grouping keys within the same slot into multiple JSON.GETs
@@ -150,11 +147,10 @@ func JsonMSet(client Client, ctx context.Context, kvs map[string]string, path st
 	}
 
 	cmds := mgetcmdsp.Get(0, len(kvs))
-	defer mgetcmdsp.Put(cmds)
 	for k, v := range kvs {
 		cmds.s = append(cmds.s, client.B().JsonSet().Key(k).Path(path).Value(v).Build().Pin())
 	}
-	return doMultiSet(client, ctx, cmds.s)
+	return doMultiSet(client, ctx, cmds)
 }
 
 // DecodeSliceOfJSON is a helper that struct-scans each RedisMessage into dest, which must be a slice of the pointer.
@@ -236,15 +232,27 @@ func doMultiCache(cc Client, ctx context.Context, cmds []CacheableTTL, keys []st
 	return ret, nil
 }
 
-func doMultiSet(cc Client, ctx context.Context, cmds []Completed) (ret map[string]error) {
+// doMultiSet runs DoMulti, recycles each Completed on success, and returns buf to
+// mgetcmdsp when every result has no non-Redis error. If any non-Redis error
+// occurs (e.g. context deadline), the auto-pipelining writer may still be
+// reading buf.s, so buf is not Put back.
+func doMultiSet(cc Client, ctx context.Context, buf *mgetcmds) (ret map[string]error) {
+	cmds := buf.s
 	ret = make(map[string]error, len(cmds))
 	resps := cc.DoMulti(ctx, cmds...)
+	recycle := true
 	for i, resp := range resps {
-		if ret[cmds[i].Commands()[1]] = resp.Error(); resp.NonRedisError() == nil {
+		ret[cmds[i].Commands()[1]] = resp.Error()
+		if resp.NonRedisError() != nil {
+			recycle = false
+		} else {
 			intl.PutCompletedForce(cmds[i])
 		}
 	}
 	resultsp.Put(&redisresults{s: resps})
+	if recycle {
+		mgetcmdsp.Put(buf)
+	}
 	return ret
 }
 
@@ -265,7 +273,6 @@ func clusterMGet(client Client, ctx context.Context, keys []string) (ret map[str
 	hint := len(keys) / 2
 	slotIdx := make(map[uint16]int, hint)
 	cmds := mgetcmdsp.Get(0, hint)
-	defer mgetcmdsp.Put(cmds)
 
 	for _, key := range keys {
 		slot := intl.Slot(key)
@@ -280,6 +287,19 @@ func clusterMGet(client Client, ctx context.Context, keys []string) (ret map[str
 
 	resps := client.DoMulti(ctx, cmds.s...)
 	defer resultsp.Put(&redisresults{s: resps})
+
+	recycle := true
+	for _, resp := range resps {
+		if resp.NonRedisError() != nil {
+			recycle = false
+			break
+		}
+	}
+	defer func() {
+		if recycle {
+			mgetcmdsp.Put(cmds)
+		}
+	}()
 
 	for i, resp := range resps {
 		arr, err := resp.ToArray()
@@ -307,7 +327,6 @@ func clusterJsonMGet(client Client, ctx context.Context, keys []string, path str
 	hint := len(keys) / 2
 	slotIdx := make(map[uint16]int, hint)
 	cmds := mgetcmdsp.Get(0, hint)
-	defer mgetcmdsp.Put(cmds)
 
 	for _, key := range keys {
 		slot := intl.Slot(key)
@@ -326,6 +345,19 @@ func clusterJsonMGet(client Client, ctx context.Context, keys []string, path str
 
 	resps := client.DoMulti(ctx, cmds.s...)
 	defer resultsp.Put(&redisresults{s: resps})
+
+	recycle := true
+	for _, resp := range resps {
+		if resp.NonRedisError() != nil {
+			recycle = false
+			break
+		}
+	}
+	defer func() {
+		if recycle {
+			mgetcmdsp.Put(cmds)
+		}
+	}()
 
 	for i, resp := range resps {
 		arr, err := resp.ToArray()

--- a/helper_test.go
+++ b/helper_test.go
@@ -1959,3 +1959,273 @@ func TestAZAffinityNodesSelection(t *testing.T) {
 		}))
 	})
 }
+
+// TestClusterHelpersMgetcmdspRecycle exercises doMultiSet / clusterMGet / clusterJsonMGet
+// paths that return *mgetcmds to the pool only when no result has a non-Redis error.
+func TestClusterHelpersMgetcmdspRecycle(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+	cluster := func() (*mockConn, *clusterClient) {
+		m := &mockConn{
+			DoFn: func(cmd Completed) RedisResult {
+				return slotsResp
+			},
+		}
+		client, err := newClusterClient(
+			&ClientOption{InitAddress: []string{":0"}},
+			func(dst string, opt *ClientOption) conn { return m },
+			newRetryer(defaultRetryDelayFn),
+		)
+		if err != nil {
+			t.Fatalf("newClusterClient: %v", err)
+		}
+		return m, client
+	}
+
+	t.Run("doMultiSet_skips_mgetcmdsp_Put_when_any_non_redis_error", func(t *testing.T) {
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			out := make([]RedisResult, len(cmd))
+			for i, c := range cmd {
+				if c.Commands()[1] == "{x}dead" {
+					out[i] = newErrResult(context.DeadlineExceeded)
+				} else {
+					out[i] = newResult(strmsg('+', "OK"), nil)
+				}
+			}
+			return &redisresults{s: out}
+		}
+		errs := MSet(client, context.Background(), map[string]string{
+			"{x}ok":   "1",
+			"{x}dead": "2",
+		})
+		if errs["{x}ok"] != nil {
+			t.Fatalf("ok key: %v", errs["{x}ok"])
+		}
+		if !errors.Is(errs["{x}dead"], context.DeadlineExceeded) {
+			t.Fatalf("dead key: got %v", errs["{x}dead"])
+		}
+	})
+
+	t.Run("doMultiSet_Put_mgetcmdsp_when_only_redis_level_errors", func(t *testing.T) {
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			out := make([]RedisResult, len(cmd))
+			for i := range cmd {
+				out[i] = newResult(strmsg(typeSimpleErr, "ERR oops"), nil)
+			}
+			return &redisresults{s: out}
+		}
+		errs := MSet(client, context.Background(), map[string]string{"{x}a": "1", "{x}b": "2"})
+		for k, e := range errs {
+			var re *RedisError
+			if !errors.As(e, &re) {
+				t.Fatalf("key %s: want *RedisError, got %T %v", k, e, e)
+			}
+		}
+	})
+
+	t.Run("clusterMGet_empty_keys", func(t *testing.T) {
+		_, client := cluster()
+		v, err := MGet(client, context.Background(), []string{})
+		if err != nil || v == nil {
+			t.Fatalf("got %v %v", v, err)
+		}
+	})
+
+	t.Run("clusterMGet_direct_empty_keys", func(t *testing.T) {
+		_, client := cluster()
+		v, err := clusterMGet(client, context.Background(), []string{})
+		if err != nil || v == nil || len(v) != 0 {
+			t.Fatalf("got %v %v", v, err)
+		}
+	})
+
+	t.Run("clusterMGet_same_slot_two_keys_recycles_mgetcmdsp", func(t *testing.T) {
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			if len(cmd) != 1 {
+				t.Fatalf("want 1 merged MGET, got %d", len(cmd))
+			}
+			args := cmd[0].Commands()
+			if args[0] != "MGET" {
+				t.Fatalf("got %v", args)
+			}
+			vals := make([]RedisMessage, len(args)-1)
+			for j := 1; j < len(args); j++ {
+				vals[j-1] = strmsg('+', args[j])
+			}
+			return &redisresults{s: []RedisResult{newResult(slicemsg('*', vals), nil)}}
+		}
+		v, err := MGet(client, context.Background(), []string{"{s}a", "{s}b"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		va, vb := v["{s}a"], v["{s}b"]
+		if va.string() != "{s}a" || vb.string() != "{s}b" {
+			t.Fatalf("unexpected map %v", v)
+		}
+	})
+
+	t.Run("clusterMGet_defers_mgetcmdsp_Put_when_ToArray_fails_without_non_redis", func(t *testing.T) {
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			if len(cmd) != 1 {
+				t.Fatalf("want 1 MGET batch, got %d", len(cmd))
+			}
+			// Non-array success: no r.err, so first-loop recycle stays true; ToArray then errors.
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "not-an-array"), nil)}}
+		}
+		_, err := MGet(client, context.Background(), []string{"{s}only"})
+		if err == nil {
+			t.Fatal("expected ToArray / parse error")
+		}
+	})
+
+	t.Run("clusterMGet_first_loop_break_on_later_non_redis", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			if len(cmd) < 2 {
+				t.Fatalf("want at least 2 MGET commands, got %d", len(cmd))
+			}
+			out := make([]RedisResult, len(cmd))
+			for i := range cmd {
+				if i == 0 {
+					args := cmd[i].Commands()
+					vals := make([]RedisMessage, len(args)-1)
+					for j := 1; j < len(args); j++ {
+						vals[j-1] = strmsg('+', args[j])
+					}
+					out[i] = newResult(slicemsg('*', vals), nil)
+				} else {
+					out[i] = newErrResult(context.Canceled)
+				}
+			}
+			return &redisresults{s: out}
+		}
+		_, err := MGet(client, ctx, []string{"1", "2"})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v", err)
+		}
+	})
+
+	t.Run("clusterMGet_skips_mgetcmdsp_Put_on_non_redis_error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			s := make([]RedisResult, len(cmd))
+			for i := range s {
+				s[i] = newErrResult(context.Canceled)
+			}
+			return &redisresults{s: s}
+		}
+		_, err := MGet(client, ctx, []string{"1", "2"})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v", err)
+		}
+	})
+
+	t.Run("clusterJsonMGet_empty_keys", func(t *testing.T) {
+		_, client := cluster()
+		v, err := JsonMGet(client, context.Background(), []string{}, "$")
+		if err != nil || v == nil {
+			t.Fatalf("got %v %v", v, err)
+		}
+	})
+
+	t.Run("clusterJsonMGet_direct_empty_keys", func(t *testing.T) {
+		_, client := cluster()
+		v, err := clusterJsonMGet(client, context.Background(), []string{}, "$")
+		if err != nil || v == nil || len(v) != 0 {
+			t.Fatalf("got %v %v", v, err)
+		}
+	})
+
+	t.Run("clusterJsonMGet_same_slot_two_keys_recycles_mgetcmdsp", func(t *testing.T) {
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			if len(cmd) != 1 {
+				t.Fatalf("want 1 merged JSON.MGET, got %d", len(cmd))
+			}
+			args := cmd[0].Commands()
+			if args[0] != "JSON.MGET" || args[len(args)-1] != "$" {
+				t.Fatalf("got %v", args)
+			}
+			vals := make([]RedisMessage, len(args)-2)
+			for j := 1; j < len(args)-1; j++ {
+				vals[j-1] = strmsg('+', args[j])
+			}
+			return &redisresults{s: []RedisResult{newResult(slicemsg('*', vals), nil)}}
+		}
+		v, err := JsonMGet(client, context.Background(), []string{"{s}x", "{s}y"}, "$")
+		if err != nil {
+			t.Fatal(err)
+		}
+		vx, vy := v["{s}x"], v["{s}y"]
+		if vx.string() != "{s}x" || vy.string() != "{s}y" {
+			t.Fatalf("unexpected map %v", v)
+		}
+	})
+
+	t.Run("clusterJsonMGet_defers_mgetcmdsp_Put_when_ToArray_fails_without_non_redis", func(t *testing.T) {
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			if len(cmd) != 1 {
+				t.Fatalf("want 1 JSON.MGET batch, got %d", len(cmd))
+			}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "not-array"), nil)}}
+		}
+		_, err := JsonMGet(client, context.Background(), []string{"{s}j"}, "$")
+		if err == nil {
+			t.Fatal("expected error from ToArray")
+		}
+	})
+
+	t.Run("clusterJsonMGet_first_loop_break_on_later_non_redis", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			if len(cmd) < 2 {
+				t.Fatalf("want at least 2 JSON.MGET commands, got %d", len(cmd))
+			}
+			out := make([]RedisResult, len(cmd))
+			for i := range cmd {
+				if i == 0 {
+					args := cmd[i].Commands()
+					vals := make([]RedisMessage, len(args)-2)
+					for j := 1; j < len(args)-1; j++ {
+						vals[j-1] = strmsg('+', args[j])
+					}
+					out[i] = newResult(slicemsg('*', vals), nil)
+				} else {
+					out[i] = newErrResult(context.Canceled)
+				}
+			}
+			return &redisresults{s: out}
+		}
+		_, err := JsonMGet(client, ctx, []string{"1", "2"}, "$")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v", err)
+		}
+	})
+
+	t.Run("clusterJsonMGet_skips_mgetcmdsp_Put_on_non_redis_error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		m, client := cluster()
+		m.DoMultiFn = func(cmd ...Completed) *redisresults {
+			s := make([]RedisResult, len(cmd))
+			for i := range s {
+				s[i] = newErrResult(context.Canceled)
+			}
+			return &redisresults{s: s}
+		}
+		_, err := JsonMGet(client, ctx, []string{"1", "2"}, "$")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cluster multi-command helpers and command-buffer pooling behavior; incorrect recycling could cause data races or subtle request corruption under concurrency/timeouts.
> 
> **Overview**
> Fixes premature recycling of pooled command buffers (`mgetcmdsp`) used by cluster helpers.
> 
> `MSet`/`MDel`/`MSetNX`/`JsonMSet` now pass the pooled `*mgetcmds` buffer into `doMultiSet`, which only returns the buffer to the pool when **no** response contains a non-Redis error (e.g., context cancellation/deadline). `clusterMGet` and `clusterJsonMGet` similarly stop deferring `mgetcmdsp.Put` and instead return buffers only after successful response processing.
> 
> Adds `TestClusterHelpersMgetcmdspRecycle` to cover recycling behavior across success, Redis-level errors, parse errors, and context-cancellation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549554d8142eb7dd36e6a042ae6a26910ba705e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->