### PR TITLE
perf: optimize ClearStaticTTL

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1137,7 +1137,8 @@ func (c *clusterClient) askingMultiCache(cc conn, ctx context.Context, multi []C
 		commands = make([]Completed, 0, len(multi)*stride)
 		for _, cmd := range multi {
 			ck, _ := cmds.CacheKey(cmd.Cmd)
-			commands = append(commands, cc.OptInCmd(), cmds.AskingCmd, cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), cmds.ClearStaticTTL(Completed(cmd.Cmd)), cmds.ExecCmd)
+			cmds.ClearStaticTTL(&cmd.Cmd)
+			commands = append(commands, cc.OptInCmd(), cmds.AskingCmd, cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), Completed(cmd.Cmd), cmds.ExecCmd)
 		}
 	}
 	results := resultsp.Get(0, len(multi))

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -156,12 +156,11 @@ func IsStaticTTL(c Completed) bool {
 	return c.cf&staticTTLTag == staticTTLTag
 }
 
-// ClearStaticTTL returns a copy of c with staticTTLTag cleared. Used
+// ClearStaticTTL clears the staticTTLTag from the command. Used
 // at wrapped-wire (MULTI/EXEC) build sites so the read goroutine's
 // direct-commit gate cannot fire on the cmd's "QUEUED" reply.
-func ClearStaticTTL(c Completed) Completed {
+func ClearStaticTTL(c *Cacheable) {
 	c.cf &^= staticTTLTag
-	return c
 }
 
 // IsBlock checks if it is blocking command which needs to be process by dedicated connection.

--- a/internal/cmds/cmds_test.go
+++ b/internal/cmds/cmds_test.go
@@ -143,12 +143,12 @@ func TestIsStaticTTL(t *testing.T) {
 		t.Fatalf("transactional/ASKING cmds must not carry staticTTLTag")
 	}
 	// ClearStaticTTL strips the bit while preserving everything else.
-	tagged := Completed(base.ToStaticTTL())
-	cleared := ClearStaticTTL(tagged)
-	if IsStaticTTL(cleared) {
+	tagged := base.ToStaticTTL()
+	ClearStaticTTL(&tagged)
+	if IsStaticTTL(Completed(tagged)) {
 		t.Fatalf("ClearStaticTTL must strip staticTTLTag")
 	}
-	if !cleared.IsRetryable() {
+	if c := Completed(tagged); !c.IsRetryable() {
 		t.Fatalf("ClearStaticTTL must preserve other flags")
 	}
 }

--- a/pipe.go
+++ b/pipe.go
@@ -1676,7 +1676,8 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisre
 				missing = append(missing, p.optInCmd(), Completed(ct.Cmd))
 			} else {
 				ck, _ := cmds.CacheKey(ct.Cmd)
-				missing = append(missing, p.optInCmd(), cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), cmds.ClearStaticTTL(Completed(ct.Cmd)), cmds.ExecCmd)
+				cmds.ClearStaticTTL(&ct.Cmd)
+				missing = append(missing, p.optInCmd(), cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), Completed(ct.Cmd), cmds.ExecCmd)
 			}
 		}
 	} else {
@@ -1694,7 +1695,8 @@ func (p *pipe) DoMultiCache(ctx context.Context, multi ...CacheableTTL) *redisre
 			if skipMultiExec {
 				missing = append(missing, p.optInCmd(), Completed(ct.Cmd))
 			} else {
-				missing = append(missing, p.optInCmd(), cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), cmds.ClearStaticTTL(Completed(ct.Cmd)), cmds.ExecCmd)
+				cmds.ClearStaticTTL(&ct.Cmd)
+				missing = append(missing, p.optInCmd(), cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), Completed(ct.Cmd), cmds.ExecCmd)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small internal API and call-site change in client-side caching wire building; main caveat is in-place tag clearing on `CacheableTTL` values in mixed batches (callers reusing the same command after `DoMultiCache` may see `staticTTLTag` cleared).
> 
> **Overview**
> **`ClearStaticTTL`** no longer returns a copied `Completed`; it mutates the `Cacheable` in place (`c.cf &^= staticTTLTag`), avoiding an extra struct copy when assembling client-side cache wire batches.
> 
> **`cluster.go`** (`askingMultiCache`) and **`pipe.go`** (`DoMultiCache`) now call `ClearStaticTTL(&cmd.Cmd)` / `&ct.Cmd` before appending `Completed(cmd.Cmd)` into MULTI/PTTL/EXEC sequences. Behavior is unchanged: the static-TTL read-path must not run on the inner command’s `QUEUED` reply.
> 
> Tests in **`cmds_test.go`** were updated for the new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b8319352712d76cdfb02e2b5505db02afec6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->