### PR TITLE
feat(sentinel): add opt-in TopologyRefreshInterval to reconcile topology periodically

### DIFF
--- a/rueidis.go
+++ b/rueidis.go
@@ -301,6 +301,25 @@ type SentinelOption struct {
 	Username   string
 	Password   string
 	ClientName string
+
+	// TopologyRefreshInterval, when > 0, periodically reconciles this client's
+	// targets with the sentinels, in addition to reacting to +switch-master
+	// PUB/SUB events. Zero disables it (the default); a negative value is
+	// rejected. A few seconds is a reasonable value; 5s works well. There is no
+	// benefit to a very small interval: it only adds load on the sentinels, and
+	// recovery just needs to catch a missed event, not react instantly.
+	//
+	// Enabling it is recommended. Sentinel topology tracking is otherwise
+	// purely event-driven, and unlike the cluster client the sentinel client
+	// has no reactive fallback: a demoted master stays alive so no connection
+	// closes (SetOnCloseHook never fires), and a replication role change causes
+	// no MOVED. A single missed +switch-master then binds the client to the old
+	// master until it is restarted, and periodic reconciliation is the only
+	// thing that recovers from it.
+	//
+	// It reconciles whichever targets the client uses: the master by default,
+	// the replica under ReplicaOnly, and both under SendToReplicas.
+	TopologyRefreshInterval time.Duration
 }
 
 // ClusterOption is the options for the redis cluster client.

--- a/sentinel.go
+++ b/sentinel.go
@@ -27,6 +27,7 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		retryHandler: retryer,
 		hasLftm:      opt.ConnLifetime > 0,
 		replica:      opt.ReplicaOnly,
