### PR TITLE
perf: avoid creating a new context if the existing deadline is closer

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -218,8 +218,11 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 		timeout = DefaultDialTimeout
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	if d, ok := ctx.Deadline(); !ok || time.Until(d) > timeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	r2 := option.AlwaysRESP2
 	if !r2 && !r2ps {

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -746,6 +746,39 @@ availability_zone:us-west-1a
 	})
 }
 
+func TestNewPipeSkipsContextWithTimeoutWhenParentDeadlineIsTighter(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+	n1, n2 := net.Pipe()
+	mock := &redisMock{buf: bufio.NewReader(n2), conn: n2, t: t}
+	go func() {
+		mock.Expect("HELLO", "3").
+			Reply(slicemsg(
+				'%',
+				[]RedisMessage{
+					strmsg('+', "proto"),
+					{typ: ':', intlen: 3},
+				},
+			))
+		mock.Expect("CLIENT", "TRACKING", "ON", "OPTIN").
+			ReplyString("OK")
+		mock.Expect("CLIENT", "SETINFO", "LIB-NAME", LibName).
+			ReplyString("OK")
+		mock.Expect("CLIENT", "SETINFO", "LIB-VER", LibVer).
+			ReplyString("OK")
+	}()
+	parent, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	p, err := newPipe(parent, func(ctx context.Context) (net.Conn, error) { return n1, nil }, &ClientOption{})
+	if err != nil {
+		t.Fatalf("pipe setup failed: %v", err)
+	}
+	go func() { mock.Expect("PING").ReplyString("OK") }()
+	p.Close()
+	mock.Close()
+	n1.Close()
+	n2.Close()
+}
+
 func TestNewRESP2Pipe(t *testing.T) {
 	defer ShouldNotLeak(SetupLeakDetection())
 	t.Run("Without DisableCache", func(t *testing.T) {

--- a/rueidiscompat/pubsub.go
+++ b/rueidiscompat/pubsub.go
@@ -340,8 +340,11 @@ retry:
 }
 
 func (p *pubsub) ReceiveTimeout(ctx context.Context, timeout time.Duration) (any, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	if d, ok := ctx.Deadline(); !ok || time.Until(d) > timeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	select {
 	case m := <-p.ChannelWithSubscriptions():

--- a/rueidiscompat/pubsub_test.go
+++ b/rueidiscompat/pubsub_test.go
@@ -449,6 +449,23 @@ var _ = Describe("PubSub", func() {
 		}
 	})
 
+	It("should use parent deadline when tighter than timeout", func() {
+		pubsub := client.Subscribe(ctx, "mychannel")
+		defer pubsub.Close()
+
+		msgi, err := pubsub.ReceiveTimeout(ctx, time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msgi.(*Subscription).Kind).To(Equal("subscribe"))
+
+		parent, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err = pubsub.ReceiveTimeout(parent, time.Hour)
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+		Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+	})
+
 	It("should ChannelMessage", func() {
 		pubsub := client.Subscribe(ctx, "mychannel")
 		defer pubsub.Close()

--- a/rueidislock/lock.go
+++ b/rueidislock/lock.go
@@ -152,7 +152,11 @@ func keyname(prefix, name string, i int32) string {
 }
 
 func (m *locker) acquire(ctx context.Context, key, val string, duration time.Duration, deadline time.Time, force bool) (err error) {
-	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	if d, ok := ctx.Deadline(); !ok || time.Until(d) > m.timeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, m.timeout)
+		defer cancel()
+	}
 	var resp rueidis.RedisResult
 	if force {
 		if m.setpx {
@@ -167,7 +171,6 @@ func (m *locker) acquire(ctx context.Context, key, val string, duration time.Dur
 			resp = acqat.Exec(ctx, m.client, []string{key}, []string{val, strconv.FormatInt(deadline.UnixMilli(), 10)})
 		}
 	}
-	cancel()
 	if err = resp.Error(); rueidis.IsRedisNil(err) {
 		return fmt.Errorf("%w: key %s is held by others", ErrNotLocked, key)
 	}
@@ -175,9 +178,12 @@ func (m *locker) acquire(ctx context.Context, key, val string, duration time.Dur
 }
 
 func (m *locker) script(ctx context.Context, script *rueidis.Lua, key, val string, deadline time.Time) error {
-	ctx, cancel := context.WithDeadline(ctx, deadline)
+	if d, ok := ctx.Deadline(); !ok || d.After(deadline) {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
 	resp := script.Exec(ctx, m.client, []string{key}, []string{val, strconv.FormatInt(deadline.UnixMilli(), 10)})
-	cancel()
 	if v, err := resp.AsInt64(); err != nil || v == 1 {
 		return err
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to deadline selection and fewer context allocations; tighter parent deadlines are now respected instead of being extended by local timeouts.
> 
> **Overview**
> Avoids wrapping contexts in a new timeout/deadline when the caller already supplied a **tighter** parent deadline, so operations honor the sooner limit and skip extra `context.WithTimeout` / `WithDeadline` work.
> 
> **`pipe` dial setup** only applies `Dialer.Timeout` via `WithTimeout` when the parent has no deadline or its remaining time is longer than that timeout. **`rueidiscompat` `ReceiveTimeout`** uses the same rule for its wait timeout. **`rueidislock`** does likewise for acquire (`m.timeout`) and script execution (`deadline`), and uses `defer cancel()` instead of calling `cancel()` immediately after the Redis call.
> 
> Tests cover pipe setup with a short parent context, pubsub receive timing when the parent expires before the requested timeout, and existing behavior when no parent deadline applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 140114cec63daa8b47c6d15ffe67a0352ee41c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->