### PR TITLE
Add VISMEMBER command

### DIFF
--- a/hack/cmds/commands_vector_sets.json
+++ b/hack/cmds/commands_vector_sets.json
@@ -175,6 +175,22 @@
       }
     ]
   },
+  "VISMEMBER": {
+    "summary": "Check if an element exists in a vector set",
+    "since": "8.2.0",
+    "group": "vector_set",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "element",
+        "type": "string"
+      }
+    ]
+  },
   "VLINKS": {
     "summary": "Return the neighbors of a specified element in a vector set. The command shows the connections for each layer of the HNSW graph.",
     "since": "Redis CE 8.0.0",

--- a/internal/cmds/gen_vector_set.go
+++ b/internal/cmds/gen_vector_set.go
@@ -420,6 +420,38 @@ func (c VinfoKey) Build() Completed {
 	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
 }
 
+type Vismember Incomplete
+
+func (b Builder) Vismember() (c Vismember) {
+	c = Vismember{cs: get(), ks: b.ks}
+	c.cs.s = append(c.cs.s, "VISMEMBER")
+	return c
+}
+
+func (c Vismember) Key(key string) VismemberKey {
+	if c.ks&NoSlot == NoSlot {
+		c.ks = NoSlot | slot(key)
+	} else {
+		c.ks = check(c.ks, slot(key))
+	}
+	c.cs.s = append(c.cs.s, key)
+	return (VismemberKey)(c)
+}
+
+type VismemberElement Incomplete
+
+func (c VismemberElement) Build() Completed {
+	c.cs.Build()
+	return Completed{cs: c.cs, cf: uint16(c.cf), ks: c.ks}
+}
+
+type VismemberKey Incomplete
+
+func (c VismemberKey) Element(element string) VismemberElement {
+	c.cs.s = append(c.cs.s, element)
+	return (VismemberElement)(c)
+}
+
 type Vlinks Incomplete
 
 func (b Builder) Vlinks() (c Vlinks) {

--- a/internal/cmds/gen_vector_set_test.go
+++ b/internal/cmds/gen_vector_set_test.go
@@ -40,6 +40,7 @@ func vector_set0(s Builder) {
 	s.Vemb().Key("1").Element("1").Build()
 	s.Vgetattr().Key("1").Element("1").Build()
 	s.Vinfo().Key("1").Build()
+	s.Vismember().Key("1").Element("1").Build()
 	s.Vlinks().Key("1").Element("1").Withscores().Build()
 	s.Vlinks().Key("1").Element("1").Build()
 	s.Vrandmember().Key("1").Count(1).Build()
@@ -104,10 +105,10 @@ func vector_set0(s Builder) {
 	s.Vsim().Key("1").Fp32().Vector("1").Build()
 	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Withscores().Build()
 	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Withattribs().Build()
-	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Count(1).Build()
 }
 
 func vector_set1(s Builder) {
+	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Count(1).Build()
 	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Epsilon(1).Build()
 	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Ef(1).Build()
 	s.Vsim().Key("1").Values(1).Vector(1).Vector(1).Filter("1").Build()


### PR DESCRIPTION
## Summary 

Add VISMEMBER command.

Related issue: #998 

## Reference

- https://github.com/redis/redis/blob/4625b8942a82c4737fc14cbf17c221ea1c3fcdb5/modules/vector-sets/commands.json#L395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive generated command binding with no changes to runtime logic, auth, or data handling.
> 
> **Overview**
> Adds client support for Redis **VISMEMBER** (Redis 8.2.0), which checks whether a given element is present in a vector set.
> 
> The command is registered in `commands_vector_sets.json` and exposed through the generated fluent builder as `Vismember().Key(...).Element(...).Build()`, including cluster slot handling on the key. Generated vector-set command tests were updated to exercise the new builder chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b370abac20df2ada85d5452a70e2f236c0d627c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->