### PR TITLE
fix: ParseURL write_timeout sets ConnWriteTimeout

### DIFF
--- a/url.go
+++ b/url.go
@@ -82,7 +82,7 @@ func ParseURL(str string) (opt ClientOption, err error) {
 		}
 	}
 	if q.Has("write_timeout") {
-		if opt.Dialer.Timeout, err = time.ParseDuration(q.Get("write_timeout")); err != nil {
+		if opt.ConnWriteTimeout, err = time.ParseDuration(q.Get("write_timeout")); err != nil {
 			return opt, fmt.Errorf("redis: invalid write timeout: %q", q.Get("write_timeout"))
 		}
 	}

--- a/url_test.go
+++ b/url_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseURL(t *testing.T) {
@@ -57,6 +58,12 @@ func TestParseURL(t *testing.T) {
 	}
 	if opt, err := ParseURL("redis://?write_timeout=a"); !strings.HasPrefix(err.Error(), "redis: invalid write timeout") {
 		t.Fatalf("unexpected %v %v", opt, err)
+	}
+	if opt, err := ParseURL("redis://?write_timeout=2s"); err != nil || opt.ConnWriteTimeout != 2*time.Second {
+		t.Fatalf("write_timeout should set ConnWriteTimeout: %v %v", opt, err)
+	}
+	if opt, err := ParseURL("redis://?dial_timeout=3s&write_timeout=4s"); err != nil || opt.Dialer.Timeout != 3*time.Second || opt.ConnWriteTimeout != 4*time.Second {
+		t.Fatalf("dial/write timeouts must not clobber each other: dial=%v write=%v err=%v", opt.Dialer.Timeout, opt.ConnWriteTimeout, err)
 	}
 	if opt, err := ParseURL("rediss://?skip_verify"); err != nil || opt.TLSConfig == nil || !opt.TLSConfig.InsecureSkipVerify {
 		t.Fatalf("unexpected %v %v", opt, err)


### PR DESCRIPTION
## Summary

`ParseURL` mapped `write_timeout` onto `Dialer.Timeout`, the same field as `dial_timeout`. That meant:

1. `write_timeout` never set `ConnWriteTimeout`
2. With both params present, `write_timeout` overwrote the dial timeout

Map `write_timeout` to `ConnWriteTimeout` instead.

## Test plan

- [x] `go test -run TestParseURL`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small URL-parsing bugfix with tests; behavior change only for callers that relied on the incorrect mapping.
> 
> **Overview**
> **`ParseURL`** no longer treats the `write_timeout` query parameter as dial timeout. It now populates **`ConnWriteTimeout`**, which is what connection write deadlines use elsewhere in the client.
> 
> Previously `write_timeout` wrote to **`Dialer.Timeout`**, so write deadlines from URLs were ignored and a URL with both `dial_timeout` and `write_timeout` left only the write value on the dialer.
> 
> **`TestParseURL`** adds cases for `write_timeout=2s` and for `dial_timeout` + `write_timeout` together so the two fields stay independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6603022860bc228c0db0ef1b0cf0c969e37a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->