### PR TITLE
fix: propagate ConnLifetime to standalone singleClient instances

### DIFF
--- a/standalone.go
+++ b/standalone.go
@@ -28,7 +28,7 @@ func newStandaloneClient(opt *ClientOption, connFn connFn, retryer retryHandler)
 		opt:            opt,
 		retryer:        retryer,
 	}
-	s.primary.Store(newSingleClientWithConn(p, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer, false))
+	s.primary.Store(newSingleClientWithConn(p, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer, opt.ConnLifetime > 0))
 
 	for i := range s.replicas {
 		replicaConn := connFn(opt.Standalone.ReplicaAddress[i], opt)
@@ -39,7 +39,7 @@ func newStandaloneClient(opt *ClientOption, connFn connFn, retryer retryHandler)
 			}
 			return nil, err
 		}
-		s.replicas[i] = newSingleClientWithConn(replicaConn, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer, false)
+		s.replicas[i] = newSingleClientWithConn(replicaConn, cmds.NewBuilder(cmds.NoSlot), !opt.DisableRetry, opt.DisableCache, retryer, opt.ConnLifetime > 0)
 	}
 	if s.opt.EnableReplicaAZInfo && (s.opt.ReadNodeSelector != nil || len(s.replicas) > 1) {
 		s.nodes = make([]NodeInfo, len(s.replicas)+1)
@@ -103,7 +103,7 @@ func (s *standalone) redirectToPrimary(addr string) error {
 	}
 
 	// Create a new primary client with the redirect connection
-	newPrimary := newSingleClientWithConn(redirectConn, cmds.NewBuilder(cmds.NoSlot), !s.opt.DisableRetry, s.opt.DisableCache, s.retryer, false)
+	newPrimary := newSingleClientWithConn(redirectConn, cmds.NewBuilder(cmds.NoSlot), !s.opt.DisableRetry, s.opt.DisableCache, s.retryer, s.opt.ConnLifetime > 0)
 
 	// Atomically swap the primary and close the old one
 	oldPrimary := s.primary.Swap(newPrimary)

--- a/standalone_test.go
+++ b/standalone_test.go
@@ -1067,3 +1067,176 @@ func TestStandaloneReadNodeSelector(t *testing.T) {
 		}
 	})
 }
