### PR TITLE
fix(sentinel): do not close a connection still referenced by mConn/rConn

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -441,6 +441,18 @@ func (c *sentinelClient) _switchTarget(addr string, isMaster bool) (err error) {
 	var (
 		target conn
 		opt    *ClientOption
+		// reused reports that target is the connection still referenced by
+		// mConn/rConn rather than one we just dialed. Closing a reused
+		// connection on a failure path leaves mConn/rConn pointing at a CLOSED
+		// mux: every subsequent command then fails with ErrClosing without even
+		// attempting to dial, and nothing ever replaces it, because the swap
+		// below is only reached on success.
+		//
+		// This is reachable in ordinary operation: when Sentinel reports the
+		// same address the client already holds, target is reused; a
+		// just-demoted master answers ROLE with "slave" -> errNotMaster -> the
+		// live mConn is closed out from under every caller.
+		reused bool
 	)
 
 	if isMaster {
@@ -449,6 +461,8 @@ func (c *sentinelClient) _switchTarget(addr string, isMaster bool) (err error) {
 			target = c.mConn.Load().(conn)
 			if target.Error() != nil {
 				target = nil
+			} else {
+				reused = true
 			}
 		}
 	} else {
@@ -457,6 +471,8 @@ func (c *sentinelClient) _switchTarget(addr string, isMaster bool) (err error) {
 			target = c.rConn.Load().(conn)
 			if target.Error() != nil {
 				target = nil
+			} else {
+				reused = true
 			}
 		}
 	}
@@ -468,15 +484,24 @@ func (c *sentinelClient) _switchTarget(addr string, isMaster bool) (err error) {
 		}
 	}
 
+	// closeIfOwned closes only a connection this call created. A reused one is
+	// still referenced by mConn/rConn and must outlive the failure; the caller
+	// retries the refresh and replaces it once a real master is found.
+	closeIfOwned := func() {
+		if !reused {
+			target.Close()
+		}
+	}
+
 	resp, err := target.Do(context.Background(), cmds.RoleCmd).ToArray()
 	if err != nil {
-		target.Close()
+		closeIfOwned()
 		return err
 	}
 
 	if isMaster {
 		if resp[0].string() != "master" {
-			target.Close()
+			closeIfOwned()
 			return errNotMaster
 		}
 
@@ -489,7 +514,7 @@ func (c *sentinelClient) _switchTarget(addr string, isMaster bool) (err error) {
 		}
 	} else {
 		if resp[0].string() != "slave" {
-			target.Close()
+			closeIfOwned()
 			return errNotSlave
 		}
 

--- a/sentinel_switchtarget_test.go
+++ b/sentinel_switchtarget_test.go
@@ -1,0 +1,54 @@
+package rueidis
+
+import (
+	"testing"
+)
+
+// TestSwitchTargetDoesNotCloseReusedConn pins the invariant that a connection
+// still referenced by mConn must never be closed on a failure path.
+//
+// Reachable in ordinary operation: Sentinel reports the address the client
+// already holds, so _switchTarget reuses the live mConn as `target`; the node
+// has just been demoted, so ROLE answers "slave"; the old code then called
+// target.Close() and returned errNotMaster WITHOUT swapping. mConn was left
+// pointing at a closed mux, so every later command failed with ErrClosing and
+// never even attempted to dial — observed in production as minutes of total
+// outage against a perfectly healthy Redis.
+func TestSwitchTargetDoesNotCloseReusedConn(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	closed := false
+	// Reports "slave": the demoted-master case.
+	demoted := &mockConn{
+		DoFn: func(cmd Completed) RedisResult {
+			return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "slave")})}
+		},
+		CloseFn: func() { closed = true },
+		ErrorFn: func() error {
+			if closed {
+				return ErrClosing
+			}
+			return nil
+		},
+	}
+
+	c := &sentinelClient{
+		mOpt:   &ClientOption{},
+		connFn: func(dst string, opt *ClientOption) conn { return demoted },
+	}
+	c.mConn.Store(conn(demoted))
+	c.mAddr.Store("127.0.0.1:6379")
+
+	// Same address the client already holds -> the reuse path.
+	if err := c._switchTarget("127.0.0.1:6379", true); err != errNotMaster {
+		t.Fatalf("expected errNotMaster, got %v", err)
+	}
+
+	if closed {
+		t.Fatal("_switchTarget closed the connection still referenced by mConn — " +
+			"mConn now points at a closed mux and every command will fail with ErrClosing")
+	}
+	if got := c.mConn.Load().(conn); got.Error() != nil {
+		t.Fatalf("mConn must remain usable after a failed switch, got error %v", got.Error())
+	}
+}


### PR DESCRIPTION
## Summary

On a failover `_switchTarget` could close the live `mConn`/`rConn` and leave the client pointing at a closed mux. This closes only connections the call itself dialed.

## Impact

- After an **ordinary failover** the client loses all connectivity to a *healthy* Redis: every command fails with `ErrClosing` **without even attempting to dial**, and the client holds no usable connection to any node.
- Recovery depends on `refreshRetry`, which `switchTargetRetry` spawns on failure. That normally re-dials and repairs `mConn` — so the usual shape of this is a total outage lasting as long as it takes Sentinel's view to settle, not a permanent one.
- It becomes permanent when it coincides with a concurrent failing refresh: the deduplicated `refresh()` hands the joining `refreshRetry` `nil`, `refreshRetry` treats that as success and exits, and nothing is left to replace the closed `mConn`. That is the singleflight bug fixed in #1014, which is why the two belong together.

## Root cause

`_switchTarget` reuses the live `mConn`/`rConn` as `target` when Sentinel reports the address the client already holds. On the ROLE failure paths it then called `target.Close()` and returned *without swapping*, so `mConn`/`rConn` referenced a closed mux and nothing replaced it (the swap is only reached on success). This is reachable in normal operation: a just-demoted master answers `ROLE` with `slave` → `errNotMaster` → the live connection is closed out from under every caller.

## Fix

Close only connections this call dialed. A reused connection is still referenced by `mConn`/`rConn` and must outlive the failure; the caller retries the refresh and replaces it once a real master is found.

Note the trade-off: keeping a demoted node as `mConn` means writes fail `-READONLY` until refresh replaces it. That is strictly better than `ErrClosing` on every command including reads, and it is transient either way.

## Tests

- `TestSwitchTargetDoesNotCloseReusedConn` — fails against the previous code (closes the connection still referenced by `mConn`), passes with the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Sentinel connection lifecycle during failover; the prior behavior caused prolonged total client outage (`ErrClosing` on every command). The fix is narrowly scoped but sits on critical Redis connectivity paths.
> 
> **Overview**
> Fixes a Sentinel failover bug where `_switchTarget` could **close the live `mConn`/`rConn`** when ROLE validation failed but the target was the **reused** connection for an address the client already held (e.g. demoted master returns `slave` → `errNotMaster`).
> 
> The change tracks whether `target` is reused vs newly dialed and uses **`closeIfOwned`** on ROLE/command errors and role mismatches so only connections created in this call are closed; reused connections stay open until a successful swap or a later refresh replaces them.
> 
> Adds **`TestSwitchTargetDoesNotCloseReusedConn`** to lock in that `mConn` must not be closed on that failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e751b180385a36052ea2a600aabc42d01fdc7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->