+		closeCh:      make(chan struct{}),
 	}
 
 	for _, sentinel := range opt.InitAddress {
@@ -35,6 +36,10 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 
 	if opt.ReplicaOnly && opt.SendToReplicas != nil {
 		return nil, ErrReplicaOnlyConflict
+	}
+
+	if opt.Sentinel.TopologyRefreshInterval < 0 {
+		return nil, ErrInvalidTopologyRefreshInterval
 	}
 
 	if opt.SendToReplicas != nil || opt.ReplicaOnly {
@@ -48,10 +53,46 @@ func newSentinelClient(opt *ClientOption, connFn connFn, retryer retryHandler) (
 		return nil, err
 	}
 
+	// Only run the background reconciler when an interval is configured; it is
+	// off by default. See SentinelOption.TopologyRefreshInterval for when and
+	// why to enable it.
+	if interval := opt.Sentinel.TopologyRefreshInterval; interval > 0 {
+		go client.runTopologyRefreshment(interval)
+	}
+
 	return client, nil
 }
 
+// runTopologyRefreshment periodically reconciles the master address with the
+// sentinels, so the client does not depend solely on catching a single
+// +switch-master PUB/SUB event. Mirrors runClusterTopologyRefreshment on the
+// cluster side. See SentinelOption.TopologyRefreshInterval for why event-only
+// tracking is not sufficient.
+func (c *sentinelClient) runTopologyRefreshment(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.closeCh:
+			// Exit immediately on Close rather than on the next tick: with a
+			// multi-second interval, polling c.stop would keep the goroutine
+			// alive well past shutdown.
+			return
+		case <-ticker.C:
+			if atomic.LoadUint32(&c.stop) == 1 {
+				return
+			}
+			// Errors are ignored on purpose: the next tick retries, and
+			// refresh() is already serialised through the singleflight in c.sc.
+			_ = c.refresh()
+		}
+	}
+}
+
 type sentinelClient struct {
+	// closeCh is closed exactly once by Close, so background goroutines exit
+	// immediately instead of waiting out a refresh interval.
+	closeCh      chan struct{}
 	mConn        atomic.Value
 	rConn        atomic.Value
 	sConn        conn
@@ -324,7 +365,9 @@ func (c *sentinelClient) Mode() ClientMode {
 }
 
 func (c *sentinelClient) Close() {
-	atomic.StoreUint32(&c.stop, 1)
+	if atomic.CompareAndSwapUint32(&c.stop, 0, 1) {
+		close(c.closeCh)
+	}
 	c.mu.Lock()
 	if c.sConn != nil {
 		c.sConn.Close()
@@ -626,6 +669,15 @@ func (c *sentinelClient) _refresh() (err error) {
 	return err
 }
 
+// currentReplica reports the replica address this client is using, or "" before
+// the first one has been resolved.
+func (c *sentinelClient) currentReplica() string {
+	if addr := c.rAddr.Load(); addr != nil {
+		return addr.(string)
+	}
+	return ""
+}
+
 // listWatch will use sentinel to list the current master,replica address along with sentinel address
 func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sentinels []string, err error) {
 	ctx := context.Background()
@@ -697,9 +749,9 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 		}
 	}
 
-	// we return a random slave address instead of master
+	// we return a slave address instead of master
 	if c.replica {
-		addr, err := pickReplica(resp.s[1])
+		addr, err := pickReplica(resp.s[1], c.currentReplica())
 		if err != nil {
 			return "", "", nil, err
 		}
@@ -709,7 +761,7 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 
 	var r string
 	if c.mOpt.SendToReplicas != nil {
-		addr, err := pickReplica(resp.s[2])
+		addr, err := pickReplica(resp.s[2], c.currentReplica())
 		if err != nil {
 			return "", "", nil, err
 		}
@@ -724,7 +776,18 @@ func (c *sentinelClient) listWatch(cc conn) (master string, replica string, sent
 	return net.JoinHostPort(m[0], m[1]), r, sentinels, nil
 }
 
-func pickReplica(resp RedisResult) (string, error) {
+// pickReplica chooses which replica to talk to. current is the address already
+// in use, if any: it is kept whenever it is still eligible, and only a client
+// that has none, or whose replica has gone away, draws a new one at random.
+//
+// The random draw spreads clients over the replicas, but it belongs at the
+// point where a client needs a replica, not at every refresh. Refresh used to
+// happen only on a sentinel event, so re-drawing there was rare; with
+// TopologyRefreshInterval it happens on every tick, and _switchTarget closes
+// the connection it replaces immediately, so a fresh draw on each tick would
+// tear down a working replica connection — and the requests in flight on it —
+// several times a minute for no reason.
+func pickReplica(resp RedisResult, current string) (string, error) {
 	replicas, err := resp.ToArray()
 	if err != nil {
 		return "", err
@@ -746,6 +809,15 @@ func pickReplica(resp RedisResult) (string, error) {
 		return "", fmt.Errorf("not enough ready replicas")
 	}
 
+	// stay on the replica already in use while it is still healthy
+	if current != "" {
+		for _, m := range eligible {
+			if addr := net.JoinHostPort(m["ip"], m["port"]); addr == current {
+				return addr, nil
+			}
+		}
+	}
+
 	// choose a replica randomly
 	m := eligible[util.FastRand(len(eligible))]
 	return net.JoinHostPort(m["ip"], m["port"]), nil
@@ -761,6 +833,10 @@ func newSentinelOpt(opt *ClientOption) *ClientOption {
 	o.SelectDB = 0 // https://github.com/redis/rueidis/issues/138
 	return &o
 }
+
+// ErrInvalidTopologyRefreshInterval mirrors ErrInvalidShardsRefreshInterval on
+// the cluster side.
+var ErrInvalidTopologyRefreshInterval = errors.New("TopologyRefreshInterval must be greater than or equal to 0")
 
 var (
 	errNotMaster = errors.New("the redis role is not master")

--- a/sentinel_refresh_test.go
+++ b/sentinel_refresh_test.go
@@ -1,0 +1,266 @@
+package rueidis
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSentinelTopologyRefreshIntervalRecoversMissedSwitch shows the client
+// recovering from a missed +switch-master event.
+//
+// A subscribed client can still miss the event: the sentinel connection can
+// drop at the same moment the master dies, and by the time a watch is
+// re-established the +switch-master was already published. Redis PUB/SUB has no
+// replay, so a subscriber that reconnects after the event never hears it.
+// Without periodic reconciliation the client stays bound to the old master; the
+// silent healthy watch in this mock reproduces that end state.
+func TestSentinelTopologyRefreshIntervalRecoversMissedSwitch(t *testing.T) {
+	var switched atomic.Bool
+	var roleAsked atomic.Int64
+
+	// Sentinel answers with :1 first, then :2 — i.e. the master moved, but the
+	// client is never told via PUB/SUB.
+	s0 := &mockConn{
+		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			addr := "1"
+			if switched.Load() {
+				addr = "2"
+			}
+			return &redisresults{s: []RedisResult{
+				{val: slicemsg('*', []RedisMessage{})},
+				{val: slicemsg('*', []RedisMessage{strmsg('+', ""), strmsg('+', addr)})},
+			}}
+		},
+	}
+	node := func(role string) *mockConn {
+		return &mockConn{
+			DoFn: func(cmd Completed) RedisResult {
+				roleAsked.Add(1)
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', role)})}
+			},
+		}
+	}
+	m1, m2 := node("master"), node("master")
+
+	client, err := newSentinelClient(
+		&ClientOption{
+			InitAddress: []string{":0"},
+			Sentinel:    SentinelOption{TopologyRefreshInterval: 50 * time.Millisecond},
+		},
+		func(dst string, opt *ClientOption) conn {
+			switch dst {
+			case ":0":
+				return s0
+			case ":1":
+				return m1
+			case ":2":
+				return m2
+			}
+			return nil
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	defer client.Close()
+
+	if got := client.mAddr.Load().(string); got != ":1" {
+		t.Fatalf("expected initial master :1, got %v", got)
+	}
+
+	// Master moves; NO +switch-master is delivered.
+	switched.Store(true)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if client.mAddr.Load().(string) == ":2" {
+			return // reconciled without any event
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("client never reconciled to the new master :2 — with no periodic " +
+		"refresh a missed +switch-master pins it to the old master indefinitely")
+}
+
+func TestSentinelNegativeTopologyRefreshInterval(t *testing.T) {
+	_, err := newSentinelClient(
+		&ClientOption{
+			InitAddress: []string{":0"},
+			Sentinel:    SentinelOption{TopologyRefreshInterval: -1},
+		},
+		func(dst string, opt *ClientOption) conn { return &mockConn{} },
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != ErrInvalidTopologyRefreshInterval {
+		t.Fatalf("expected ErrInvalidTopologyRefreshInterval, got %v", err)
+	}
+}
+
+// TestSentinelTopologyRefreshmentStopsOnClose pins that the background
+// reconciler exits immediately on Close rather than on its next tick. With a
+// multi-second interval, polling c.stop alone kept the goroutine alive well
+// past shutdown — which the suite's leak detector caught, and which would be
+// a real shutdown delay for an application closing its client (e.g. on
+// graceful process restart).
+func TestSentinelTopologyRefreshmentStopsOnClose(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	s0 := &mockConn{
+		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			return &redisresults{s: []RedisResult{
+				{val: slicemsg('*', []RedisMessage{})},
+				{val: slicemsg('*', []RedisMessage{strmsg('+', ""), strmsg('+', "1")})},
+			}}
+		},
+	}
+	m := &mockConn{DoFn: func(cmd Completed) RedisResult {
+		return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', "master")})}
+	}}
+
+	client, err := newSentinelClient(
+		&ClientOption{
+			InitAddress: []string{":0"},
+			// Far longer than the test: only prompt exit on Close can pass.
+			Sentinel: SentinelOption{TopologyRefreshInterval: time.Hour},
+		},
+		func(dst string, opt *ClientOption) conn {
+			if dst == ":0" {
+				return s0
+			}
+			return m
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	client.Close()
+	// Close must be idempotent: closeCh is closed under a CAS on stop.
+	client.Close()
+}
+
+// TestSentinelTopologyRefreshKeepsReplica pins that reconciling does not move a
+// client off a replica that is still healthy.
+//
+// Sentinel reports every replica and the client picks one. That pick used to be
+// re-drawn at random on every refresh, which was almost invisible while refresh
+// only ran on a sentinel event. On an interval it is not: _switchTarget closes
+// the connection it replaces immediately, so with three replicas roughly two
+// ticks in three tore down a working connection, and the requests in flight on
+// it, for no reason at all. The replica must only change when the one in use
+// stops being eligible.
+//
+// The ticks are performed by calling client.refresh() directly — the same call
+// runTopologyRefreshment makes — rather than running a real ticker, so the
+// count of reconciliations is exact.
+func TestSentinelTopologyRefreshKeepsReplica(t *testing.T) {
+	defer ShouldNotLeak(SetupLeakDetection())
+
+	replicaAddrs := []string{":10", ":11", ":12"}
+	var down atomic.Value // address currently reported with s-down-time
+	down.Store("")
+
+	replicasReply := func() RedisResult {
+		out := make([]RedisMessage, 0, len(replicaAddrs))
+		for _, addr := range replicaAddrs {
+			fields := []RedisMessage{
+				strmsg('+', "ip"), strmsg('+', ""),
+				strmsg('+', "port"), strmsg('+', addr[1:]),
+			}
+			if addr == down.Load().(string) {
+				fields = append(fields, strmsg('+', "s-down-time"), strmsg('+', "1000"))
+			}
+			out = append(out, slicemsg('*', fields))
+		}
+		return RedisResult{val: slicemsg('*', out)}
+	}
+
+	s0 := &mockConn{
+		DoFn: func(cmd Completed) RedisResult { return RedisResult{} },
+		DoMultiFn: func(multi ...Completed) *redisresults {
+			return &redisresults{s: []RedisResult{
+				{val: slicemsg('*', []RedisMessage{})},
+				{val: slicemsg('*', []RedisMessage{strmsg('+', ""), strmsg('+', "1")})},
+				replicasReply(),
+			}}
+		},
+	}
+
+	var mu sync.Mutex
+	dials := map[string]int{}
+	closes := map[string]int{}
+	node := func(dst, role string) *mockConn {
+		return &mockConn{
+			DoFn: func(cmd Completed) RedisResult {
+				return RedisResult{val: slicemsg('*', []RedisMessage{strmsg('+', role)})}
+			},
+			CloseFn: func() {
+				mu.Lock()
+				defer mu.Unlock()
+				closes[dst]++
+			},
+		}
+	}
+
+	client, err := newSentinelClient(
+		&ClientOption{
+			InitAddress:    []string{":0"},
+			SendToReplicas: func(cmd Completed) bool { return true },
+		},
+		func(dst string, opt *ClientOption) conn {
+			mu.Lock()
+			dials[dst]++
+			mu.Unlock()
+			switch dst {
+			case ":0":
+				return s0
+			case ":1":
+				return node(dst, "master")
+			}
+			return node(dst, "slave")
+		},
+		newRetryer(defaultRetryDelayFn),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err %v", err)
+	}
+	defer client.Close()
+
+	first := client.rAddr.Load().(string)
+
+	for i := 0; i < 20; i++ {
+		if err := client.refresh(); err != nil {
+			t.Fatalf("refresh %d: %v", i, err)
+		}
+		if got := client.rAddr.Load().(string); got != first {
+			t.Fatalf("refresh %d moved the client from replica %s to %s while both were healthy", i, first, got)
+		}
+	}
+
+	mu.Lock()
+	replicaDials, replicaCloses := 0, 0
+	for _, addr := range replicaAddrs {
+		replicaDials += dials[addr]
+		replicaCloses += closes[addr]
+	}
+	mu.Unlock()
+	if replicaDials != 1 || replicaCloses != 0 {
+		t.Fatalf("20 reconciliations should touch no replica connection, got %d dials and %d closes",
+			replicaDials, replicaCloses)
+	}
+
+	// Stickiness must not outlive eligibility: once sentinel reports the replica
+	// in use as subjectively down, the client has to move to another one.
+	down.Store(first)
+	if err := client.refresh(); err != nil {
+		t.Fatalf("refresh after s-down: %v", err)
+	}
+	if got := client.rAddr.Load().(string); got == first {
+		t.Fatalf("client stayed on replica %s after sentinel reported it down", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `SentinelOption.TopologyRefreshInterval`. When set, the sentinel client re-checks the current master with the sentinels on that interval, instead of only relying on `+switch-master` events.

## Impact

The sentinel client learns about a failover in one way only: the `+switch-master` PUB/SUB event. There is no backup path. When a master is demoted it stays alive, so its connection does not close (no `SetOnCloseHook`), and a role change does not send a `MOVED`. If the client does not see that one event, it never learns the master changed.

When that happens, the client keeps using the node it thinks is the master. But that node is now a read-only replica. It stays that way until the process restarts.

A common Sentinel layout triggers this. The Bitnami redis Helm chart, for example, runs a sentinel next to each redis node, so the client's sentinel connection dies at the same moment the master does. Redis PUB/SUB does not replay old messages, so by the time the client reconnects to another sentinel, the `+switch-master` is already gone.

A read-only replica cannot do a master's job, so:

- **Writes** (`SET`, `INCR`, anything Redis treats as a write) fail with `READONLY You can't write against a read only replica`, and keep failing until the process restarts.
- **Reads** (`GET`, which go to the master by default) still work, but return stale data. The node is a lagging replica now, and if it has been cut off from the new master, the data can be very old.

So this hits any workload, not just PUB/SUB. A plain key/value app on Sentinel hits it too.

The behavior is consistent across runs. With the interval off, a client that misses the event keeps failing writes with `READONLY` for good, unless a later, unrelated failover happens to move it (or you restart the process). With the interval on, it recovers on its own within one interval.

## Reproduced

This is a real case, reproduced on purpose, not a theory. The trigger is the client losing its sentinel connection at the same moment the master goes — which is what a co-located-sentinel layout gives you (the Bitnami Redis Helm chart runs a sentinel next to each Redis node). Force-delete the master pod: the client's sentinel connection drops with it, so `+switch-master` is missed. The node restarts and rejoins as a replica, the client re-dials that same address, and every write to it now returns `READONLY`. It stays pinned there until the process restarts. Turning on `TopologyRefreshInterval` was the one change that let it recover on its own — with it off, the same run stayed stuck. A clean `SENTINEL FAILOVER` (no node death) never triggers it, since the client keeps its subscription and catches the event — which is what pins the cause to the missed event.

## What it adds

`SentinelOption.TopologyRefreshInterval`: when `> 0`, the client re-checks its targets with the sentinels every interval, on top of the event path. `0` turns it off (the default). A negative value is rejected with `ErrInvalidTopologyRefreshInterval`. It re-checks whichever targets the client uses: the master by default, the replica under `ReplicaOnly`, both under `SendToReplicas`.

This mirrors the cluster client's `ShardsRefreshInterval` / `ErrInvalidShardsRefreshInterval`. The background goroutine stops right away on `Close` (it waits on a close channel guarded by a CAS on `stop`) instead of running until the next tick.

One related change to replica selection: when the client picks a replica (under `ReplicaOnly` or `SendToReplicas`), it now stays on the replica it is already using as long as that replica is still healthy, instead of drawing a new one at random on every refresh. Without this, periodic reconciliation would keep churning the replica connection for no reason. The random draw still happens the first time a client needs a replica, so clients still spread across the available replicas. Note this also touches the existing recovery path, not just the new periodic one: a replica-using client no longer drops a healthy replica connection when it re-resolves the topology after an error.

## Tests

- `TestSentinelTopologyRefreshIntervalRecoversMissedSwitch` — recovers after a missed `+switch-master`.
- `TestSentinelNegativeTopologyRefreshInterval` — a negative interval is rejected.
- `TestSentinelTopologyRefreshmentStopsOnClose` — the goroutine stops right away on `Close`, not on the next tick.
