### PR TITLE
avoid context creation for TTL when the parent suffices

### DIFF
--- a/rueidisaside/aside.go
+++ b/rueidisaside/aside.go
@@ -145,8 +145,11 @@ func randStr() string {
 }
 
 func (c *Client) Get(ctx context.Context, ttl time.Duration, key string, fn func(ctx context.Context, key string) (val string, err error)) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, ttl)
-	defer cancel()
+	if d, ok := ctx.Deadline(); !ok || time.Until(d) > ttl {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, ttl)
+		defer cancel()
+	}
 
 retry:
 	wait := c.register(key)

--- a/rueidisaside/aside_test.go
+++ b/rueidisaside/aside_test.go
@@ -617,6 +617,28 @@ func TestOverrideCacheTTLNegativeCachingLL(t *testing.T) {
 	}
 }
 
+func TestGetSkipsContextWithTimeoutWhenParentDeadlineIsTighter(t *testing.T) {
+	client := makeClient(t, addr).(*Client)
+	defer client.Close()
+
+	key := strconv.Itoa(rand.Int())
+	parent, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	parentDone := parent.Done()
+
+	var innerDone <-chan struct{}
+	val, err := client.Get(parent, time.Hour, key, func(ctx context.Context, key string) (val string, err error) {
+		innerDone = ctx.Done()
+		return "v", nil
+	})
+	if err != nil || val != "v" {
+		t.Fatalf("Get returned %q, %v", val, err)
+	}
+	if innerDone != parentDone {
+		t.Fatal("expected ctx.Done() inside fn to equal parent.Done()")
+	}
+}
+
 func BenchmarkGet(b *testing.B) {
 	client, err := NewClient(ClientOption{
 		ClientOption: rueidis.ClientOption{InitAddress: addr, PipelineMultiplex: -1, SelectDB: 5},

--- a/rueidisaside/aside_test.go
+++ b/rueidisaside/aside_test.go
@@ -616,3 +616,55 @@ func TestOverrideCacheTTLNegativeCachingLL(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func BenchmarkGet(b *testing.B) {
+	client, err := NewClient(ClientOption{
+		ClientOption: rueidis.ClientOption{InitAddress: addr, PipelineMultiplex: -1, SelectDB: 5},
+		ClientTTL:    time.Second,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer client.Close()
+
+	// Populate the key and warm the rueidis client-side cache so subsequent
+	// Get calls hit the cache and exercise the rueidisaside fast path only.
+	key := "bench-" + strconv.Itoa(rand.Int())
+	if _, err := client.Get(context.Background(), time.Minute, key, func(context.Context, string) (string, error) {
+		return "v", nil
+	}); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := client.Get(context.Background(), time.Minute, key, nil); err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("context.Background", func(b *testing.B) {
+		ctx := context.Background()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if _, err := client.Get(ctx, time.Minute, key, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+
+	b.Run("parent.TTL", func(b *testing.B) {
+		parent, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if _, err := client.Get(parent, time.Minute, key, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+}


### PR DESCRIPTION
Good day,

Today I was checking some profiles and noticed that a lot of time was spend calling `context.WithTimeout` for every `rueidisaside.(*Client).Get` call. In my specific case the usage of `context.WithTimeout` is not needed as we have a parent context with a deadline already set.

This PR adds a check so that the TTL context is only created when the parent context has no deadline or the deadline is after the TTL. 

Please let me know what you think and than thanks for taking the time to review this PR and maintaining this library.

[Go Benchstats](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) results:
```
benchstat 0b7fa11ef60f3dc879fa6214f4eab76e2e0a2a95.txt 0f21bf3f6b45bf96ea0439ed7138bc1da3caf00b.txt 
goos: linux
goarch: amd64
pkg: github.com/redis/rueidis/rueidisaside
cpu: AMD Ryzen 7 Pro 7735U with Radeon Graphics     
                          │ 0b7fa11ef60f3dc879fa6214f4eab76e2e0a2a95.txt │ 0f21bf3f6b45bf96ea0439ed7138bc1da3caf00b.txt │
                          │                    sec/op                    │        sec/op         vs base                │
Get/context.Background-16                                    226.9n ± 5%            227.0n ± 4%        ~ (p=0.780 n=10)
Get/parent.TTL-16                                            575.2n ± 3%            133.6n ± 4%  -76.78% (p=0.000 n=10)
geomean                                                      361.3n                 174.1n       -51.81%

                          │ 0b7fa11ef60f3dc879fa6214f4eab76e2e0a2a95.txt │ 0f21bf3f6b45bf96ea0439ed7138bc1da3caf00b.txt │
                          │                     B/op                     │        B/op         vs base                  │
Get/context.Background-16                                     280.0 ± 0%           280.0 ± 0%        ~ (p=1.000 n=10) ¹
Get/parent.TTL-16                                           104.000 ± 0%           8.000 ± 0%  -92.31% (p=0.000 n=10)
geomean                                                       170.6                47.33       -72.26%
¹ all samples are equal

                          │ 0b7fa11ef60f3dc879fa6214f4eab76e2e0a2a95.txt │ 0f21bf3f6b45bf96ea0439ed7138bc1da3caf00b.txt │
                          │                  allocs/op                   │     allocs/op       vs base                  │
Get/context.Background-16                                     5.000 ± 0%           5.000 ± 0%        ~ (p=1.000 n=10) ¹
Get/parent.TTL-16                                             3.000 ± 0%           1.000 ± 0%  -66.67% (p=0.000 n=10)
geomean                                                       3.873                2.236       -42.26%
¹ all samples are equal
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small context-deadline optimization with a targeted test; behavior for callers without a deadline or with a looser deadline is unchanged.
> 
> **Overview**
> **`rueidisaside.Client.Get`** no longer always wraps the caller context in `context.WithTimeout` for the cache TTL. It only adds that child timeout when the parent has **no deadline**, or when the parent’s remaining time is **longer than** `ttl`; otherwise Redis and the populate callback use the parent context unchanged.
> 
> A regression test asserts that with a short parent deadline and a large `ttl`, the callback sees the **same** `Done()` channel as the parent. A new **`BenchmarkGet`** compares the hot cache path with `context.Background` vs a parent that already carries a tighter deadline (documenting large alloc/latency wins in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f21bf3f6b45bf96ea0439ed7138bc1da3caf00b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->