+
+func TestStandaloneClientConnLifetime(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	setup := func() (*standalone, *mockConn, *mockConn) {
+		primary := &mockConn{}
+		replica := &mockConn{}
+		client, err := newStandaloneClient(
+			&ClientOption{
+				InitAddress: []string{"primary"},
+				Standalone: StandaloneOption{
+					ReplicaAddress: []string{"replica"},
+				},
+				ConnLifetime: 5 * time.Second,
+				SendToReplicas: func(cmd Completed) bool { return cmd.IsReadOnly() },
+			},
+			func(dst string, opt *ClientOption) conn {
+				if dst == "replica" {
+					return replica
+				}
+				return primary
+			},
+			newRetryer(defaultRetryDelayFn),
+		)
+		if err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+		return client, primary, replica
+	}
+
+	t.Run("Do recovery", func(t *testing.T) {
+		client, primary, _ := setup()
+		defer client.Close()
+		attempts := 0
+		primary.DoFn = func(cmd Completed) RedisResult {
+			attempts++
+			if attempts == 1 {
+				return newErrResult(errConnExpired)
+			}
+			return newResult(strmsg('+', "OK"), nil)
+		}
+		if v, err := client.Do(context.Background(), client.B().Set().Key("k").Value("v").Build()).ToString(); err != nil || v != "OK" {
+			t.Fatalf("unexpected response %v %v", v, err)
+		}
+	})
+
+	t.Run("DoMulti errConnExpired at head", func(t *testing.T) {
+		client, primary, _ := setup()
+		defer client.Close()
+		attempts := 0
+		primary.DoMultiFn = func(multi ...Completed) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{
+					newErrResult(errConnExpired),
+					newErrResult(errConnExpired),
+				}}
+			}
+			return &redisresults{s: []RedisResult{
+				newResult(strmsg('+', "1"), nil),
+				newResult(strmsg('+', "2"), nil),
+			}}
+		}
+		resps := client.DoMulti(context.Background(),
+			client.B().Set().Key("k1").Value("v1").Build(),
+			client.B().Set().Key("k2").Value("v2").Build(),
+		)
+		if len(resps) != 2 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		for i, resp := range resps {
+			if err := resp.Error(); err != nil {
+				t.Fatalf("results[%d] unexpected error %v", i, err)
+			}
+		}
+	})
+
+	t.Run("DoMulti errConnExpired in middle", func(t *testing.T) {
+		client, primary, _ := setup()
+		defer client.Close()
+		attempts := 0
+		primary.DoMultiFn = func(multi ...Completed) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{
+					newResult(strmsg('+', "OK"), nil),
+					newErrResult(errConnExpired),
+				}}
+			}
+			return &redisresults{s: []RedisResult{
+				newResult(strmsg('+', "OK"), nil),
+			}}
+		}
+		resps := client.DoMulti(context.Background(),
+			client.B().Set().Key("k1").Value("v1").Build(),
+			client.B().Set().Key("k2").Value("v2").Build(),
+		)
+		if len(resps) != 2 {
+			t.Fatalf("unexpected response length %v", len(resps))
+		}
+		for i, resp := range resps {
+			if err := resp.Error(); err != nil {
+				t.Fatalf("results[%d] unexpected error %v", i, err)
+			}
+		}
+	})
+
+	t.Run("DoMulti replica errConnExpired at head", func(t *testing.T) {
+		client, _, replica := setup()
+		defer client.Close()
+		attempts := 0
+		replica.DoMultiFn = func(multi ...Completed) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{newErrResult(errConnExpired)}}
+			}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
+		}
+		resps := client.DoMulti(context.Background(),
+			client.B().Get().Key("k").Build(),
+		)
+		if err := resps[0].Error(); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		if attempts != 2 {
+			t.Fatalf("expected 2 attempts (1 errConnExpired + 1 retry), got %d", attempts)
+		}
+	})
+
+	t.Run("redirectToPrimary hasLftm propagated", func(t *testing.T) {
+		redirectConn := &mockConn{}
+		attempts := 0
+		redirectConn.DoMultiFn = func(multi ...Completed) *redisresults {
+			attempts++
+			if attempts == 1 {
+				return &redisresults{s: []RedisResult{newErrResult(errConnExpired)}}
+			}
+			return &redisresults{s: []RedisResult{newResult(strmsg('+', "OK"), nil)}}
+		}
+
+		client, err := newStandaloneClient(
+			&ClientOption{
+				InitAddress: []string{"primary"},
+				ConnLifetime: 5 * time.Second,
+			},
+			func(dst string, opt *ClientOption) conn {
+				if dst == "redirect" {
+					return redirectConn
+				}
+				return &mockConn{}
+			},
+			newRetryer(defaultRetryDelayFn),
+		)
+		if err != nil {
+			t.Fatalf("unexpected err %v", err)
+		}
+		defer client.Close()
+
+		if err := client.redirectToPrimary("redirect"); err != nil {
+			t.Fatalf("unexpected redirect err %v", err)
+		}
+
+		resps := client.DoMulti(context.Background(),
+			client.B().Set().Key("k").Value("v").Build(),
+		)
+		if err := resps[0].Error(); err != nil {
+			t.Fatalf("unexpected error after redirect: %v", err)
+		}
+		if attempts != 2 {
+			t.Fatalf("expected 2 attempts (1 errConnExpired + 1 retry), got %d", attempts)
+		}
+	})
+}


### PR DESCRIPTION
fix https://github.com/redis/rueidis/issues/993

standalone.go hardcoded hasLftm=false at three call sites of newSingleClientWithConn (primary, replicas, redirectToPrimary), regardless of opt.ConnLifetime.  This caused singleClient.DoMulti to skip the errConnExpired recovery loop, leaking the internal error to callers for any non-retryable (write) command.

Pass opt.ConnLifetime > 0 at all three sites, mirroring the existing behaviour in client.go, cluster.go, and sentinel.go.

Add TestStandaloneClientConnLifetime covering:
- Do recovery (regression)
- DoMulti recovery at head and in middle of result slice
- DoMulti recovery on replica path
- redirectToPrimary producing a primary with hasLftm set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes standalone connection/client construction to enable connection-lifetime expiry handling and retries; could affect retry behavior and command execution timing for standalone deployments using `ConnLifetime`. Test coverage reduces risk but touches core request path.
> 
> **Overview**
> Fixes standalone client construction to **honor `ClientOption.ConnLifetime`** by passing `opt.ConnLifetime > 0` into `newSingleClientWithConn` for the primary, replicas, and `redirectToPrimary`, enabling the expected `errConnExpired` recovery behavior.
> 
> Adds `TestStandaloneClientConnLifetime` to cover regression scenarios for `Do` and `DoMulti` retries (including mid-slice failures), replica-path retries, and ensuring redirected primaries also inherit the connection-lifetime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003e2f7a3da11575b1176eec26b2db205a204491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->