### PR TITLE
rueidiscompat: fix HSetEXWithArgs panic when Condition is unset

### DIFF
--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -1672,6 +1672,8 @@ func (c *Compat) HSetEXWithArgs(ctx context.Context, key string, options *HSetEX
 			partial = c.client.B().Hsetex().Key(key).Fnx().Pxat(options.ExpirationVal).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
 		case HSetEXExpirationKEEPTTL:
 			partial = c.client.B().Hsetex().Key(key).Fnx().Keepttl().Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		default:
+			partial = c.client.B().Hsetex().Key(key).Fnx().Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
 		}
 	case HSetEXFXX:
 		switch options.ExpirationType {
@@ -1685,6 +1687,23 @@ func (c *Compat) HSetEXWithArgs(ctx context.Context, key string, options *HSetEX
 			partial = c.client.B().Hsetex().Key(key).Fxx().Pxat(options.ExpirationVal).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
 		case HSetEXExpirationKEEPTTL:
 			partial = c.client.B().Hsetex().Key(key).Fxx().Keepttl().Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		default:
+			partial = c.client.B().Hsetex().Key(key).Fxx().Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		}
+	default:
+		switch options.ExpirationType {
+		case HSetEXExpirationEX:
+			partial = c.client.B().Hsetex().Key(key).Ex(options.ExpirationVal).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		case HSetEXExpirationPX:
+			partial = c.client.B().Hsetex().Key(key).Px(options.ExpirationVal).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		case HSetEXExpirationEXAT:
+			partial = c.client.B().Hsetex().Key(key).Exat(options.ExpirationVal).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		case HSetEXExpirationPXAT:
+			partial = c.client.B().Hsetex().Key(key).Pxat(options.ExpirationVal).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		case HSetEXExpirationKEEPTTL:
+			partial = c.client.B().Hsetex().Key(key).Keepttl().Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
+		default:
+			partial = c.client.B().Hsetex().Key(key).Fields().Numfields(int64(len(fieldsAndValues) / 2)).FieldValue()
 		}
 	}
 

--- a/rueidiscompat/adapter_test.go
+++ b/rueidiscompat/adapter_test.go
@@ -12174,6 +12174,25 @@ func testAdapterRedis86() {
 			Expect(res.IIDsAdded).To(BeNumerically(">=", 0))
 			Expect(res.IIDsDuplicates).To(BeNumerically(">=", 0))
 		})
+
+		It("should HSetEXWithArgs apply ExpirationType without a Condition", func() {
+			res, err := adapter.HSetEXWithArgs(ctx, "hsetex-no-condition", &HSetEXOptions{
+				ExpirationType: HSetEXExpirationEX,
+				ExpirationVal:  100,
+			}, "field1", "value1").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(int64(1)))
+
+			val, err := adapter.HGet(ctx, "hsetex-no-condition", "field1").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("value1"))
+
+			ttl, err := adapter.HTTL(ctx, "hsetex-no-condition", "field1").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ttl).To(HaveLen(1))
+			Expect(ttl[0]).To(BeNumerically(">", 0))
+			Expect(ttl[0]).To(BeNumerically("<=", 100))
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary
`HSetEXWithArgs` only built the underlying `HSETEX` command inside the `Condition == HSetEXFNX` / `Condition == HSetEXFXX` branches. Since `Condition` is optional (per `HSetEXOptions`), leaving it unset to apply only `ExpirationType` (e.g. `EX`/`PX`/`KEEPTTL`) left the command builder at its zero value, causing a nil pointer dereference in `HsetexFieldValue.FieldValue`.

## Repro
```go
adapter.HSetEXWithArgs(ctx, "key", &rueidiscompat.HSetEXOptions{
    ExpirationType: rueidiscompat.HSetEXExpirationEX,
    ExpirationVal:  100,
}, "field1", "value1")
```
panics with `invalid memory address or nil pointer dereference` in `gen_hash.go:HsetexFieldValue.FieldValue`.

## Fix
Add the missing no-condition path in the `Condition` switch, building directly off `Hsetex().Key(key)` (no `.Fnx()`/`.Fxx()`). Also added a `default` case to each `ExpirationType` switch so an unset expiration falls through to `.Fields()` instead of leaving the command unset.

## Test plan
- Added a regression test (`should HSetEXWithArgs apply ExpirationType without a Condition`) in the existing `Redis 8.6+ commands` suite, covering set + get + TTL round-trip.
- Verified the new test panics on `main` (before the fix) and passes after.
- `go build`/`go vet` clean; existing hash-command specs still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fix to Redis hash command adapter command-building; behavior change only affects previously broken call paths.
> 
> **Overview**
> Fixes a **nil pointer panic** in `HSetEXWithArgs` when `HSetEXOptions.Condition` is left unset but `ExpirationType` (e.g. `EX`) is set—previously only `FNX`/`FXX` branches built the `HSETEX` command.
> 
> The adapter now handles the **no-condition** path by building `Hsetex().Key(key)` with the appropriate expiration modifiers, and adds **`default`** fallbacks on each `ExpirationType` switch (including `FNX`/`FXX`) so the field builder is always initialized before `FieldValue` runs.
> 
> A regression test covers set/get/TTL when only expiration options are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff969bc1c03e1743dfc8cee6e87e82ed29ea3631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->