### PR TITLE
feat: add ForEachMaster method to rueidiscompat Cmdable interface

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -61,6 +61,10 @@ type Cmdable interface {
 
 	Watch(ctx context.Context, fn func(Tx) error, keys ...string) error
 
+	// ForEachMaster concurrently calls the fn on each master node in the cluster.
+	// It returns the first error if any.
+	ForEachMaster(ctx context.Context, fn func(ctx context.Context, client Cmdable) error) error
+
 	Client() rueidis.Client
 }
 
@@ -667,6 +671,14 @@ func NewAdapter(client rueidis.Client, options ...AdapterOption) Cmdable {
 
 func (c *Compat) Client() rueidis.Client {
 	return c.client
+}
+
+// ForEachMaster concurrently calls the fn on each master node in the cluster.
+// It returns the first error if any.
+func (c *Compat) ForEachMaster(ctx context.Context, fn func(ctx context.Context, client Cmdable) error) error {
+	return c.doPrimaries(ctx, func(client rueidis.Client) error {
+		return fn(ctx, NewAdapter(client))
+	})
 }
 
 func (c *Compat) Cache(ttl time.Duration) CacheCompat {

--- a/rueidiscompat/adapter_option_test.go
+++ b/rueidiscompat/adapter_option_test.go
@@ -27,9 +27,13 @@
 package rueidiscompat
 
 import (
+	"context"
+	"errors"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
+	"github.com/redis/rueidis"
 	"github.com/redis/rueidis/mock"
 	"go.uber.org/mock/gomock"
 )
@@ -75,6 +79,212 @@ func TestWithNodeScaleoutLimit(t *testing.T) {
 		compat = adapter.(*Compat)
 		if compat.maxp != 1 {
 			t.Errorf("expected maxp to be 1, got %d", compat.maxp)
+		}
+	})
+}
+
+func TestForEachMaster(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("calls fn for each master node", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		masterNode := mock.NewClient(ctrl)
+		replicaNode := mock.NewClient(ctrl)
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{
+			"master:6379":  masterNode,
+			"replica:6380": replicaNode,
+		})
+
+		masterNode.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("master"))),
+		)
+		replicaNode.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("slave"))),
+		)
+
+		var called atomic.Int32
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			called.Add(1)
+			return nil
+		})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if called.Load() != 1 {
+			t.Errorf("expected fn to be called 1 time, got %d", called.Load())
+		}
+	})
+
+	t.Run("returns first error from fn", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		masterNode := mock.NewClient(ctrl)
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{
+			"master:6379": masterNode,
+		})
+
+		masterNode.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("master"))),
+		)
+
+		expectedErr := errors.New("test error")
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			return expectedErr
+		})
+		if err == nil {
+			t.Error("expected an error, got nil")
+		} else if err.Error() != expectedErr.Error() {
+			t.Errorf("expected error %v, got %v", expectedErr, err)
+		}
+	})
+
+	t.Run("does not call fn when no master nodes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		replicaNode := mock.NewClient(ctrl)
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{
+			"replica:6380": replicaNode,
+		})
+
+		replicaNode.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("slave"))),
+		)
+
+		var called atomic.Int32
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			called.Add(1)
+			return nil
+		})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if called.Load() != 0 {
+			t.Errorf("expected fn to not be called, got %d", called.Load())
+		}
+	})
+
+	t.Run("returns error when ROLE command fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		node := mock.NewClient(ctrl)
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{
+			"node:6379": node,
+		})
+
+		roleErr := errors.New("connection refused")
+		node.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.ErrorResult(roleErr),
+		)
+
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			t.Error("fn should not be called when ROLE fails")
+			return nil
+		})
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	t.Run("calls fn with multiple master nodes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		master1 := mock.NewClient(ctrl)
+		master2 := mock.NewClient(ctrl)
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{
+			"master1:6379": master1,
+			"master2:6380": master2,
+		})
+
+		master1.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("master"))),
+		)
+		master2.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("master"))),
+		)
+
+		var called atomic.Int32
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			called.Add(1)
+			return nil
+		})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if called.Load() != 2 {
+			t.Errorf("expected fn to be called 2 times, got %d", called.Load())
+		}
+	})
+
+	t.Run("works with empty nodes map", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{})
+
+		var called atomic.Int32
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			called.Add(1)
+			return nil
+		})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if called.Load() != 0 {
+			t.Errorf("expected fn to not be called, got %d", called.Load())
+		}
+	})
+
+	t.Run("provides a working Cmdable to fn", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		masterNode := mock.NewClient(ctrl)
+		clusterClient := mock.NewClient(ctrl)
+
+		clusterClient.EXPECT().Nodes().Return(map[string]rueidis.Client{
+			"master:6379": masterNode,
+		})
+
+		masterNode.EXPECT().Do(gomock.Any(), mock.Match("ROLE")).Return(
+			mock.Result(mock.RedisArray(mock.RedisString("master"))),
+		)
+
+		adapter := NewAdapter(clusterClient)
+		err := adapter.ForEachMaster(ctx, func(ctx context.Context, client Cmdable) error {
+			if client == nil {
+				t.Error("expected non-nil client")
+			}
+			if client.Client() != masterNode {
+				t.Error("expected client to wrap the master node")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
 		}
 	})
 }

--- a/rueidiscompat/pipeline.go
+++ b/rueidiscompat/pipeline.go
@@ -3184,6 +3184,10 @@ func (c *Pipeline) Watch(_ context.Context, _ func(Tx) error, _ ...string) error
 	panic("not implemented")
 }
 
+func (c *Pipeline) ForEachMaster(_ context.Context, _ func(ctx context.Context, client Cmdable) error) error {
+	panic("not implemented")
+}
+
 func (c *Pipeline) Client() rueidis.Client {
 	return c.comp.client.(*proxy).Client
 }


### PR DESCRIPTION
Add ForEachMaster to the Cmdable interface and implement it on Compat. It concurrently calls a function on each master node in the cluster, delegating to the existing doPrimaries method. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public interface expansion can be breaking for any external `Cmdable` implementations and introduces a new concurrent execution entrypoint whose error/role handling must remain correct across cluster nodes.
> 
> **Overview**
> Adds a new `Cmdable.ForEachMaster(ctx, fn)` API to run a callback concurrently against each *master* node in a Redis cluster, returning the first error encountered.
> 
> Implements `ForEachMaster` on `Compat` by delegating to existing `doPrimaries` and passing a per-node `Cmdable` wrapper into the callback; `Pipeline` now satisfies the expanded interface with a stub that panics. Adds comprehensive unit tests covering master filtering, error propagation, empty/no-master cases, and ensuring the callback receives a working wrapped client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f1c8fc8b2ae519d1d53d0a8046e319886afdeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->