### PR TITLE
fix: potential nil dereference

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -306,7 +306,7 @@ func (c *sentinelClient) Nodes() map[string]Client {
 	case c.replica:
 		cc := c.rConn.Load().(conn)
 		return map[string]Client{cc.Addr(): newSingleClientWithConn(cc, c.cmd, c.retry, disableCache, c.retryHandler, false)}
-	case c.mOpt.SendToReplicas != nil:
+	case c.mOpt != nil && c.mOpt.SendToReplicas != nil:
 		master := c.mConn.Load().(conn)
 		replica := c.rConn.Load().(conn)
 		return map[string]Client{


### PR DESCRIPTION
After nil check c.mOpt was used unsafely.
Fixes: 23c9b7e ("feat: send to replicas sentinel client (#850)") 
Found by PostgresPro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive nil check in `Nodes()`; no auth, routing, or API behavior change when options are present.
> 
> **Overview**
> Fixes a **nil pointer panic** in `sentinelClient.Nodes()` when `ClientOption` is not set on the client.
> 
> The `SendToReplicas` branch now matches the existing guard on `DisableCache`: it only enters the master/replica map path when `c.mOpt != nil` **and** `SendToReplicas` is configured, instead of dereferencing `c.mOpt` after a nil-only check on the callback field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360ebae9c6d3481f86b7b1e4bd641abc9e519cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->