### PR TITLE
fix: prefer complete CLUSTER SHARDS response and skip invalid redirect addresses

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -195,6 +195,8 @@ func (c *clusterClient) _refresh() (err error) {
 	c.mu.RUnlock()
 
 	var result clusterslots
+	var bestResult clusterslots
+	var bestCoverage int64
 	for i := 0; i < cap(results); i++ {
 		if i&3 == 0 { // batch CLUSTER SLOTS/CLUSTER SHARDS for every 4 connections
 			for j := i; j < i+4 && j < len(pending); j++ {
@@ -206,8 +208,30 @@ func (c *clusterClient) _refresh() (err error) {
 		result = <-results
 		err = result.reply.Error()
 		if len(result.reply.val.values()) != 0 {
-			break
+			var coverage int64
+			for _, v := range result.reply.val.values() {
+				shard, _ := v.AsMap()
+				shardSlots := shard["slots"]
+				slotPairs := shardSlots.values()
+				for k := 0; k+1 < len(slotPairs); k += 2 {
+					start, _ := slotPairs[k].AsInt64()
+					end, _ := slotPairs[k+1].AsInt64()
+					coverage += end - start + 1
+				}
+			}
+			if coverage >= 16384 {
+				bestResult = result
+				break
+			}
+			if coverage > bestCoverage {
+				bestResult = result
+				bestCoverage = coverage
+			}
 		}
+	}
+	if bestCoverage > 0 || bestResult.addr != "" {
+		result = bestResult
+		err = nil
 	}
 	if err != nil {
 		return err
@@ -490,6 +514,9 @@ func (c *clusterClient) pick(ctx context.Context, slot uint16, toReplica bool) (
 }
 
 func (c *clusterClient) redirectOrNew(addr string, prev conn, slot uint16, mode RedirectMode) conn {
+	if host, _, err := net.SplitHostPort(addr); err != nil || host == "" || host == "?" {
+		return prev
+	}
 	c.mu.RLock()
 	cc := c.conns[addr]
 	c.mu.RUnlock()


### PR DESCRIPTION
## Problem

During cluster topology changes (failover, node replacement), different nodes converge at different times via gossip. Two issues arise:

1. **Incomplete CLUSTER SHARDS**: The first node queried may return incomplete slot coverage (e.g., 13107/16384 slots) while others already have the full topology. Accepting this incomplete response causes `ErrNoSlot` for the missing slots until the next refresh.

2. **Invalid MOVED redirects**: After CLUSTER FORGET, some nodes temporarily return `endpoint: "?"` for the forgotten node. MOVED redirects to `?:6379` cause connections to unresolvable addresses and DNS error storms.

## Changes

### `_refresh`: Prefer complete response

Instead of accepting the first non-empty CLUSTER SHARDS response, count slot coverage and prefer the response with >= 16384 slots. Falls back to the best available if none is complete.

**Performance:** Zero impact in normal operation — first node returns 16384, breaks immediately. During topology changes, reads one more buffered channel result.

### `redirectOrNew`: Skip invalid addresses

Skip MOVED/ASK redirects to addresses with empty or `?` hostname. Returns the previous connection instead of creating one to an unresolvable address.

## Testing

Tested on a 15-node Redis 8.4 cluster with repeated failover + forget cycles. The `_refresh` fix eliminates `ErrNoSlot` errors caused by accepting incomplete topology.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology refresh selection and redirect handling, which affects request routing during failover/topology churn. Logic is localized but could impact slot mapping/connection reuse if coverage parsing or host validation is wrong.
> 
> **Overview**
> Improves cluster topology refresh by scoring `CLUSTER SHARDS`/`CLUSTER SLOTS` responses by slot coverage and preferring a fully covered (16384-slot) result, falling back to the best partial response instead of the first non-empty reply.
> 
> Hardens redirect handling by refusing to follow `MOVED`/`ASK` targets whose host is empty or `?`, returning the existing connection to avoid dialing unresolvable addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1cb647d8726e102ff48f47af3cc30b3fd7ef34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->