### PR TITLE
fix: data race on authTimer between constructor and timer callback

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -81,6 +81,7 @@ type pipe struct {
 	psubs           *subs // pubsub pmessage subscriptions
 	r2p             *r2p
 	pingTimer       *time.Timer // timer for background ping
+	authMu          sync.Mutex  // guards authTimer and authRefreshAt across the constructor, timer callback, background and pool goroutines
 	authTimer       *time.Timer // timer for refreshing dynamic auth credentials
 	lftmTimer       *time.Timer // lifetime timer
 	info            map[string]RedisMessage
@@ -374,10 +375,16 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 	}
 	if option.AuthCredentialsFn != nil && !authCredentials.RefreshAfter.IsZero() {
 		authFn := option.AuthCredentialsFn
+		// A RefreshAfter already in the past makes the timer fire before
+		// AfterFunc even returns, and everything downstream of the callback,
+		// including the background goroutine, reads authTimer. The lock makes
+		// those readers wait for the assignment instead of racing it.
+		p.authMu.Lock()
 		p.authRefreshAt = authCredentials.RefreshAfter
 		p.authTimer = time.AfterFunc(time.Until(p.authRefreshAt), func() {
 			p.refreshAuth(authFn, authCredentialsContext)
 		})
+		p.authMu.Unlock()
 	}
 	if !nobg {
 		if p.timeout > 0 && p.pinggap > 0 {
@@ -444,9 +451,11 @@ func (p *pipe) _background() {
 	if p.pingTimer != nil {
 		p.pingTimer.Stop()
 	}
+	p.authMu.Lock()
 	if p.authTimer != nil {
 		p.authTimer.Stop()
 	}
+	p.authMu.Unlock()
 	err := p.Error()
 	p.nsubs.Close()
 	p.psubs.Close()
@@ -759,6 +768,8 @@ func (p *pipe) backgroundPing() {
 }
 
 func (p *pipe) scheduleAuthRefresh(refreshAfter time.Time) {
+	p.authMu.Lock()
+	defer p.authMu.Unlock()
 	p.authRefreshAt = refreshAfter
 	if p.authRefreshAt.IsZero() || p.Error() != nil || p.authTimer == nil {
 		return
@@ -1914,9 +1925,11 @@ func (p *pipe) Close() {
 	if p.pingTimer != nil {
 		p.pingTimer.Stop()
 	}
+	p.authMu.Lock()
 	if p.authTimer != nil {
 		p.authTimer.Stop()
 	}
+	p.authMu.Unlock()
 	if p.conn != nil {
 		p.conn.Close()
 	}
@@ -1930,9 +1943,11 @@ func (p *pipe) StopTimer() bool {
 	if p.lftmTimer != nil {
 		stopped = p.lftmTimer.Stop()
 	}
+	p.authMu.Lock()
 	if p.authTimer != nil {
 		stopped = p.authTimer.Stop() && stopped
 	}
+	p.authMu.Unlock()
 	return stopped
 }
 
@@ -1944,9 +1959,11 @@ func (p *pipe) ResetTimer() bool {
 	if p.lftmTimer != nil {
 		reset = p.lftmTimer.Reset(p.lftm)
 	}
+	p.authMu.Lock()
 	if p.authTimer != nil && !p.authRefreshAt.IsZero() {
 		reset = p.authTimer.Reset(time.Until(p.authRefreshAt)) && reset
 	}
+	p.authMu.Unlock()
 	return reset
 }
 

--- a/pipe.go
+++ b/pipe.go
@@ -81,11 +81,10 @@ type pipe struct {
 	psubs           *subs // pubsub pmessage subscriptions
 	r2p             *r2p
 	pingTimer       *time.Timer // timer for background ping
-	authMu          sync.Mutex  // guards authTimer and authRefreshAt across the constructor, timer callback, background and pool goroutines
-	authTimer       *time.Timer // timer for refreshing dynamic auth credentials
+	authTimer       *time.Timer // timer for refreshing dynamic auth credentials, written once in _newPipe
 	lftmTimer       *time.Timer // lifetime timer
 	info            map[string]RedisMessage
-	authRefreshAt   time.Time
+	authRefreshAt   atomic.Pointer[time.Time]
 	timeout         time.Duration
 	pinggap         time.Duration
 	maxFlushDelay   time.Duration
@@ -375,16 +374,23 @@ func _newPipe(ctx context.Context, connFn func(context.Context) (net.Conn, error
 	}
 	if option.AuthCredentialsFn != nil && !authCredentials.RefreshAfter.IsZero() {
 		authFn := option.AuthCredentialsFn
+		p.authRefreshAt.Store(&authCredentials.RefreshAfter)
 		// A RefreshAfter already in the past makes the timer fire before
-		// AfterFunc even returns, and everything downstream of the callback,
-		// including the background goroutine, reads authTimer. The lock makes
-		// those readers wait for the assignment instead of racing it.
-		p.authMu.Lock()
-		p.authRefreshAt = authCredentials.RefreshAfter
-		p.authTimer = time.AfterFunc(time.Until(p.authRefreshAt), func() {
+		// AfterFunc even returns. The captured mutex makes the callback wait
+		// for the assignment below, and everything the callback spawns
+		// inherits that ordering, so every reader reached through the
+		// callback sees authTimer set. All other readers see it through the
+		// pipe being published after _newPipe returns: the field is written
+		// exactly once, here. Holding the mutex for the whole refresh also
+		// keeps overlapping fires from running refreshAuth concurrently.
+		var mu sync.Mutex
+		mu.Lock()
+		p.authTimer = time.AfterFunc(time.Until(authCredentials.RefreshAfter), func() {
+			mu.Lock()
 			p.refreshAuth(authFn, authCredentialsContext)
+			mu.Unlock()
 		})
-		p.authMu.Unlock()
+		mu.Unlock()
 	}
 	if !nobg {
 		if p.timeout > 0 && p.pinggap > 0 {
@@ -451,11 +457,9 @@ func (p *pipe) _background() {
 	if p.pingTimer != nil {
 		p.pingTimer.Stop()
 	}
-	p.authMu.Lock()
 	if p.authTimer != nil {
 		p.authTimer.Stop()
 	}
-	p.authMu.Unlock()
 	err := p.Error()
 	p.nsubs.Close()
 	p.psubs.Close()
@@ -768,13 +772,11 @@ func (p *pipe) backgroundPing() {
 }
 
 func (p *pipe) scheduleAuthRefresh(refreshAfter time.Time) {
-	p.authMu.Lock()
-	defer p.authMu.Unlock()
-	p.authRefreshAt = refreshAfter
-	if p.authRefreshAt.IsZero() || p.Error() != nil || p.authTimer == nil {
+	p.authRefreshAt.Store(&refreshAfter)
+	if refreshAfter.IsZero() || p.Error() != nil || p.authTimer == nil {
 		return
 	}
-	p.authTimer.Reset(time.Until(p.authRefreshAt))
+	p.authTimer.Reset(time.Until(refreshAfter))
 }
 
 func (p *pipe) refreshAuth(authFn func(AuthCredentialsContext) (AuthCredentials, error), authContext AuthCredentialsContext) {
@@ -1925,11 +1927,9 @@ func (p *pipe) Close() {
 	if p.pingTimer != nil {
 		p.pingTimer.Stop()
 	}
-	p.authMu.Lock()
 	if p.authTimer != nil {
 		p.authTimer.Stop()
 	}
-	p.authMu.Unlock()
 	if p.conn != nil {
 		p.conn.Close()
 	}
@@ -1943,11 +1943,9 @@ func (p *pipe) StopTimer() bool {
 	if p.lftmTimer != nil {
 		stopped = p.lftmTimer.Stop()
 	}
-	p.authMu.Lock()
 	if p.authTimer != nil {
 		stopped = p.authTimer.Stop() && stopped
 	}
-	p.authMu.Unlock()
 	return stopped
 }
 
@@ -1959,11 +1957,11 @@ func (p *pipe) ResetTimer() bool {
 	if p.lftmTimer != nil {
 		reset = p.lftmTimer.Reset(p.lftm)
 	}
-	p.authMu.Lock()
-	if p.authTimer != nil && !p.authRefreshAt.IsZero() {
-		reset = p.authTimer.Reset(time.Until(p.authRefreshAt)) && reset
+	if p.authTimer != nil {
+		if at := p.authRefreshAt.Load(); at != nil && !at.IsZero() {
+			reset = p.authTimer.Reset(time.Until(*at)) && reset
+		}
 	}
-	p.authMu.Unlock()
 	return reset
 }
 


### PR DESCRIPTION

## Reproduce

On current main (`256d25a`, feat: refresh dynamic auth credentials, #1008):

```
go test -race -count=20 -run 'TestNewPipe/Auth_Credentials_Refresh_Timeout' .
```

fails within a second:

```
WARNING: DATA RACE
Read at 0x00c00011c1b8 by goroutine 62:
  github.com/redis/rueidis.(*pipe)._background()
      rueidis/pipe.go:447 +0x1ec
  github.com/redis/rueidis.(*pipe).background.gowrap1()
      rueidis/pipe.go:401 +0x2c

Previous write at 0x00c00011c1b8 by goroutine 55:
  github.com/redis/rueidis._newPipe()
      rueidis/pipe.go:378 +0x4c5c
  github.com/redis/rueidis.newPipe()
      rueidis/pipe.go:105 +0x490
  github.com/redis/rueidis.TestNewPipe.func19()
      rueidis/pipe_test.go:1033 +0x98
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34

Goroutine 62 (running) created at:
  github.com/redis/rueidis.(*pipe).background()
      rueidis/pipe.go:401 +0xc4
  github.com/redis/rueidis.(*pipe).syncDo()
      rueidis/pipe.go:1460 +0x448
  github.com/redis/rueidis.(*pipe).Do()
      rueidis/pipe.go:1117 +0x560
  github.com/redis/rueidis.(*pipe).refreshAuth()
      rueidis/pipe.go:796 +0x420
  github.com/redis/rueidis._newPipe.func2()
      rueidis/pipe.go:379 +0x54

Goroutine 55 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x7bc
  github.com/redis/rueidis.TestNewPipe()
      rueidis/pipe_test.go:1010 +0x2b4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34
==================
```

## Cause

A `RefreshAfter` already in the past makes the timer fire before
`time.AfterFunc` even returns, so the callback goroutine — and everything it
spawns, here `refreshAuth → Do → syncDo → background` — can observe
`p.authTimer` while `_newPipe` is still assigning it.

The reported pair is not the only unsynchronised one. `authTimer` and
`authRefreshAt` are touched from four goroutine contexts: the constructor
writes both, the timer callback writes and resets them through
`scheduleAuthRefresh`, the background goroutine and the close path stop the
timer, and the pool stops and resets it through `StopTimer`/`ResetTimer` on
every wire acquire and store. `scheduleAuthRefresh` writing `authRefreshAt`
while `ResetTimer` reads it races the same way, it is just not what this test
happens to catch.

## Reachability outside the test

The test provokes the constructor pair by handing the timer a RefreshAfter
already in the past, but that window exists in production too: credentials are
fetched near the top of `_newPipe` (line 160) while the timer is armed near the
bottom (line 378), with the entire handshake in between, so the refresh horizon
is eroded by every round trip and retry of connection setup before the timer is
armed. Short-lived tokens and slow handshakes tend to occur together. The
consequence of this pair is bounded, though: a reader that misses the
assignment skips a `Stop`, and a refresh firing on a dying pipe returns at the
`p.Error()` guard.

The `authRefreshAt` pair is the more consequential one, and it is not a
construction window: it recurs on every refresh cycle for the lifetime of the
connection, racing every concurrent pool store. `time.Time` is a multi-word
struct, so the unsynchronised read in `ResetTimer` can be torn, and a
half-updated value makes `time.Until` produce an arbitrary duration for
`Reset`. An early refresh is harmless; a late or never one lets the
credentials expire on that connection, turning into AUTH failures until the
connection is replaced.

## Fix

A mutex captured by the timer callback guards the constructor assignment:
the callback takes it before anything else, so everything reached through the
callback orders after the write. `authTimer` is written exactly once, and
every other reader first obtains the pipe through the pool or mux publication
that follows `_newPipe`, so those paths need no lock at all. `authRefreshAt`,
the one genuinely multi-writer field, becomes an `atomic.Pointer[time.Time]`,
removing the torn read without a lock. Holding the captured mutex for the
whole refresh also serialises overlapping timer fires. (The first commit used
a struct mutex at every touchpoint; this shape, suggested in review, keeps
the pool hot path lock-free.)

## Cost

`StopTimer`/`ResetTimer` run once per pool acquire/store, so the lock sits on
the pooled-command path. benchstat over the pair, 2s x 10 runs against the
unfixed base (Apple M4):

```
                            |  unfixed    |           this PR
TimerHooks/noAuthTimer-10     2.526n +-12%   2.428n +-20%   ~ (p=0.971 n=10)
TimerHooks/withAuthTimer-10   45.46n +- 9%   49.14n +-14%   ~ (p=0.684 n=10)
```

No statistically detectable difference in either case, zero allocations. The
first commit's struct mutex measured ~+9ns on the no-auth case; the captured
mutex and atomic pointer shape removed that entirely, since the pool paths
ended up needing no synchronisation at all.

## Verification

The reproducer is clean at `-count=50`, every Auth subtest at `-count=10`,
and the pipe, pool and close lifecycle tests pass under `-race`.
